### PR TITLE
Revert setup.py to specify unversioned deps

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,13 +6,10 @@ from setuptools import find_packages, setup
 
 from src.bandersnatch import __version__
 
-assert version_info >= (3, 6, 1), "black requires Python >=3.6.1"
+assert version_info >= (3, 6, 1), "bandersnatch requires Python >=3.6.1"
 
 
-def get_install_deps():
-    """ Load requirements.txt to get pinned versions installed """
-    with open("requirements.txt") as rfp:
-        return rfp.read().split("\n")
+INSTALL_DEPS = ("aiohttp", "packaging", "requests", "setuptools", "xmlrpc2")
 
 
 setup(
@@ -28,7 +25,7 @@ setup(
     packages=find_packages("src"),
     package_dir={"": "src"},
     include_package_data=True,
-    install_requires=get_install_deps(),
+    install_requires=INSTALL_DEPS,
     entry_points="""
             [bandersnatch_filter_plugins.project]
                 blacklist_project = bandersnatch_filter_plugins.blacklist_name:BlacklistProject

--- a/src/bandersnatch/__init__.py
+++ b/src/bandersnatch/__init__.py
@@ -19,7 +19,7 @@ __version_info__ = _VersionInfo(
     major=3,
     minor=1,
     micro=0,
-    releaselevel="dev0",
+    releaselevel="dev1",
     serial=0,  # Not currently in use with Bandersnatch versioning
 )
 __version__ = __version_info__.version_str


### PR DESCRIPTION
- Lets allow people to install latest deps
- Leave requirements.txt that hard pin known working versions
Test install in a venv: https://pastebin.com/FUzsgcX6

Addresses #81