### PR TITLE
Python36 doc changes

### DIFF
--- a/doc_requirements.txt
+++ b/doc_requirements.txt
@@ -7,5 +7,8 @@ xmlrpc2
 # We don't want to accidently get an old version of the package that is being documented
 # bandersnatch
 
+zest.releaser
+
 sphinx
 recommonmark
+docutils==0.12

--- a/doc_requirements.txt
+++ b/doc_requirements.txt
@@ -4,8 +4,6 @@ python-dateutil
 packaging
 requests
 xmlrpc2
-# We don't want to accidently get an old version of the package that is being documented
-# bandersnatch
 
 zest.releaser
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -8,10 +8,12 @@ chat rooms, and mailing lists is expected to follow the
 
 ## Getting Started
 
+Bandersnatch is developed using the [GitHub Flow](https://guides.github.com/introduction/flow/)
+
 ### Pre Install
 Please make sure you system has the following:
 
-- Python 3.5 or greater
+- Python 3.6 or greater
 
 ### Development venv
 One way to develop and install all the dependencies of bandersnatch is to use a venv.
@@ -19,13 +21,13 @@ One way to develop and install all the dependencies of bandersnatch is to use a 
 - First create one and upgrade `pip`
 
 ```
-python3 -m venv /path/to/venv
+python3.6 -m venv /path/to/venv
 /path/to/venv/bin/pip install --upgrade pip
 ```
 
 For example:
 ```console
-$ python3 -m venv bandersnatchvenv
+$ python3.6 -m venv bandersnatchvenv
 $ bandersnatchvenv/bin/pip install --upgrade pip
 Collecting pip
   Using cached https://files.pythonhosted.org/packages/0f/74/ecd13431bcc456ed390b44c8a6e917c1820365cbebcb6a8974d1cd045ab4/pip-10.0.1-py2.py3-none-any.whl

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -3,7 +3,7 @@
 The following instructions will place the bandersnatch executable in a
 virtualenv under `bandersnatch/bin/bandersnatch`.
 
-- bandersnatch **requires** `>= Python 3.5`
+- bandersnatch **requires** `>= Python 3.6`
 
 
 ### pip
@@ -11,18 +11,16 @@ virtualenv under `bandersnatch/bin/bandersnatch`.
 This installs the latest stable, released version.
 
 ```
-  $ virtualenv --python=python3.5 bandersnatch
-  $ cd bandersnatch
-  $ bin/pip install -r https://bitbucket.org/pypa/bandersnatch/raw/stable/requirements.txt
+  $ python3.6 -m venv bandersnatch
+  $ bandersnatch/bin/pip install bandersnatch
 ```
 
 ### zc.buildout
 
-This installs the current development version. Use 'hg up <version>' and run
-buildout again to choose a specific release.
+This installs the current development version.
 
 ```
-  $ hg clone https://bitbucket.org/pypa/bandersnatch
+  $ git clone https://github.org/pypa/bandersnatch
   $ cd bandersnatch
   $ ./bootstrap.sh
 ```

--- a/tox.ini
+++ b/tox.ini
@@ -12,9 +12,7 @@ commands =
 	{envpython} {envbindir}/sphinx-build -a -b html docs docs/html
 changedir = {toxinidir}
 deps =
-	-rrequirements.txt
-  	sphinx
-	recommonmark
+	-rdoc_requirements.txt
     sphinx-rtd-theme
 
 extras = doc_build


### PR DESCRIPTION
This changes the install docs on read_the_docs to require python 3.6.

It also adds a reference to github flow to the contributing document. 

Change the reference to bitbucket in the documentation to point to github.

Adds zest.releaser to the doc_requirements.txt because it's referenced in the autodocs.