### PR TITLE
Fixes for https://github.com/pypa/bandersnatch/issues/196

### DIFF
--- a/src/bandersnatch/package.py
+++ b/src/bandersnatch/package.py
@@ -219,7 +219,7 @@ class Package:
                 del self.releases[version]
             else:
                 self.releases[version] = new_files
-        logger.debug(f"{self.name}:  filename removed: {removed}")
+        logger.debug(f"{self.name}: filename removed: {removed}")
 
     # TODO: async def once we go full asyncio - Have concurrency at the
     # release file level

--- a/src/bandersnatch/tests/plugins/test_latest_release.py
+++ b/src/bandersnatch/tests/plugins/test_latest_release.py
@@ -85,9 +85,9 @@ keep = 2
             "2.0.0": {},
         }
 
-        pkg._filter_latest()
+        pkg._filter_latest("1.0.0")
 
-        assert pkg.releases == {"1.1.3": {}, "2.0.0": {}}
+        assert pkg.releases == {"1.0.0": {}, "2.0.0": {}}
 
 
 class TestLatestReleaseFilter2(BasePluginTestCase):
@@ -129,7 +129,7 @@ plugins =
             "2.0.0": {},
         }
 
-        pkg._filter_latest()
+        pkg._filter_latest("2.0.0")
 
         assert pkg.releases == {
             "1.0.0": {},

--- a/src/bandersnatch_filter_plugins/filename_name.py
+++ b/src/bandersnatch_filter_plugins/filename_name.py
@@ -24,7 +24,6 @@ class ExcludePlatformFilter(FilterFilenamePlugin):
         try:
             tags = self.configuration["blacklist"]["platforms"].split("\n")
         except KeyError:
-            logger.info(f"Plugin {self.name}: missing platforms= setting")
             return
 
         for platform in tags:

--- a/src/bandersnatch_filter_plugins/filename_name.py
+++ b/src/bandersnatch_filter_plugins/filename_name.py
@@ -22,7 +22,7 @@ class ExcludePlatformFilter(FilterFilenamePlugin):
         """
 
         try:
-            tags = self.configuration["blacklist"]["platforms"].split("\n")
+            tags = self.configuration["blacklist"]["platforms"].split()
         except KeyError:
             return
 


### PR DESCRIPTION
Sorry one PR... read your message too late

* `verify.py` applies filters like Package to prevent downloading unwanted files
* latest releases filter always keeps the official version
