### PR TITLE
Fix turning on all plugins by default

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,3 +2,4 @@ include MANIFEST.in
 include CHANGES.md
 include requirements.txt
 include src/bandersnatch/default.conf
+include src/bandersnatch/unittest.conf

--- a/setup.py
+++ b/setup.py
@@ -33,8 +33,8 @@ setup(
                 regex_project = bandersnatch_filter_plugins.regex_name:RegexProjectFilter
             [bandersnatch_filter_plugins.release]
                 blacklist_release = bandersnatch_filter_plugins.blacklist_name:BlacklistRelease
-                regex_release = bandersnatch_filter_plugins.regex_name:RegexReleaseFilter
                 prerelease_release = bandersnatch_filter_plugins.prerelease_name:PreReleaseFilter
+                regex_release = bandersnatch_filter_plugins.regex_name:RegexReleaseFilter
             [console_scripts]
                 bandersnatch = bandersnatch.main:main
             [zc.buildout]

--- a/src/bandersnatch/filter.py
+++ b/src/bandersnatch/filter.py
@@ -71,27 +71,27 @@ def load_filter_plugins(entrypoint_group: str) -> Iterable[Filter]:
         A list of objects derived from the Blacklist class
     """
     global loaded_filter_plugins
-    enabled_plugins = ["all"]
+    enabled_plugins: List[str] = []
     config = BandersnatchConfig().config
     try:
         config_blacklist_plugins = config["blacklist"]["plugins"]
+        split_plugins = config_blacklist_plugins.split("\n")
+        if "all" in split_plugins:
+            enabled_plugins = ["all"]
+        else:
+            for plugin in split_plugins:
+                if not plugin:
+                    continue
+                enabled_plugins.append(plugin)
     except KeyError:
-        config_blacklist_plugins = ""
-    if config_blacklist_plugins:
-        config_plugins = []
-        for plugin in config_blacklist_plugins.split("\n"):
-            plugin = plugin.strip()
-            if plugin:
-                config_plugins.append(plugin)
-        if config_plugins:
-            enabled_plugins = config_plugins
+        pass
 
     # If the plugins for the entrypoint_group have been loaded return them
     cached_plugins = loaded_filter_plugins.get(entrypoint_group)
     if cached_plugins:
         return cached_plugins
 
-    plugins = set()  # Use a set to prevent possible duplicates
+    plugins = set()
     for entry_point in pkg_resources.iter_entry_points(group=entrypoint_group):
         plugin_class = entry_point.load()
         plugin_instance = plugin_class()

--- a/src/bandersnatch/mirror.py
+++ b/src/bandersnatch/mirror.py
@@ -137,9 +137,16 @@ class Mirror:
         packages_to_sync that match any filters.
         - Logging of action will be done within the check_match methods
         """
+        filter_plugins = filter_project_plugins()
+        if not filter_plugins:
+            logger.info("No project filters are enabled. Skipping filtering")
+            return
+
+        # Make a copy of self.packages_to_sync keys
+        # as we may delete packages during iteration
         packages = list(self.packages_to_sync.keys())
         for package_name in packages:
-            for plugin in filter_project_plugins():
+            for plugin in filter_plugins:
                 if plugin.check_match(name=package_name):
                     if package_name not in self.packages_to_sync:
                         logger.error(

--- a/src/bandersnatch/package.py
+++ b/src/bandersnatch/package.py
@@ -152,10 +152,17 @@ class Package:
         Run the release filtering plugins and remove any releases from
         `releases` that match any filters.
         """
+        filter_plugins = filter_release_plugins()
+        if not filter_plugins:
+            logger.info("No package filters are enabled. Skipping filtering")
+            return
+
+        # Make a copy of self.releases keys
+        # as we may delete packages during iteration
         versions = list(self.releases.keys())
         for version in versions:
             filter_ = False
-            for plugin in filter_release_plugins():
+            for plugin in filter_plugins:
                 filter_ = filter_ or plugin.check_match(name=self.name, version=version)
             if filter_:
                 del (self.releases[version])
@@ -206,6 +213,9 @@ class Package:
 
         # Get a list of all of the files.
         release_files = []
+        logger.debug(
+            f"There are {len(self.releases.values())} releases for {self.name}"
+        )
         for release in self.releases.values():
             release_files.extend(release)
         # Lets sort based on the filename rather than the whole URL

--- a/src/bandersnatch/tests/ci.conf
+++ b/src/bandersnatch/tests/ci.conf
@@ -5,14 +5,19 @@ directory = /tmp/pypi
 json = true
 master = https://pypi.org
 timeout = 10
-workers = 2
+workers = 3
 hash-index = true
 stop-on-error = true
-verifiers = 2
+verifiers = 3
 keep_index_versions = 2
+
+[blacklist]
+plugins =
+    whitelist_project
 
 [whitelist]
 packages =
+    black
     peerme
     pyaib
 

--- a/src/bandersnatch/tests/plugins/test_blacklist_name.py
+++ b/src/bandersnatch/tests/plugins/test_blacklist_name.py
@@ -9,6 +9,8 @@ from bandersnatch.master import Master
 from bandersnatch.mirror import Mirror
 from bandersnatch.package import Package
 
+TEST_CONF = "test.conf"
+
 
 class TestBlacklistProject(TestCase):
     """
@@ -31,7 +33,7 @@ class TestBlacklistProject(TestCase):
             self.tempdir = None
 
     def test__plugin__loads__explicitly_enabled(self):
-        with open("test.conf", "w") as testconfig_handle:
+        with open(TEST_CONF, "w") as testconfig_handle:
             testconfig_handle.write(
                 """\
 [blacklist]
@@ -40,7 +42,7 @@ plugins =
 """
             )
         instance = BandersnatchConfig()
-        instance.config_file = "test.conf"
+        instance.config_file = TEST_CONF
         instance.load_configuration()
 
         plugins = bandersnatch.filter.filter_project_plugins()
@@ -49,7 +51,7 @@ plugins =
         self.assertEqual(len(plugins), 1)
 
     def test__plugin__doesnt_load__explicitly__disabled(self):
-        with open("test.conf", "w") as testconfig_handle:
+        with open(TEST_CONF, "w") as testconfig_handle:
             testconfig_handle.write(
                 """\
 [blacklist]
@@ -58,7 +60,7 @@ plugins =
 """
             )
         instance = BandersnatchConfig()
-        instance.config_file = "test.conf"
+        instance.config_file = TEST_CONF
         instance.load_configuration()
 
         plugins = bandersnatch.filter.filter_project_plugins()
@@ -66,22 +68,22 @@ plugins =
         self.assertNotIn("blacklist_project", names)
 
     def test__plugin__loads__default(self):
-        with open("test.conf", "w") as testconfig_handle:
+        with open(TEST_CONF, "w") as testconfig_handle:
             testconfig_handle.write(
                 """\
 [blacklist]
 """
             )
         instance = BandersnatchConfig()
-        instance.config_file = "test.conf"
+        instance.config_file = TEST_CONF
         instance.load_configuration()
 
         plugins = bandersnatch.filter.filter_project_plugins()
         names = [plugin.name for plugin in plugins]
-        self.assertIn("blacklist_project", names)
+        self.assertNotIn("blacklist_project", names)
 
     def test__filter__matches__package(self):
-        with open("test.conf", "w") as testconfig_handle:
+        with open(TEST_CONF, "w") as testconfig_handle:
             testconfig_handle.write(
                 """\
 [blacklist]
@@ -92,7 +94,7 @@ packages =
 """
             )
         instance = BandersnatchConfig()
-        instance.config_file = "test.conf"
+        instance.config_file = TEST_CONF
         instance.load_configuration()
 
         mirror = Mirror(".", Master(url="https://foo.bar.com"))
@@ -102,7 +104,7 @@ packages =
         self.assertNotIn("foo", mirror.packages_to_sync.keys())
 
     def test__filter__nomatch_package(self):
-        with open("test.conf", "w") as testconfig_handle:
+        with open(TEST_CONF, "w") as testconfig_handle:
             testconfig_handle.write(
                 """\
         [blacklist]
@@ -113,7 +115,7 @@ packages =
         """
             )
         instance = BandersnatchConfig()
-        instance.config_file = "test.conf"
+        instance.config_file = TEST_CONF
         instance.load_configuration()
 
         mirror = Mirror(".", Master(url="https://foo.bar.com"))
@@ -144,7 +146,7 @@ class TestBlacklistRelease(TestCase):
             self.tempdir = None
 
     def test__plugin__loads__explicitly_enabled(self):
-        with open("test.conf", "w") as testconfig_handle:
+        with open(TEST_CONF, "w") as testconfig_handle:
             testconfig_handle.write(
                 """\
 [blacklist]
@@ -153,7 +155,7 @@ plugins =
 """
             )
         instance = BandersnatchConfig()
-        instance.config_file = "test.conf"
+        instance.config_file = TEST_CONF
         instance.load_configuration()
 
         plugins = bandersnatch.filter.filter_release_plugins()
@@ -162,7 +164,7 @@ plugins =
         self.assertEqual(len(plugins), 1)
 
     def test__plugin__doesnt_load__explicitly__disabled(self):
-        with open("test.conf", "w") as testconfig_handle:
+        with open(TEST_CONF, "w") as testconfig_handle:
             testconfig_handle.write(
                 """\
 [blacklist]
@@ -171,30 +173,15 @@ plugins =
 """
             )
         instance = BandersnatchConfig()
-        instance.config_file = "test.conf"
+        instance.config_file = TEST_CONF
         instance.load_configuration()
 
         plugins = bandersnatch.filter.filter_release_plugins()
         names = [plugin.name for plugin in plugins]
         self.assertNotIn("blacklist_release", names)
 
-    def test__plugin__loads__default(self):
-        with open("test.conf", "w") as testconfig_handle:
-            testconfig_handle.write(
-                """\
-[blacklist]
-"""
-            )
-        instance = BandersnatchConfig()
-        instance.config_file = "test.conf"
-        instance.load_configuration()
-
-        plugins = bandersnatch.filter.filter_release_plugins()
-        names = [plugin.name for plugin in plugins]
-        self.assertIn("blacklist_release", names)
-
     def test__filter__matches__release(self):
-        with open("test.conf", "w") as testconfig_handle:
+        with open(TEST_CONF, "w") as testconfig_handle:
             testconfig_handle.write(
                 """\
 [blacklist]
@@ -205,7 +192,7 @@ packages =
 """
             )
         instance = BandersnatchConfig()
-        instance.config_file = "test.conf"
+        instance.config_file = TEST_CONF
         instance.load_configuration()
 
         mirror = Mirror(".", Master(url="https://foo.bar.com"))

--- a/src/bandersnatch/tests/plugins/test_whitelist_name.py
+++ b/src/bandersnatch/tests/plugins/test_whitelist_name.py
@@ -8,6 +8,8 @@ from bandersnatch.configuration import BandersnatchConfig
 from bandersnatch.master import Master
 from bandersnatch.mirror import Mirror
 
+TEST_CONF = "test.conf"
+
 
 class TestWhitelistProject(TestCase):
     """
@@ -30,7 +32,7 @@ class TestWhitelistProject(TestCase):
             self.tempdir = None
 
     def test__plugin__loads__explicitly_enabled(self):
-        with open("test.conf", "w") as testconfig_handle:
+        with open(TEST_CONF, "w") as testconfig_handle:
             testconfig_handle.write(
                 """\
 [blacklist]
@@ -39,7 +41,7 @@ plugins =
 """
             )
         instance = BandersnatchConfig()
-        instance.config_file = "test.conf"
+        instance.config_file = TEST_CONF
         instance.load_configuration()
 
         plugins = bandersnatch.filter.filter_project_plugins()
@@ -48,22 +50,22 @@ plugins =
         self.assertEqual(len(plugins), 1)
 
     def test__plugin__loads__default(self):
-        with open("test.conf", "w") as testconfig_handle:
+        with open(TEST_CONF, "w") as testconfig_handle:
             testconfig_handle.write(
                 """\
 [blacklist]
 """
             )
         instance = BandersnatchConfig()
-        instance.config_file = "test.conf"
+        instance.config_file = TEST_CONF
         instance.load_configuration()
 
         plugins = bandersnatch.filter.filter_project_plugins()
         names = [plugin.name for plugin in plugins]
-        self.assertIn("whitelist_project", names)
+        self.assertNotIn("whitelist_project", names)
 
     def test__filter__matches__package(self):
-        with open("test.conf", "w") as testconfig_handle:
+        with open(TEST_CONF, "w") as testconfig_handle:
             testconfig_handle.write(
                 """\
 [blacklist]
@@ -76,7 +78,7 @@ packages =
 """
             )
         instance = BandersnatchConfig()
-        instance.config_file = "test.conf"
+        instance.config_file = TEST_CONF
         instance.load_configuration()
 
         mirror = Mirror(".", Master(url="https://foo.bar.com"))
@@ -86,7 +88,7 @@ packages =
         self.assertIn("foo", mirror.packages_to_sync.keys())
 
     def test__filter__nomatch_package(self):
-        with open("test.conf", "w") as testconfig_handle:
+        with open(TEST_CONF, "w") as testconfig_handle:
             testconfig_handle.write(
                 """\
 [blacklist]
@@ -99,7 +101,7 @@ packages =
 """
             )
         instance = BandersnatchConfig()
-        instance.config_file = "test.conf"
+        instance.config_file = TEST_CONF
         instance.load_configuration()
 
         mirror = Mirror(".", Master(url="https://foo.bar.com"))

--- a/src/bandersnatch/tests/test_configuration.py
+++ b/src/bandersnatch/tests/test_configuration.py
@@ -3,6 +3,8 @@ import unittest
 from tempfile import TemporaryDirectory
 from unittest import TestCase
 
+from pkg_resources import resource_filename
+
 from bandersnatch.configuration import BandersnatchConfig, Singleton
 
 
@@ -34,7 +36,8 @@ class TestBandersnatchConf(TestCase):
         self.assertEqual(id(instance1), id(instance2))
 
     def test_single_config__default__all_sections_present(self):
-        instance = BandersnatchConfig()
+        config_file = resource_filename("bandersnatch", "unittest.conf")
+        instance = BandersnatchConfig(config_file)
         # All default values should at least be present and be the write types
         for section in ["mirror", "blacklist"]:
             self.assertIn(section, instance.config.sections())

--- a/src/bandersnatch/tests/test_filter.py
+++ b/src/bandersnatch/tests/test_filter.py
@@ -7,6 +7,8 @@ import bandersnatch.filter
 from bandersnatch.configuration import BandersnatchConfig
 from bandersnatch.filter import filter_project_plugins, filter_release_plugins
 
+TEST_CONF = "test.conf"
+
 
 class TestBandersnatchFilter(TestCase):
     """
@@ -28,16 +30,21 @@ class TestBandersnatchFilter(TestCase):
             self.tempdir.cleanup()
             self.tempdir = None
 
-    def test__filter_project_plugins__default__loads(self):
-        with open("test.conf", "w") as testconfig_handle:
+    def test__filter_project_plugins__loads(self):
+        with open(TEST_CONF, "w") as testconfig_handle:
             testconfig_handle.write(
                 """\
 [blacklist]
+plugins = all
 """
             )
-        builtin_plugin_names = ["blacklist_project", "whitelist_project"]
+        builtin_plugin_names = [
+            "blacklist_project",
+            "regex_project",
+            "whitelist_project",
+        ]
         instance = BandersnatchConfig()
-        instance.config_file = "test.conf"
+        instance.config_file = TEST_CONF
         instance.load_configuration()
 
         plugins = filter_project_plugins()
@@ -45,16 +52,21 @@ class TestBandersnatchFilter(TestCase):
         for name in builtin_plugin_names:
             self.assertIn(name, names)
 
-    def test__filter_release_plugins__default__loads(self):
-        with open("test.conf", "w") as testconfig_handle:
+    def test__filter_release_plugins__loads(self):
+        with open(TEST_CONF, "w") as testconfig_handle:
             testconfig_handle.write(
                 """\
 [blacklist]
+plugins = all
 """
             )
-        builtin_plugin_names = ["blacklist_release"]
+        builtin_plugin_names = [
+            "blacklist_release",
+            "prerelease_release",
+            "regex_release",
+        ]
         instance = BandersnatchConfig()
-        instance.config_file = "test.conf"
+        instance.config_file = TEST_CONF
         instance.load_configuration()
 
         plugins = filter_release_plugins()

--- a/src/bandersnatch/tests/test_main.py
+++ b/src/bandersnatch/tests/test_main.py
@@ -45,7 +45,7 @@ def test_main_cant_create_config(caplog, tmpdir):
 
 
 def test_main_reads_config_values(mirror_mock):
-    config = os.path.dirname(bandersnatch.__file__) + "/default.conf"
+    config = os.path.dirname(bandersnatch.__file__) + "/unittest.conf"
     sys.argv = ["bandersnatch", "-c", config, "mirror"]
     assert os.path.exists(config)
     assert isinstance(bandersnatch.mirror.Mirror, mock.Mock)
@@ -94,7 +94,7 @@ def test_main_throws_exception_on_unsupported_digest_name(customconfig):
 
 @pytest.fixture
 def customconfig(tmpdir):
-    default = os.path.dirname(bandersnatch.__file__) + "/default.conf"
+    default = os.path.dirname(bandersnatch.__file__) + "/unittest.conf"
     config = open(default).read()
     config = config.replace("/srv/pypi", str(tmpdir / "pypi"))
     with open(str(tmpdir / "bandersnatch.conf"), "w") as f:

--- a/src/bandersnatch/tests/test_mirror.py
+++ b/src/bandersnatch/tests/test_mirror.py
@@ -106,6 +106,7 @@ def test_mirror_filter_packages_match(tmpdir):
     """
     test_configuration = """\
 [blacklist]
+plugins = blacklist_project
 packages =
     example1
 """

--- a/src/bandersnatch/unittest.conf
+++ b/src/bandersnatch/unittest.conf
@@ -63,4 +63,13 @@ verifiers = 3
 ; If unset defaults to 0.
 ; keep_index_versions = 0
 
+; Enable filtering plugins
+[blacklist]
+; Enable all or specific plugins - e.g. whitelist_project
+plugins = all
+; List of PyPI packages not to sync - Useful if malicious packages are mirrored
+packages =
+    example1
+    example2
+
 ; vim: set ft=cfg:

--- a/test_runner.py
+++ b/test_runner.py
@@ -21,6 +21,7 @@ from src.bandersnatch.utils import hash
 
 BANDERSNATCH_EXE = Path(which("bandersnatch") or "bandersnatch")
 CI_CONFIG = Path("src/bandersnatch/tests/ci.conf")
+EOP = "[CI ERROR]:"
 MIRROR_ROOT = Path(f"{gettempdir()}/pypi")
 MIRROR_BASE = MIRROR_ROOT / "web"
 TGZ_SHA256 = "bc9430dae93f8bc53728773545cbb646a6b5327f98de31bdd6e1a2b2c6e805a9"
@@ -28,6 +29,7 @@ TOX_EXE = Path(which("tox") or "tox")
 
 
 def do_ci_verify():
+    black_index = MIRROR_BASE / "simple/b/black/index.html"
     peerme_index = MIRROR_BASE / "simple/p/peerme/index.html"
     peerme_json = MIRROR_BASE / "json/peerme"
     peerme_tgz = (
@@ -38,21 +40,26 @@ def do_ci_verify():
     )
 
     if not peerme_index.exists():
-        print(f"No peerme simple API index exists @ {peerme_index}")
+        print(f"{EOP} No peerme simple API index exists @ {peerme_index}")
         return 69
 
     if not peerme_json.exists():
-        print(f"No peerme JSON API file exists @ {peerme_json}")
+        print(f"{EOP} No peerme JSON API file exists @ {peerme_json}")
         return 70
 
     if not peerme_tgz.exists():
-        print(f"No peerme tgz file exists @ {peerme_tgz}")
+        print(f"{EOP} No peerme tgz file exists @ {peerme_tgz}")
         return 71
 
     peerme_tgz_sha256 = hash(str(peerme_tgz))
     if peerme_tgz_sha256 != TGZ_SHA256:
-        print(f"Bad peerme 1.0.0 sha256: {peerme_tgz_sha256} != {TGZ_SHA256}")
+        print(f"{EOP} Bad peerme 1.0.0 sha256: {peerme_tgz_sha256} != {TGZ_SHA256}")
         return 72
+
+    with black_index.open("r") as bifp:
+        if "a href" not in bifp.read():
+            print(f"{EOP} {black_index} has no hyperlinks")
+            return 73
 
     rmtree(MIRROR_ROOT)
 


### PR DESCRIPTION
- Turning on all plugins by default is misleading and causes unexpected issues
- `black` project has all it's versions as beta, so we were filtering them by default and it clobbered my 3 production mirrors Simple API for `black`
- We now have all plugins off unless explicitly configuring all or the plugins name

Fixes #140

Testing:
- Fix all unit tests
- Edit Integration test to include black
- Manually run Integration with all plugins enabled - See CI fail
- Manually run with ONLY whitelist_project enabled and see it work as expected