### PR TITLE
Remove broken delete logic

### DIFF
--- a/src/bandersnatch/default.conf
+++ b/src/bandersnatch/default.conf
@@ -43,12 +43,6 @@ hash-index = false
 ; "false".
 stop-on-error = false
 
-; Whether or not files that have been deleted on the master should be deleted
-; on the mirror, too.
-; IMPORTANT: if you are running an official mirror than you *need* to leave
-; this on.
-delete-packages = true
-
 ; Advanced logging configuration. Uncomment and set to the location of a
 ; python logging format logging config file.
 ; log-config = /etc/bandersnatch-log.conf

--- a/src/bandersnatch/main.py
+++ b/src/bandersnatch/main.py
@@ -56,7 +56,6 @@ def mirror(config):
         master,
         stop_on_error=config.getboolean('mirror', 'stop-on-error'),
         workers=config.getint('mirror', 'workers'),
-        delete_packages=config.getboolean('mirror', 'delete-packages'),
         hash_index=config.getboolean('mirror', 'hash-index'),
         json_save=json_save,
         root_uri=root_uri,
@@ -67,8 +66,7 @@ def mirror(config):
     changed_packages = mirror.synchronize()
     logger.info("{0} packages had changes".format(len(changed_packages)))
     for package_name, changes in changed_packages.items():
-        logger.debug("{0} removed: {1}".format(package_name, changes[0]))
-        logger.debug("{0} added: {1}".format(package_name, changes[1]))
+        logger.debug("{0} added: {1}".format(package_name, changes))
 
 
 def main():

--- a/src/bandersnatch/mirror.py
+++ b/src/bandersnatch/mirror.py
@@ -42,7 +42,6 @@ class Mirror():
     stop_on_error = False
 
     package_blacklist = None
-    delete_packages = True
 
     digest_name = 'sha256'
 
@@ -63,7 +62,6 @@ class Mirror():
         master,
         stop_on_error=False,
         workers=3,
-        delete_packages=True,
         hash_index=False,
         json_save=False,
         digest_name=None,
@@ -75,7 +73,6 @@ class Mirror():
         self.master = master
         self.stop_on_error = stop_on_error
         self.json_save = json_save
-        self.delete_packages = delete_packages
         self.hash_index = hash_index
         self.package_blacklist = package_blacklist if package_blacklist else []
         self.root_uri = root_uri

--- a/src/bandersnatch/package.py
+++ b/src/bandersnatch/package.py
@@ -2,14 +2,12 @@ from . import utils
 from .master import StalePage
 from packaging.utils import canonicalize_name
 from urllib.parse import urlparse, unquote
-import glob
 import hashlib
 import json
 import logging
 import os.path
 import pkg_resources
 import requests
-import shutil
 import sys
 import time
 
@@ -39,18 +37,6 @@ class Package():
         return os.path.join(self.mirror.webdir, 'pypi', self.name, 'json')
 
     @property
-    def package_directories(self):
-        expr = '{0}/packages/*/{1}/{2}'.format(
-            self.mirror.webdir, self.name[0], self.name)
-        return glob.glob(expr)
-
-    @property
-    def package_files(self):
-        expr = '{0}/packages/*/{1}/{2}/*'.format(
-            self.mirror.webdir, self.name[0], self.name)
-        return glob.glob(expr)
-
-    @property
     def simple_directory(self):
         if self.mirror.hash_index:
             return os.path.join(self.mirror.webdir, 'simple',
@@ -74,15 +60,6 @@ class Package():
                 self.normalized_name[0], self.normalized_name_legacy)
         return os.path.join(
             self.mirror.webdir, 'simple', self.normalized_name_legacy)
-
-    @property
-    def serversig_file(self):
-        return os.path.join(self.mirror.webdir, 'serversig', self.name)
-
-    @property
-    def directories(self):
-        return (self.package_directories + [self.simple_directory,
-                os.path.dirname(self.json_pypi_symlink)])
 
     def save_json_metadata(self, package_info):
         ''' Take the JSON metadata we just fetched and save to disk '''
@@ -121,7 +98,9 @@ class Package():
                         )
                     except requests.HTTPError as e:
                         if e.response.status_code == 404:
-                            self.delete()
+                            logger.info(
+                                '{0} no longer exists on PyPI'.format(
+                                    self.name))
                             return
                         raise
 
@@ -157,14 +136,14 @@ class Package():
             logger.error('Exiting early after error.')
             sys.exit(1)
 
+    # TODO: async def once we go full asyncio - Have concurrency at the
+    # release file level
     def sync_release_files(self):
         ''' Purge + download files returning files removed + added '''
         release_files = []
 
         for release in self.releases.values():
             release_files.extend(release)
