### PR TITLE
Try to download each remaining file in a package before bailing

### DIFF
--- a/src/bandersnatch/package.py
+++ b/src/bandersnatch/package.py
@@ -179,7 +179,8 @@ class Package:
                     )
             except Exception as e:
                 logger.exception(
-                    f"Continuing to next file after error downloading: {release_file['url']}"
+                    f"Continuing to next file after error downloading: "
+                    f"{release_file['url']}"
                 )
                 if not deferred_exception:  # keep first exception
                     deferred_exception = e

--- a/src/bandersnatch/package.py
+++ b/src/bandersnatch/package.py
@@ -167,14 +167,21 @@ class Package:
             release_files.extend(release)
 
         downloaded_files = set()
+        deferred_exception = None
         for release_file in release_files:
-            downloaded_file = self.download_file(
-                release_file["url"], release_file["digests"]["sha256"]
-            )
-            if downloaded_file:
-                downloaded_files.add(
-                    os.path.relpath(downloaded_file, self.mirror.homedir)
+            try:
+                downloaded_file = self.download_file(
+                    release_file["url"], release_file["digests"]["sha256"]
                 )
+                if downloaded_file:
+                    downloaded_files.add(
+                        os.path.relpath(downloaded_file, self.mirror.homedir)
+                    )
+            except Exception as e:
+                if not deferred_exception:  # keep first exception
+                    deferred_exception = e
+        if deferred_exception:
+            raise deferred_exception  # raise the exception after trying all files
 
         self.mirror.altered_packages[self.name] = downloaded_files
 

--- a/src/bandersnatch/package.py
+++ b/src/bandersnatch/package.py
@@ -178,6 +178,7 @@ class Package:
                         os.path.relpath(downloaded_file, self.mirror.homedir)
                     )
             except Exception as e:
+                logger.exception(f"Continuing to next file after error downloading: {release_file['url']}")
                 if not deferred_exception:  # keep first exception
                     deferred_exception = e
         if deferred_exception:

--- a/src/bandersnatch/package.py
+++ b/src/bandersnatch/package.py
@@ -178,7 +178,9 @@ class Package:
                         os.path.relpath(downloaded_file, self.mirror.homedir)
                     )
             except Exception as e:
-                logger.exception(f"Continuing to next file after error downloading: {release_file['url']}")
+                logger.exception(
+                    f"Continuing to next file after error downloading: {release_file['url']}"
+                )
                 if not deferred_exception:  # keep first exception
                     deferred_exception = e
         if deferred_exception:


### PR DESCRIPTION
Without this patch, bandersnatch skips a package as soon as it fails to download a single file.

In an environment with connectivity issues, e.g. where long downloads are difficult to complete, this means that large packages will never complete in practice, causing the mirror to fall behind.

This issue mostly manifests itself with several "deep learning" packages that appear to use PyPI for their continuous integration hosting.  mxnet* is a particular offender here, with multiple 300MB+ packages added per day.  At least tensorflow has a separate "nightlies" package which could separately be blacklisted if desired.

This patch lets bandersnatch at least try to download each file in the package before giving up, making substantially more progress during each run.  In practice, this has allowed even the mxnet packages' daily updates to be fully downloaded over the course of 3-4 runs of bandersnatch.  Without this patch, running bandersnatch on a continual loop 24x7 was unable to keep up.

Ideally bandernsnatch would be able to resume incomplete downloads, but that would be a far more extensive undertaking, and this minimal change has been good enough.

If you think there's a better approach, either in bandersnatch or in discussions with package maintainers, I have no attachment to this particular solution.