### PR TITLE
Add a Maintainers guide + Mission Statement to README.md

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,52 @@
+# Maintaining Bandersnatch
+
+This document sets out the roles, processes and responsibilities `bandersnatch`
+maintainers hold and can conduct.
+
+## Summary of being a Maintainer of `bandersnatch`
+
+- **Issue Triage**
+  - Asses if the Issue is accurate + reproducible
+  - If feature, asses if this fits the *bandersnatch mission*
+- **PR Merging**
+  - Access Pull Requests for suitability and adherence to the *bandersnatch mission*
+- If is preferred that big changes be pulling in from *branches* via *Pull Requests*
+  - Peer reviewed by another maintainer
+- **Releases**
+- You will have **"the commit bit"** access
+
+### Links to key mentioned files
+
+- Change Log: [CHANGES.md](https://github.com/pypa/bandersnatch/blob/master/CHANGES.md)
+- Mission Statement: Can be found in bandersnatch's [README.md](https://github.com/pypa/bandersnatch/blob/master/README.md)
+- Readme File: [README.md](https://github.com/pypa/bandersnatch/blob/master/README.md)
+- Semantic Versioning: [PEP 440 Semantic](https://www.python.org/dev/peps/pep-0440/#semantic-versioning)
+
+## Processes
+
+### Evaluating Issues and Pull Requests
+
+Please always think of the mission of bandersnatch. We should just mirror in a
+compatible way a PEP381 mirror. Simple is always better than complex and all *bug*
+issues need to be reproducable for our developers.
+
+#### pyup.io
+- Remember it's not perfect
+  - It does not take into account modules pinned dependencies
+  - e.g. If requests wants *urllib3<1.25* *pyup.io* can still try and update it
+- Until we have **CI** that effectively runs `pip freeze` from time to time we
+  should recheck our minimal deps that we pin in `requirements.txt`
+
+### Releasing to PyPI
+Every maintainer can release to PyPI. A maintainer should have agreement of
+two or more Maintainers that it is a suitable time for a release.
+
+#### Release Process
+
+- Update `src/bandersnatch/__init__.py` version
+- Update the Change Log with difference from the last release
+- Push / Merge to Master
+- Create a GitHub Release
+  - Tag with the semantic version number
+- Build a `sdist` + `wheel`
+- Use `twine` to upload to PyPI

--- a/README.md
+++ b/README.md
@@ -10,6 +10,13 @@
 This is a PyPI mirror client according to `PEP 381`
 http://www.python.org/dev/peps/pep-0381/.
 
+
+**bandersnatch maintainers** are looking for more **help**! Please refer to our
+[MAINTAINER](https://github.com/pypa/bandersnatch/blob/master/MAINTAINERS.md) documentation to see the roles and responsibilities. We would also
+ask you read our **Mission Statement** to ensure it aligns with your thoughts for
+this project.
+- If interested contact @cooperlees
+
 ## Installation
 
 The following instructions will place the bandersnatch executable in a
@@ -125,10 +132,20 @@ other purposes.
 An example of an unsupported API is PyPI's XML-RPC interface, which is used
 when running `pip search`.
 
+### Bandersnatch Mission
+The bandersnatch project strives to:
+- Mirror all static objects of the Python Package Index (https://pypi.org/)
+- bandersnatch's main goal is to support the main global index to local syncing **only**
+- This will allow organizations to have lower latency access to PyPI and
+  save bandwidth on their WAN connections and more importantly the PyPI CDN
+- Custom features and requests may be accepted if they can be of a *plugin* form
+  - e.g. refer to the `blacklist` and `whitelist` plugins
+
 ### Contact
 
 If you have questions or comments, please submit a bug report to
 https://github.com/pypa/bandersnatch/issues/new
+- IRC: #bandersnatch on *Freenode*
 
 ### Code of Conduct
 


### PR DESCRIPTION
- Advertise at the top of the README.md that we're looking for new maintainers
- Add detail about what being a maintainer is

This is action post the Maintainer's summit. We discussed that this would be a good move to try and help attract new maintainers and explain what it is to be one.

cc: @brainwane @jreese - Need to get this in front of other people @ the Summit somehow.

Fixes #213