### PR TITLE
Make verify.py more async program friendly

### DIFF
--- a/src/bandersnatch/main.py
+++ b/src/bandersnatch/main.py
@@ -1,4 +1,5 @@
 import argparse
+import asyncio
 import configparser
 import logging
 import logging.config
@@ -146,7 +147,11 @@ def main():
         )
 
     if args.op == "verify":
-        bandersnatch.verify.metadata_verify(config, args)
+        loop = asyncio.get_event_loop()
+        try:
+            loop.run_until_complete(bandersnatch.verify.metadata_verify(config, args))
+        finally:
+            loop.close()
     else:
         mirror(config)
 

--- a/src/bandersnatch/verify.py
+++ b/src/bandersnatch/verify.py
@@ -60,7 +60,6 @@ def _unlink_parent_dir(path):
         logger.debug(f"Did not remove {path.parent.as_posix()}: {str(oe)}")
 
 
-
 async def verify(
     config,
     json_file,
@@ -131,7 +130,6 @@ async def url_fetch(url, file_path, executor, chunk_size=65536, timeout=60):
                     if not chunk:
                         break
                     fd.write(chunk)
-
 
 
 async def async_verify(


### PR DESCRIPTION
- I want to include this in my larger asyncio daemon @ Facebook
- Make the entry point async and start loop in main.py
- Move everything to fstrings
- Fix some small bugs:
-- always use our created executor
-- wrap all IO in executors
-- print unowned files only if there are unowned files in dry run mode

Test:
python3.6 -m venv /tmp/v
/tmp/v/bin/pip install --upgrade pip
/tmp/v/bin/pip install -e .
/tmp/v/bin/bandersnatch --debug verify --dry-run
/tmp/v/bin/bandersnatch --debug verify --json-update - Output: https://pastebin.com/G89VBGd6