### PR TITLE
Force cancel on KeyboardInterrupt

### DIFF
--- a/src/bandersnatch/mirror.py
+++ b/src/bandersnatch/mirror.py
@@ -5,6 +5,7 @@ import datetime
 import fcntl
 import logging
 import os
+from concurrent.futures import thread as futures_thread
 from threading import RLock
 
 from packaging.utils import canonicalize_name
@@ -201,7 +202,7 @@ class Mirror:
         # Replace threading with asyncio executors for now
         loop = asyncio.new_event_loop()
         try:
-            atexit.unregister(concurrent.futures.thread._python_exit)
+            atexit.unregister(futures_thread._python_exit)
             thread_pool = concurrent.futures.ThreadPoolExecutor(
                 max_workers=self.workers
             )


### PR DESCRIPTION
Fixes #27

The output varies when force cancelling the threads in this way. Usually it's fairly clean and immediate but I've seen instances where there's leftover output from the threads and once I got the following:

```
exception calling callback for <Future at 0x10fc176d8 state=finished returned NoneType>
Traceback (most recent call last):
  File "/Users/yeray.diaz/.pyenv/versions/3.6.5/lib/python3.6/concurrent/futures/_base.py", line 324, in _invoke_callbacks
    callback(self)
  File "/Users/yeray.diaz/.pyenv/versions/3.6.5/lib/python3.6/asyncio/futures.py", line 414, in _call_set_state
    dest_loop.call_soon_threadsafe(_set_state, destination, source)
  File "/Users/yeray.diaz/.pyenv/versions/3.6.5/lib/python3.6/asyncio/base_events.py", line 621, in call_soon_threadsafe
    self._check_closed()
  File "/Users/yeray.diaz/.pyenv/versions/3.6.5/lib/python3.6/asyncio/base_events.py", line 358, in _check_closed
    raise RuntimeError('Event loop is closed')
RuntimeError: Event loop is closed
2018-10-31 13:45:27,213 INFO: Syncing package: 01changer (serial 2080766)
Fatal Python error: could not acquire lock for <_io.BufferedWriter name='<stderr>'> at interpreter shutdown, possibly due to daemon threads

Thread 0x000070000abf4000 (most recent call first):
  File "/Users/yeray.diaz/.pyenv/versions/3.6.5/lib/python3.6/genericpath.py", line 19 in exists
  File "/Users/yeray.diaz/code/personal/bandersnatch/src/bandersnatch/utils.py", line 99 in update_safe
  File "/Users/yeray.diaz/.pyenv/versions/3.6.5/lib/python3.6/contextlib.py", line 88 in __exit__
  File "/Users/yeray.diaz/code/personal/bandersnatch/src/bandersnatch/mirror.py", line 232 in record_finished_package
  File "/Users/yeray.diaz/code/personal/bandersnatch/src/bandersnatch/package.py", line 120 in sync
  File "/Users/yeray.diaz/.pyenv/versions/3.6.5/lib/python3.6/concurrent/futures/thread.py", line 56 in run
  File "/Users/yeray.diaz/.pyenv/versions/3.6.5/lib/python3.6/concurrent/futures/thread.py", line 69 in _worker
  File "/Users/yeray.diaz/.pyenv/versions/3.6.5/lib/python3.6/threading.py", line 864 in run
  File "/Users/yeray.diaz/.pyenv/versions/3.6.5/lib/python3.6/threading.py", line 916 in _bootstrap_inner
  File "/Users/yeray.diaz/.pyenv/versions/3.6.5/lib/python3.6/threading.py", line 884 in _bootstrap
```

Which I guess the user would understand as the point is to stop as soon as possible.

It'd be good to try it out on other platforms as well, I've only tested in on Mac OS X.