### PR TITLE
Filter plugin fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,6 @@ language: python
 matrix:
   fast_finish: true
   include:
-    - python: 3.5
-      env: TOXENV=py35
     - python: 3.6
       env: TOXENV=py36
     - python: "3.7-dev"

--- a/doc_requirements.txt
+++ b/doc_requirements.txt
@@ -10,3 +10,6 @@ zest.releaser
 sphinx
 recommonmark
 docutils==0.12
+
+git+https://github.com/pypa/pypa-docs-theme.git#egg=pypa-docs-theme
+git+https://github.com/python/python-docs-theme.git#egg=python-docs-theme

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -231,6 +231,17 @@ try:
 except ImportError:
     pass
 
+try:
+    import pypa_theme
+    available_themes.insert(0, 'pypa')
+    available_theme_settings['pypa'] = dict()
+    available_theme_settings['pypa']['theme'] = 'pypa_theme'
+    available_theme_settings['pypa']['path'] = []
+    available_theme_settings['pypa']['options'] = {
+    }
+except ImportError:
+    pass
+
 selected_theme = os.environ.get('SPHINX_THEME', available_themes[0])
 if selected_theme not in available_themes:
     selected_theme = available_themes[0]

--- a/src/bandersnatch/main.py
+++ b/src/bandersnatch/main.py
@@ -94,7 +94,9 @@ def main():
             logger.error('Could not create config file: {0}'.format(str(e)))
         return 1
 
