### PR TITLE
bug fix: reading either default or system configuration instead of both

### DIFF
--- a/src/bandersnatch/configuration.py
+++ b/src/bandersnatch/configuration.py
@@ -37,8 +37,10 @@ class BandersnatchConfig(metaclass=Singleton):
 
     def load_configuration(self) -> None:
         """
-        Read the configuration from the configuration files
+        Read the configuration from a configuration file
         """
-        config_file = self.config_file if self.config_file else self.default_config_file
+        config_file = self.default_config_file
+        if self.config_file:
+            config_file = self.config_file
         self.config = ConfigParser()
         self.config.read(config_file)

--- a/src/bandersnatch/configuration.py
+++ b/src/bandersnatch/configuration.py
@@ -39,8 +39,6 @@ class BandersnatchConfig(metaclass=Singleton):
         """
         Read the configuration from the configuration files
         """
-        config_files = [self.default_config_file]
-        if self.config_file:
-            config_files.append(self.config_file)
+        config_file = self.config_file if self.config_file else self.default_config_file
         self.config = ConfigParser()
-        self.config.read(config_files)
+        self.config.read(config_file)


### PR DESCRIPTION
I fixed this [issue](https://github.com/pypa/bandersnatch/issues/95). #95 
I think the problem was configuration module tries to read default and system configuration. The problem is when you comment any section in system configuration, it'll read that section through default configuration.