### PR TITLE
prevent executing bandersnatch when no argument has entered

### DIFF
--- a/src/bandersnatch/main.py
+++ b/src/bandersnatch/main.py
@@ -4,6 +4,7 @@ import configparser
 import logging
 import logging.config
 import shutil
+import sys
 from os import path
 from tempfile import gettempdir
 
@@ -133,6 +134,10 @@ def main():
         help="# of parallel iops [Defaults to bandersnatch.conf]",
     )
     v.set_defaults(op="verify")
+
+    if len(sys.argv) < 2:
+        parser.print_help()
+        parser.exit()
 
     args = parser.parse_args()
 

--- a/src/bandersnatch/main.py
+++ b/src/bandersnatch/main.py
@@ -74,6 +74,9 @@ def mirror(config):
 def main():
     parser = argparse.ArgumentParser(description="PyPI PEP 381 mirroring client.")
     parser.add_argument(
+        "--version", action="version", version=f"%(prog)s {bandersnatch.__version__}"
+    )
+    parser.add_argument(
         "-c",
         "--config",
         default="/etc/bandersnatch.conf",


### PR DESCRIPTION
Hi

Sometimes I just want to see `bandersnatch` options but it tries to mirror everything so I changed the code for that part and I added `--version` option to make sure I'm using the latest version due to `force-check` option.

thanks

