### PR TITLE
Add setuptools as a requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,8 +10,9 @@ packaging==17.1
 pycares==2.3.0
 pyparsing==2.2.0
 python-dateutil==2.7.3
-requests==2.18.4
+requests==2.19.1
+setuptools==39.2.0
 six==1.11.0
-urllib3==1.22
+urllib3==1.23
 xmlrpc2==0.3.1
 yarl==1.2.4

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import find_packages, setup
 
 from src.bandersnatch import __version__
 
-install_deps = ["aiodns", "aiohttp", "packaging", "requests", "xmlrpc2"]
+install_deps = ["aiodns", "aiohttp", "packaging", "requests", "setuptools", "xmlrpc2"]
 
 setup(
     name="bandersnatch",


### PR DESCRIPTION
pkg_resources is needed and needs to be explicitly defiend for non virtual environments where setuptools is always implicitly there.

- Found this building bandersnatch 3.0 for testing inside of Facebook, where we don't use Virtual Environments.