### PR TITLE
Improve logging of the filter operations

### DIFF
--- a/src/bandersnatch/filter.py
+++ b/src/bandersnatch/filter.py
@@ -1,11 +1,13 @@
 """
 Blacklist management
 """
+import logging
 import pkg_resources
 from collections import defaultdict
 from .configuration import BandersnatchConfig
 
 
+logger = logging.getLogger(__name__)
 loaded_filter_plugins = defaultdict(list)
 
 
@@ -120,3 +122,25 @@ def filter_release_plugins():
         List of objects drived from the bandersnatch.filter.Filter class
     """
     return load_filter_plugins('bandersnatch_filter_plugins.release')
+
+
+def is_project_filtered(name: str) -> bool:
+    """
+    Check if a project/package name is filtered
+
+    Parameters
+    ----------
+    name: str
+        The normalized name of the package to check for filtering
+
+    Returns
+    -------
+    bool:
+        True if the package should be filtered False otherwise
+
+    """
+    for plugin in filter_project_plugins():
+        if plugin.check_match(name=name):
+            logger.debug(f'MATCH: Project {name!r} is filtered')
+            return True
+    return False

--- a/src/bandersnatch/mirror.py
+++ b/src/bandersnatch/mirror.py
@@ -1,4 +1,4 @@
-from .filter import filter_project_plugins
+from .filter import is_project_filtered
 from .package import Package
 from .utils import rewrite, USER_AGENT, update_safe
 from packaging.utils import canonicalize_name
@@ -128,18 +128,17 @@ class Mirror():
 
     def _filter_packages(self):
         """
-        Run the package filtering plugins and remove any packages from the
-        packages_to_sync that match any filters.
+        Run the package filtering plugins and remove any packages from
+        self.packages_to_sync that match any filters.
         """
         packages = list(self.packages_to_sync.keys())
         for package_name in packages:
-            for plugin in filter_project_plugins():
-                if plugin.check_match(name=package_name):
-                    logger.info(
-                        f'Filtered project '
-                        f'{plugin.name}(name={package_name!r})'
-                    )
-                    del(self.packages_to_sync[package_name])
+            if is_project_filtered(package_name):
+                logger.info(
+                    f'Filtered project '
+                    f'name={package_name!r}'
+                )
+                del(self.packages_to_sync[package_name])
 
     def determine_packages_to_sync(self):
         """

--- a/src/bandersnatch/package.py
+++ b/src/bandersnatch/package.py
@@ -154,6 +154,10 @@ class Package():
                     name=self.name, version=version
                 )
             if filter:
+                logger.debug(
+                    f'Filtered release '
+                    f'{plugin.name}(name={self.name!r}, version={version!r})'
+                )
                 del(self.releases[version])
 
     # TODO: async def once we go full asyncio - Have concurrency at the

--- a/src/bandersnatch_filter_plugins/blacklist_name.py
+++ b/src/bandersnatch_filter_plugins/blacklist_name.py
@@ -154,10 +154,10 @@ class BlacklistRelease(FilterReleasePlugin):
         for requirement in self.blacklist_release_requirements:
             if name != requirement.name:
                 continue
-            if version in requirement.specifer:
+            if version in requirement.specifier:
                 logger.debug(
-                    'MATCH: Release {name}=={version} matches specifier '
-                    '{requirement.specifier}'
+                    f'MATCH: Release {name}=={version} matches specifier '
+                    f'{requirement.specifier}'
                 )
                 return True
         return False


### PR DESCRIPTION
Add an is_project_filtered() function to easily find if a project is in
a filter rule..

Added more debug logging to show when releases are getting filtered.

Fix a one character typo that was causing an exception in the release
filters because the wrong attribute name was being used.

Fixed a log message that was printing the formatting string because
the string wasn't an f-string.