### PR TITLE
Issue a purge request when we get a stale serial.

### DIFF
--- a/src/bandersnatch/master.py
+++ b/src/bandersnatch/master.py
@@ -74,7 +74,8 @@ class Master:
                     )
 
                 raise StalePage(
-                    "Expected PyPI serial {} for request {} but got {}".format(
+                    "Expected PyPI serial {} for request {} but got {}. "
+                    + "HTTP PURGE has been issued to the request url".format(
                         required_serial, path, got_serial
                     )
                 )

--- a/src/bandersnatch/master.py
+++ b/src/bandersnatch/master.py
@@ -60,6 +60,23 @@ class Master:
                         required_serial, path, got_serial
                     )
                 )
+                # HACK: The following attempts to purge the cache of the page we
+                # just tried to fetch. This works around PyPI's caches sometimes
+                # returning a stale serial for a package. Ideally, this should
+                # be fixed on the PyPI side, at which point the following code
+                # should be removed.
+                logger.debug(
+                    "Issuing a PURGE for {} to clear the cache".format(
+                        path
+                    )
+                )
+                try:
+                    self.session.request("PURGE", path, timeout=self.timeout)
+                except requests.exceptions.HTTPError:
+                    logger.warning(
+                        "Got an error when attempting to clear the cache", exc_info=True
+                    )
+
                 raise StalePage(
                     "Expected PyPI serial {} for request {} but got {}".format(
                         required_serial, path, got_serial

--- a/src/bandersnatch/master.py
+++ b/src/bandersnatch/master.py
@@ -65,11 +65,7 @@ class Master:
                 # returning a stale serial for a package. Ideally, this should
                 # be fixed on the PyPI side, at which point the following code
                 # should be removed.
-                logger.debug(
-                    "Issuing a PURGE for {} to clear the cache".format(
-                        path
-                    )
-                )
+                logger.debug(f"Issuing a PURGE for {path} to clear the cache")
                 try:
                     self.session.request("PURGE", path, timeout=self.timeout)
                 except requests.exceptions.HTTPError:


### PR DESCRIPTION
Temporary fix for #56. We issue a PURGE to the url if we get a stale serial. Not ideal, but a workaround until PyPI's caches are fixed to always return the up-to-date header.