-
-        removed_files = self.purge_files(release_files)
 
         downloaded_files = set()
         for release_file in release_files:
@@ -176,8 +155,7 @@ class Package():
                 downloaded_files.add(os.path.relpath(downloaded_file,
                                                      self.mirror.homedir))
 
-        self.mirror.altered_packages[self.name] = [removed_files,
-                                                   downloaded_files]
+        self.mirror.altered_packages[self.name] = downloaded_files
 
     def generate_simple_page(self):
         # Generate the header of our simple page.
@@ -252,10 +230,6 @@ class Package():
         with utils.rewrite(normalized_simple_page, 'w', encoding='utf-8') as f:
             f.write(simple_page_content)
 
-        # Remove the /serversig page if it exists
-        if os.path.exists(self.serversig_file):
-            os.unlink(self.serversig_file)
-
     def _file_url_to_local_url(self, url):
         parsed = urlparse(url)
         if not parsed.path.startswith('/packages'):
@@ -270,23 +244,6 @@ class Package():
             raise RuntimeError('Got invalid download URL: {0}'.format(url))
         path = path[1:]
         return os.path.join(self.mirror.webdir, path)
-
-    def purge_files(self, release_files):
-        if not self.mirror.delete_packages:
-            return set()
-        master_files = [self._file_url_to_local_path(f['url'])
-                        for f in release_files]
-        existing_files = list(self.package_files)
-        to_remove = set(existing_files) - set(master_files)
-        relative_removed = set()
-        for filename in to_remove:
-            logger.info('Removing deleted file {0}'.format(filename))
-            os.unlink(filename)
-            # Get the relative path for upstream consumers + stats
-            relative_removed.add(os.path.relpath(filename,
-                                 self.mirror.homedir))
-
-        return relative_removed
 
     def download_file(self, url, sha256sum):
         path = self._file_url_to_local_path(url)
@@ -334,16 +291,3 @@ class Package():
                     'Inconsistent file. {0} has hash {1} instead of {2}.'
                     .format(url, existing_hash, sha256sum))
         return path
-
-    def delete(self):
-        if not self.mirror.delete_packages:
-            return
-        logger.info('Deleting package: {0}'.format(self.name))
-        for directory in self.directories:
-            if not os.path.exists(directory):
-                continue
-            shutil.rmtree(directory)
-        if os.path.exists(self.serversig_file):
-            os.unlink(self.serversig_file)
-        if os.path.exists(self.json_file):
-            os.unlink(self.json_file)

--- a/src/bandersnatch/tests/test_main.py
+++ b/src/bandersnatch/tests/test_main.py
@@ -42,8 +42,7 @@ def test_main_reads_config_values(mirror_mock):
     (homedir, master), kwargs = mirror_mock.call_args_list[0]
     assert '/srv/pypi' == homedir
     assert isinstance(master, bandersnatch.master.Master)
-    assert {'delete_packages': True,
-            'stop_on_error': False,
+    assert {'stop_on_error': False,
             'hash_index': False,
             'workers': 3,
             'root_uri': None,
@@ -60,7 +59,6 @@ def test_main_reads_custom_config_values(
     main()
     (log_config, kwargs) = logging_mock.call_args_list[0]
     assert log_config == (str(customconfig / 'bandersnatch-log.conf'),)
-    assert not mirror_mock.call_args[1]['delete_packages']
     assert mirror_mock().synchronize.called
 
 
@@ -72,8 +70,6 @@ def customconfig(tmpdir):
     with open(str(tmpdir / 'bandersnatch.conf'), 'w') as f:
         f.write(config)
     config = config.replace('; log-config', 'log-config')
-    config = config.replace('delete-packages = true',
-                            'delete-packages = false')
     config = config.replace(
         '/etc/bandersnatch-log.conf',
         str(tmpdir / 'bandersnatch-log.conf'))

--- a/src/bandersnatch/tests/test_mirror.py
+++ b/src/bandersnatch/tests/test_mirror.py
@@ -276,7 +276,7 @@ def test_mirror_sync_package_error_no_early_exit(mirror, requests):
     assert open('todo').read() == '1\n'
 
     # Check the returned dict is accurate
-    expected = {'foo': [set(), {'web/packages/any/f/foo/foo.zip'}]}
+    expected = {'foo': {'web/packages/any/f/foo/foo.zip'}}
     assert changed_packages == expected
 
 


### PR DESCRIPTION
We've decided to move all deletion logic to a batch job so that we can
leave bandersnatch stateless. So this diff removes all the deletion logic
that is only working today for simple, serversig and json files.

This will all be moved and well unit tested in a new 'verify' option
that bandersnatch will get. This will have an optional `--delete`
that will clean up unowned files and packages (simple + JSON files) with 0 remaining release files.