-    config = BandersnatchConfig(config_file=args.config).config
+    config = configparser.ConfigParser()
+    config.read([default_config, args.config])
+    BandersnatchConfig(config_file=args.config)
 
     if config.has_option('mirror', 'log-config'):
         logging.config.fileConfig(

--- a/src/bandersnatch/main.py
+++ b/src/bandersnatch/main.py
@@ -8,6 +8,7 @@ import logging
 import logging.config
 import os.path
 import shutil
+from .configuration import BandersnatchConfig
 
 
 logger = logging.getLogger(__name__)
@@ -93,8 +94,7 @@ def main():
             logger.error('Could not create config file: {0}'.format(str(e)))
         return 1
 
-    config = configparser.ConfigParser()
-    config.read([default_config, args.config])
+    config = BandersnatchConfig(config_file=args.config).config
 
     if config.has_option('mirror', 'log-config'):
         logging.config.fileConfig(

--- a/src/bandersnatch/mirror.py
+++ b/src/bandersnatch/mirror.py
@@ -135,7 +135,10 @@ class Mirror():
         for package_name in packages:
             for plugin in filter_project_plugins():
                 if plugin.check_match(name=package_name):
-                    logger.info(f'Filtered project {plugin.name}(name={package_name!r})')
+                    logger.info(
+                        f'Filtered project '
+                        f'{plugin.name}(name={package_name!r})'
+                    )
                     del(self.packages_to_sync[package_name])
 
     def determine_packages_to_sync(self):

--- a/src/bandersnatch/mirror.py
+++ b/src/bandersnatch/mirror.py
@@ -135,6 +135,7 @@ class Mirror():
         for package_name in packages:
             for plugin in filter_project_plugins():
                 if plugin.check_match(name=package_name):
+                    logger.info(f'Filtered project {plugin.name}(name={package_name!r})')
                     del(self.packages_to_sync[package_name])
 
     def determine_packages_to_sync(self):

--- a/src/bandersnatch_filter_plugins/blacklist_name.py
+++ b/src/bandersnatch_filter_plugins/blacklist_name.py
@@ -35,7 +35,6 @@ class BlacklistProject(FilterProjectPlugin):
         filtered_packages = set()
         try:
             lines = self.configuration['blacklist']['packages']
-            logger.debug('blacklist->packages: %r', lines)
             package_lines = lines.split('\n')
         except KeyError:
             package_lines = []
@@ -45,10 +44,6 @@ class BlacklistProject(FilterProjectPlugin):
                 continue
             package_requirement = Requirement(package_line)
             if package_requirement.specifier:
-                logger.debug(
-                    'Package line %r has a version spec, ignoring',
-                    package_line
-                )
                 continue
             if package_requirement.name != package_line:
                 logger.debug(
@@ -81,10 +76,7 @@ class BlacklistProject(FilterProjectPlugin):
             return False
 
         if name in self.blacklist_package_names:
-            logger.debug(
-                'MATCH: Package %r is in %r', name,
-                self.blacklist_package_names
-            )
+            logger.debug(f'MATCH: Package {name!r} is in the blacklist')
             return True
         return False
 
@@ -118,7 +110,6 @@ class BlacklistRelease(FilterReleasePlugin):
         filtered_requirements = set()
         try:
             lines = self.configuration['blacklist']['packages']
-            logger.debug('blacklist->packages: %r', lines)
             package_lines = lines.split('\n')
         except KeyError:
             package_lines = []

--- a/src/bandersnatch_filter_plugins/blacklist_name.py
+++ b/src/bandersnatch_filter_plugins/blacklist_name.py
@@ -99,7 +99,8 @@ class BlacklistRelease(FilterReleasePlugin):
         # Generate a list of blacklisted packages from the configuration and
         # store it into self.blacklist_package_names attribute so this
         # operation doesn't end up in the fastpath.
-        self.blacklist_release_requirements = self._determine_filtered_package_requirements()
+        self.blacklist_release_requirements = \
+            self._determine_filtered_package_requirements()
         logger.debug(
             f'Initialized release plugin {self.name!r}, filtering '
             f'{self.blacklist_release_requirements!r}'
@@ -164,7 +165,8 @@ class BlacklistRelease(FilterReleasePlugin):
                 continue
             if version in requirement.specifer:
                 logger.debug(
-                'MATCH: Release {name}=={version} matches specifier {requirement.specifier}'
-            )
+                    'MATCH: Release {name}=={version} matches specifier '
+                    '{requirement.specifier}'
+                )
                 return True
         return False

--- a/src/bandersnatch_filter_plugins/blacklist_name.py
+++ b/src/bandersnatch_filter_plugins/blacklist_name.py
@@ -1,6 +1,7 @@
 import logging
 from bandersnatch.filter import FilterProjectPlugin, FilterReleasePlugin
 from packaging.requirements import Requirement
+from packaging.version import InvalidVersion, Version
 
 
 logger = logging.getLogger(__name__)
@@ -16,8 +17,11 @@ class BlacklistProject(FilterProjectPlugin):
         # Generate a list of blacklisted packages from the configuration and
         # store it into self.blacklist_package_names attribute so this
         # operation doesn't end up in the fastpath.
-        logger.debug('Initializing the %r plugin', self.name)
         self.blacklist_package_names = self._determine_filtered_package_names()
+        logger.debug(
+            f'Initialized project plugin {self.name!r}, filtering '
+            f'{self.blacklist_package_names!r}'
+        )
 
     def _determine_filtered_package_names(self):
         """
@@ -37,7 +41,7 @@ class BlacklistProject(FilterProjectPlugin):
             package_lines = []
         for package_line in package_lines:
             package_line = package_line.strip()
-            if not package_line:
+            if not package_line or package_line.startswith('#'):
                 continue
             package_requirement = Requirement(package_line)
             if package_requirement.specifier:
@@ -72,14 +76,10 @@ class BlacklistProject(FilterProjectPlugin):
         bool:
             True if it matches, False otherwise.
         """
-        logger.debug('Running filter plugin %s', self.name)
         name = kwargs.get('name', None)
         if not name:
             return False
 
-        logger.info(
-            'Checking for package %s in %r', name, self.blacklist_package_names
-        )
         if name in self.blacklist_package_names:
             logger.debug(
                 'MATCH: Package %r is in %r', name,
@@ -91,6 +91,42 @@ class BlacklistProject(FilterProjectPlugin):
 
 class BlacklistRelease(FilterReleasePlugin):
     name = 'blacklist_release'
+
+    def initialize_plugin(self):
+        """
+        Initialize the plugin
+        """
+        # Generate a list of blacklisted packages from the configuration and
+        # store it into self.blacklist_package_names attribute so this
+        # operation doesn't end up in the fastpath.
+        self.blacklist_release_requirements = self._determine_filtered_package_requirements()
+        logger.debug(
+            f'Initialized release plugin {self.name!r}, filtering '
+            f'{self.blacklist_release_requirements!r}'
+        )
+
+    def _determine_filtered_package_requirements(self):
+        """
+        Parse the configuration file for [blacklist]packages
+
+        Returns
+        -------
+        list of packaging.requirements.Requirement
+            For all PEP440 package specifiers
+        """
+        filtered_requirements = set()
+        try:
+            lines = self.configuration['blacklist']['packages']
+            logger.debug('blacklist->packages: %r', lines)
+            package_lines = lines.split('\n')
+        except KeyError:
+            package_lines = []
+        for package_line in package_lines:
+            package_line = package_line.strip()
+            if not package_line or package_line.startswith('#'):
+                continue
+            filtered_requirements.add(Requirement(package_line))
+        return list(filtered_requirements)
 
     def check_match(self, **kwargs):
         """
@@ -111,9 +147,24 @@ class BlacklistRelease(FilterReleasePlugin):
             True if it matches, False otherwise.
         """
         name = kwargs.get('name', None)
-        version = kwargs.get('version', None)
+        version_string = kwargs.get('version', None)
 
-        if not name or not version:
+        if not name or not version_string:
             return False
 
+        try:
+            version = Version(version_string)
+        except InvalidVersion:
+            logger.debug(
+                f'Package {name}=={version_string} has an invalid version'
+            )
+            return False
+        for requirement in self.blacklist_release_requirements:
+            if name != requirement.name:
+                continue
+            if version in requirement.specifer:
+                logger.debug(
+                'MATCH: Release {name}=={version} matches specifier {requirement.specifier}'
+            )
+                return True
         return False

--- a/tox.ini
+++ b/tox.ini
@@ -18,4 +18,4 @@ deps =
 extras = doc_build
 passenv = SSH_AUTH_SOCK
 setenv =
-    SPHINX_THEME='sphinx_rtd_theme'
+    SPHINX_THEME='pypa'


### PR DESCRIPTION
This is to address issue #28 

The problem is the configuration object being used by the plugins does not load the configuration file passed as a command line argument in main() as a result the plugins are ignoring setting values from the actual configuration file.

This fixes the issue by populating the configuration singleton with the configuration file name.

This also includes some code that evidently didn't get included in the release plugin that was needed to actually validate the release versions.