### PR TITLE
Add a reference Docker File

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+FROM python:3
+
+RUN mkdir -p /src
+ADD setup.py /src
+ADD requirements.txt /src
+ADD README.md /src
+ADD CHANGES.md /src
+ADD src /src/src
+
+# Remember to bind mount the "directory" in bandersnatch.conf
+# Could also comment this out and bind mount in the config and add arg below
+ADD bandersnatch.conf /etc
+
+RUN pip install --upgrade pip
+RUN pip install --upgrade -r /src/requirements.txt
+RUN cd /src && pip install .
+
+# Please adjust the interval - Could move this to the config file or ENV Variable
+CMD ["python", "/src/src/runner.py", "3600"]

--- a/src/runner.py
+++ b/src/runner.py
@@ -11,7 +11,7 @@ from subprocess import run
 def main() -> None:
     parser = argparse.ArgumentParser()
     parser.add_argument("interval", help="Time in seconds between jobs")
-    parser.parse_args()
+    args = parser.parse_args()
 
     print(f"Running bandersnatch every {args.interval}s", file=sys.stderr)
     while True:

--- a/src/runner.py
+++ b/src/runner.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python3
+
+# Simple Script to replace cron for Docker
+
+import argparse
+import sys
+import time
+from subprocess import run
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("interval", help="Time in seconds between jobs")
+    parser.parse_args()
+
+    print(f"Running bandersnatch every {args.interval}s", file=sys.stderr)
+    while True:
+        start_time = time.time()
+        run(["/usr/bin/bandersnatch", "mirror"])
+        run_time = time.time() - start_time
+        if run_time < args.interval:
+            sleep_time = args.interval - run_time
+            print(f"Sleeping for {sleep_time}s", file=sys.stderr)
+            time.sleep(sleep_time)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
- Use latest Python 3
- Install all tested Python module version in requirements.txt

Tested build via `docker build --network=host --tag bandersnatch .`:
https://pastebin.com/0ZGgMUtA

Addresses #88 - Will see what the best way to automate building this image on every commit or release? Don't know what's the hotness with Docker (lost inside Facebook)