### PR TITLE
Add version specifier for urllib3 until requests get to support 1.25

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,6 +14,6 @@ requests==2.21.0
 setuptools==41.0.1
 six==1.12.0
 typing-extensions==3.7.2
-urllib3==1.24.3
+urllib3==1.24.3  # pyup: >=1.21.1,<1.25
 xmlrpc2==0.3.1
 yarl==1.3.0


### PR DESCRIPTION
- Stop getting PRs for now from PyUP.