### PR TITLE
Fix Unit test Coverage + add lint run with Tox

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -4,31 +4,22 @@ So you want to help out? **Awesome**. Go you!
 
 ## Getting Started
 
-We use a Bitbucket `hg` (Mercurial) repo.
+We use GitHub. To get started I'd suggest visiting https://guides.github.com/
 
 ### Pre Install
 Please make sure you system has the following:
 
-- Python 3.5 or greater
-- Mercurial Installed
+- Python 3.6 or greater
+- git cli client
 
-```
-# Mac OS X - To get latest version
-brew install hg
-
-# Ubuntu
-apt install mercurial
-
-# Windows - Please note, no recent bandersnatch changes have been tested on Windows
-https://www.mercurial-scm.org/wiki/WindowsInstall
-```
+Also esure you can authenticate with GitHub via SSH Keys or HTTPS.
 
 ### Checkout `bandersnatch`
 
 Lets now cd to where we want the code and use hg:
 
 - `cd somewhere`
-- `hg clone ssh://hg@bitbucket.org/pypa/bandersnatch`
+- `git clone git@github.com:pypa/bandersnatch.git`
 
 ### Development venv
 
@@ -38,7 +29,7 @@ One way to develop and install all the dependencies of bandersnatch is to use a 
 
 ```
 python3 -m venv /path/to/venv
-/path/to/venv/bin/pip install --upgrade pip
+/path/to/venv/bin/pip install --upgrade pip setuptools
 ```
 
 - Then we should install the dependencies to the venv:

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,3 @@
 [pytest]
-addopts = --tb=native --cov=src --cov-report=html --timeout=10 src
 log_cli_level = DEBUG
 log_level = DEBUG

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,7 +1,8 @@
+black
+coverage
 pytest
 pytest-cov
 pytest-timeout
 pytest-cache
 setuptools
 tox
-black

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,12 @@
 [tox]
-envlist = py36
+envlist = lint,py36
 
 [testenv]
 deps = -rtest-requirements.txt
-commands = pytest
+commands =
+    coverage run -m pytest
+    coverage report -m
+    coverage html
 
 [testenv:doc_build]
 basepython=python3


### PR DESCRIPTION
- Looking around it seems it's better to run coverage directly these days
- Edit pytest to not run pytest-cov as it seems to not work with tox anymore
- Update DEVELOPMENT.md