### PR TITLE
Readthedocs fix

### DIFF
--- a/doc_requirements.txt
+++ b/doc_requirements.txt
@@ -7,5 +7,8 @@ xmlrpc2
 # We don't want to accidently get an old version of the package that is being documented
 # bandersnatch
 
+zest.releaser
+
 sphinx
 recommonmark
+docutils==0.12

--- a/doc_requirements.txt
+++ b/doc_requirements.txt
@@ -4,8 +4,6 @@ python-dateutil
 packaging
 requests
 xmlrpc2
-# We don't want to accidently get an old version of the package that is being documented
-# bandersnatch
 
 zest.releaser
 

--- a/doc_requirements.txt
+++ b/doc_requirements.txt
@@ -9,4 +9,7 @@ zest.releaser
 
 sphinx
 recommonmark
+
+# This is needed for the documentation build to work from read_the_docs.  This isn't needed to build
+# the documentation locally using tox -e doc_build
 docutils==0.12

--- a/tox.ini
+++ b/tox.ini
@@ -12,9 +12,7 @@ commands =
 	{envpython} {envbindir}/sphinx-build -a -b html docs docs/html
 changedir = {toxinidir}
 deps =
-	-rrequirements.txt
-  	sphinx
-	recommonmark
+	-rdoc_requirements.txt
     sphinx-rtd-theme
 
 extras = doc_build


### PR DESCRIPTION
The doc_requirements.txt needs some more tweaks to work properly with read_the_docs.  

Currently the doc build works locally using tox -e doc_build but fails when run by read_the_docs.  The particular failure occurs with newer versions of docutils and this change pins the docutils version to one that works with read_the_docs.