### PR TITLE
Document + enforce we need >= 3.6.1

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -9,7 +9,7 @@ We use GitHub. To get started I'd suggest visiting https://guides.github.com/
 ### Pre Install
 Please make sure you system has the following:
 
-- Python 3.6 or greater
+- Python 3.6.1 or greater
 - git cli client
 
 Also esure you can authenticate with GitHub via SSH Keys or HTTPS.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ http://www.python.org/dev/peps/pep-0381/.
 The following instructions will place the bandersnatch executable in a
 virtualenv under `bandersnatch/bin/bandersnatch`.
 
-- bandersnatch **requires** `>= Python 3.6`
+- bandersnatch **requires** `>= Python 3.6.1`
 
 
 ### pip

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -13,7 +13,7 @@ Bandersnatch is developed using the [GitHub Flow](https://guides.github.com/intr
 ### Pre Install
 Please make sure you system has the following:
 
-- Python 3.6 or greater
+- Python 3.6.1 or greater
 
 ### Development venv
 One way to develop and install all the dependencies of bandersnatch is to use a venv.

--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,13 @@
 #!/usr/bin/env python3
 
 from setuptools import find_packages, setup
+from sys import version_info
 
 from src.bandersnatch import __version__
 
 install_deps = ["aiodns", "aiohttp", "packaging", "requests", "setuptools", "xmlrpc2"]
+
+assert sys.version_info >= (3, 6, 1), "black requires Python >=3.6.1"
 
 setup(
     name="bandersnatch",

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from src.bandersnatch import __version__
 
 install_deps = ["aiodns", "aiohttp", "packaging", "requests", "setuptools", "xmlrpc2"]
 
-assert sys.version_info >= (3, 6, 1), "black requires Python >=3.6.1"
+assert version_info >= (3, 6, 1), "black requires Python >=3.6.1"
 
 setup(
     name="bandersnatch",

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python3
 
-from setuptools import find_packages, setup
 from sys import version_info
+
+from setuptools import find_packages, setup
 
 from src.bandersnatch import __version__
 


### PR DESCRIPTION
- Save future devs time by not trying to use 3.6.0
- We need `from typing import NamedTuple`