### PR TITLE
Version plugin api

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -11,6 +11,9 @@ long_description_content_type = text/markdown
 license = Academic Free License, version 3
 license_file = LICENSE
 name = bandersnatch
+project_urls =
+    Source Code = https://github.com/pypa/bandersnatch
+    Change Log = https://github.com/pypa/bandersnatch/CHANGES.md
 url = https://github.com/pypa/bandersnatch/
 version = 3.4.0
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,89 @@
+[metadata]
+author = Christian Theune
+author_email = ct@flyingcircus.io
+classifiers =
+    Programming Language :: Python :: 3 :: Only
+    Programming Language :: Python :: 3.6
+    Programming Language :: Python :: 3.7
+description = Mirroring tool that implements the client (mirror) side of PEP 381
+long_description = file:README.md
+long_description_content_type = text/markdown
+license = Academic Free License, version 3
+license_file = LICENSE
+name = bandersnatch
+url = https://github.com/pypa/bandersnatch/
+version = 3.4.0
+
+[options]
+include_package_data = True
+install_requires =
+    aiohttp
+    filelock
+    packaging
+    requests
+    setuptools>40.0.0
+    xmlrpc2
+package_dir =
+    =src
+packages = find:
+python_requires = >=3.6
+
+[options.packages.find]
+where=src
+
+[options.entry_points]
+# This entrypoint group must match the value of bandersnatch.filter.PROJECT_PLUGIN_RESOURCE_GROUP
+bandersnatch_filter_plugins.v2.project =
+    blacklist_project = bandersnatch_filter_plugins.blacklist_name:BlacklistProject
+    whitelist_project = bandersnatch_filter_plugins.whitelist_name:WhitelistProject
+    regex_project = bandersnatch_filter_plugins.regex_name:RegexProjectFilter
+
+# This entrypoint group must match the value of bandersnatch.filter.RELEASE_PLUGIN_RESOURCE_GROUP
+bandersnatch_filter_plugins.v2.release =
+    blacklist_release = bandersnatch_filter_plugins.blacklist_name:BlacklistRelease
+    prerelease_release = bandersnatch_filter_plugins.prerelease_name:PreReleaseFilter
+    regex_release = bandersnatch_filter_plugins.regex_name:RegexReleaseFilter
+    latest_release = bandersnatch_filter_plugins.latest_name:LatestReleaseFilter
+    exclude_platform = bandersnatch_filter_plugins.filename_name:ExcludePlatformFilter
+
+console_scripts =
+    bandersnatch = bandersnatch.main:main
+
+zc.buildout =
+    requirements = bandersnatch.buildout:Requirements
+
+zest.releaser.prereleaser.after =
+    update_requirements = bandersnatch.release:update_requirements
+
+zest.releaser.releaser.after =
+    update_stable_tag = bandersnatch.release:update_stable_tag
+
+zest.releaser.postreleaser.after =
+    update_requirements = bandersnatch.release:update_requirements
+
+[options.extras_require]
+safety_db =
+    bandersnatch_safety_db
+
+test =
+    coverage
+    freezegun
+    pytest
+    pytest-timeout
+    pytest-cache
+
+doc_build =
+    docutils
+    sphinx
+    sphinx_bootstrap_theme
+    guzzle_sphinx_theme
+    sphinx_rtd_theme
+    recommonmark
+    # git+https://github.com/pypa/pypa-docs-theme.git#egg=pypa-docs-theme
+    # git+https://github.com/python/python-docs-theme.git#egg=python-docs-theme
+
+[pycodestyle]
+count = False
+# ignore = E226,E302,E41
+max-line-length = 160
+statistics = True

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,13 +32,13 @@ python_requires = >=3.6
 where=src
 
 [options.entry_points]
-# This entrypoint group must match the value of bandersnatch.filter.PROJECT_PLUGIN_RESOURCE_GROUP
+# This entrypoint group must match the value of bandersnatch.filter.PROJECT_PLUGIN_RESOURCE
 bandersnatch_filter_plugins.v2.project =
     blacklist_project = bandersnatch_filter_plugins.blacklist_name:BlacklistProject
     whitelist_project = bandersnatch_filter_plugins.whitelist_name:WhitelistProject
     regex_project = bandersnatch_filter_plugins.regex_name:RegexProjectFilter
 
-# This entrypoint group must match the value of bandersnatch.filter.RELEASE_PLUGIN_RESOURCE_GROUP
+# This entrypoint group must match the value of bandersnatch.filter.RELEASE_PLUGIN_RESOURCE
 bandersnatch_filter_plugins.v2.release =
     blacklist_release = bandersnatch_filter_plugins.blacklist_name:BlacklistRelease
     prerelease_release = bandersnatch_filter_plugins.prerelease_name:PreReleaseFilter

--- a/setup.cfg
+++ b/setup.cfg
@@ -49,18 +49,6 @@ bandersnatch_filter_plugins.v2.release =
 console_scripts =
     bandersnatch = bandersnatch.main:main
 
-zc.buildout =
-    requirements = bandersnatch.buildout:Requirements
-
-zest.releaser.prereleaser.after =
-    update_requirements = bandersnatch.release:update_requirements
-
-zest.releaser.releaser.after =
-    update_stable_tag = bandersnatch.release:update_stable_tag
-
-zest.releaser.postreleaser.after =
-    update_requirements = bandersnatch.release:update_requirements
-
 [options.extras_require]
 safety_db =
     bandersnatch_safety_db

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
 from setuptools import setup
 
-
 setup()

--- a/setup.py
+++ b/setup.py
@@ -1,56 +1,6 @@
 #!/usr/bin/env python3
-
-from sys import version_info
-
-from setuptools import find_packages, setup
-
-from src.bandersnatch import __version__
-
-assert version_info >= (3, 6, 1), "bandersnatch requires Python >=3.6.1"
+#!/usr/bin/env python3
+from setuptools import setup
 
 
-INSTALL_DEPS = ("aiohttp", "filelock", "packaging", "requests", "setuptools", "xmlrpc2")
-
-
-setup(
-    name="bandersnatch",
-    version=__version__,
-    description=("Mirroring tool that implements the client (mirror) side of PEP 381"),
-    long_description="\n\n".join([open("README.md").read(), open("CHANGES.md").read()]),
-    long_description_content_type="text/markdown",
-    author="Christian Theune",
-    author_email="ct@flyingcircus.io",
-    license="Academic Free License, version 3",
-    url="https://github.com/pypa/bandersnatch/",
-    packages=find_packages("src"),
-    package_dir={"": "src"},
-    include_package_data=True,
-    install_requires=INSTALL_DEPS,
-    entry_points="""
-            [bandersnatch_filter_plugins.project]
-                blacklist_project = bandersnatch_filter_plugins.blacklist_name:BlacklistProject
-                whitelist_project = bandersnatch_filter_plugins.whitelist_name:WhitelistProject
-                regex_project = bandersnatch_filter_plugins.regex_name:RegexProjectFilter
-            [bandersnatch_filter_plugins.release]
-                blacklist_release = bandersnatch_filter_plugins.blacklist_name:BlacklistRelease
-                prerelease_release = bandersnatch_filter_plugins.prerelease_name:PreReleaseFilter
-                regex_release = bandersnatch_filter_plugins.regex_name:RegexReleaseFilter
-                latest_release = bandersnatch_filter_plugins.latest_name:LatestReleaseFilter
-                exclude_platform = bandersnatch_filter_plugins.filename_name:ExcludePlatformFilter
-            [console_scripts]
-                bandersnatch = bandersnatch.main:main
-            [zc.buildout]
-                requirements = bandersnatch.buildout:Requirements
-            [zest.releaser.prereleaser.after]
-                update_requirements = bandersnatch.release:update_requirements
-            [zest.releaser.releaser.after]
-                update_stable_tag = bandersnatch.release:update_stable_tag
-            [zest.releaser.postreleaser.after]
-                update_requirements = bandersnatch.release:update_requirements
-      """,  # noqa
-    classifiers=[
-        "Programming Language :: Python :: 3 :: Only",
-        "Programming Language :: Python :: 3.6",
-        "Programming Language :: Python :: 3.7",
-    ],
-)
+setup()

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-#!/usr/bin/env python3
 from setuptools import setup
 
 

--- a/src/bandersnatch/filter.py
+++ b/src/bandersnatch/filter.py
@@ -8,6 +8,12 @@ import pkg_resources
 
 from .configuration import BandersnatchConfig
 
+# The API_REVISION is incremented if the plugin class is modified in a backwards incompatible way.
+# In order to prevent loading older broken plugins that may be installed and will break due to
+# changes to the methods of the classes.
+PLUGiN_API_REVISION = 2
+PROJECT_PLUGIN_RESOURCE_GROUP = f"bandersnatch_filter_plugins.v{PLUGiN_API_REVISION}.project"
+RELEASE_PLUGIN_RESOURCE_GROUP = f"bandersnatch_filter_plugins.v{PLUGiN_API_REVISION}.release"
 loaded_filter_plugins: Dict[str, List["Filter"]] = defaultdict(list)
 
 
@@ -36,6 +42,11 @@ class Filter:
         """
         Code to initialize the plugin
         """
+        # The intialize_plugin method is run once to initialize the plugin.  This should
+        # contain all code to set up the plugin.
+        # This method is not run in the fast path and should be used to do things like indexing
+        # filter databases, etc that will speed the operation of the filter and check_match
+        # methods that are called in the fast path.
         pass
 
 
@@ -135,7 +146,7 @@ def filter_project_plugins() -> Iterable[Filter]:
     list of bandersnatch.filter.Filter:
         List of objects derived from the bandersnatch.filter.Filter class
     """
-    return load_filter_plugins("bandersnatch_filter_plugins.project")
+    return load_filter_plugins(PROJECT_PLUGIN_RESOURCE_GROUP)
 
 
 def filter_release_plugins() -> Iterable[Filter]:
@@ -147,4 +158,4 @@ def filter_release_plugins() -> Iterable[Filter]:
     list of bandersnatch.filter.Filter:
         List of objects derived from the bandersnatch.filter.Filter class
     """
-    return load_filter_plugins("bandersnatch_filter_plugins.release")
+    return load_filter_plugins(RELEASE_PLUGIN_RESOURCE_GROUP)

--- a/src/bandersnatch/filter.py
+++ b/src/bandersnatch/filter.py
@@ -13,8 +13,8 @@ from .configuration import BandersnatchConfig
 # broken plugins that may be installed and will break due to changes to
 # the methods of the classes.
 PLUGIN_API_REVISION = 2
-PROJECT_PLUGIN_RESOURCE_GROUP = f"bandersnatch_filter_plugins.v{PLUGIN_API_REVISION}.project"
-RELEASE_PLUGIN_RESOURCE_GROUP = f"bandersnatch_filter_plugins.v{PLUGIN_API_REVISION}.release"
+PROJECT_PLUGIN_RESOURCE = f"bandersnatch_filter_plugins.v{PLUGIN_API_REVISION}.project"
+RELEASE_PLUGIN_RESOURCE = f"bandersnatch_filter_plugins.v{PLUGIN_API_REVISION}.release"
 loaded_filter_plugins: Dict[str, List["Filter"]] = defaultdict(list)
 
 
@@ -147,7 +147,7 @@ def filter_project_plugins() -> Iterable[Filter]:
     list of bandersnatch.filter.Filter:
         List of objects derived from the bandersnatch.filter.Filter class
     """
-    return load_filter_plugins(PROJECT_PLUGIN_RESOURCE_GROUP)
+    return load_filter_plugins(PROJECT_PLUGIN_RESOURCE)
 
 
 def filter_release_plugins() -> Iterable[Filter]:
@@ -159,4 +159,4 @@ def filter_release_plugins() -> Iterable[Filter]:
     list of bandersnatch.filter.Filter:
         List of objects derived from the bandersnatch.filter.Filter class
     """
-    return load_filter_plugins(RELEASE_PLUGIN_RESOURCE_GROUP)
+    return load_filter_plugins(RELEASE_PLUGIN_RESOURCE)

--- a/src/bandersnatch/filter.py
+++ b/src/bandersnatch/filter.py
@@ -47,9 +47,9 @@ class Filter:
         """
         # The intialize_plugin method is run once to initialize the plugin.  This should
         # contain all code to set up the plugin.
-        # This method is not run in the fast path and should be used to do things like indexing
-        # filter databases, etc that will speed the operation of the filter and check_match
-        # methods that are called in the fast path.
+        # This method is not run in the fast path and should be used to do things like
+        # indexing filter databases, etc that will speed the operation of the filter
+        # and check_match methods that are called in the fast path.
         pass
 
 

--- a/src/bandersnatch/filter.py
+++ b/src/bandersnatch/filter.py
@@ -13,10 +13,8 @@ from .configuration import BandersnatchConfig
 # broken plugins that may be installed and will break due to changes to
 # the methods of the classes.
 PLUGIN_API_REVISION = 2
-PROJECT_PLUGIN_RESOURCE_GROUP = \
-    f"bandersnatch_filter_plugins.v{PLUGIN_API_REVISION}.project"
-RELEASE_PLUGIN_RESOURCE_GROUP = \
-    f"bandersnatch_filter_plugins.v{PLUGIN_API_REVISION}.release"
+PROJECT_PLUGIN_RESOURCE_GROUP = f"bandersnatch_filter_plugins.v{PLUGIN_API_REVISION}.project"
+RELEASE_PLUGIN_RESOURCE_GROUP = f"bandersnatch_filter_plugins.v{PLUGIN_API_REVISION}.release"
 loaded_filter_plugins: Dict[str, List["Filter"]] = defaultdict(list)
 
 

--- a/src/bandersnatch/filter.py
+++ b/src/bandersnatch/filter.py
@@ -8,12 +8,15 @@ import pkg_resources
 
 from .configuration import BandersnatchConfig
 
-# The API_REVISION is incremented if the plugin class is modified in a backwards incompatible way.
-# In order to prevent loading older broken plugins that may be installed and will break due to
-# changes to the methods of the classes.
-PLUGiN_API_REVISION = 2
-PROJECT_PLUGIN_RESOURCE_GROUP = f"bandersnatch_filter_plugins.v{PLUGiN_API_REVISION}.project"
-RELEASE_PLUGIN_RESOURCE_GROUP = f"bandersnatch_filter_plugins.v{PLUGiN_API_REVISION}.release"
+# The API_REVISION is incremented if the plugin class is modified in a 
+# backwards incompatible way.  In order to prevent loading older
+# broken plugins that may be installed and will break due to changes to
+# the methods of the classes.
+PLUGIN_API_REVISION = 2
+PROJECT_PLUGIN_RESOURCE_GROUP = \
+    f"bandersnatch_filter_plugins.v{PLUGIN_API_REVISION}.project"
+RELEASE_PLUGIN_RESOURCE_GROUP = \
+    f"bandersnatch_filter_plugins.v{PLUGIN_API_REVISION}.release"
 loaded_filter_plugins: Dict[str, List["Filter"]] = defaultdict(list)
 
 

--- a/src/bandersnatch/filter.py
+++ b/src/bandersnatch/filter.py
@@ -8,7 +8,7 @@ import pkg_resources
 
 from .configuration import BandersnatchConfig
 
-# The API_REVISION is incremented if the plugin class is modified in a 
+# The API_REVISION is incremented if the plugin class is modified in a
 # backwards incompatible way.  In order to prevent loading older
 # broken plugins that may be installed and will break due to changes to
 # the methods of the classes.

--- a/src/bandersnatch/main.py
+++ b/src/bandersnatch/main.py
@@ -17,7 +17,6 @@ import bandersnatch.verify
 from .configuration import BandersnatchConfig
 from .filter import filter_project_plugins, filter_release_plugins
 
-
 logger = logging.getLogger(__name__)  # pylint: disable=C0103
 
 

--- a/src/bandersnatch/main.py
+++ b/src/bandersnatch/main.py
@@ -24,7 +24,7 @@ def mirror(config):
     # Load the filter plugins so the loading doesn't happen in the fast path
     filter_project_plugins()
     filter_release_plugins()
-    
+
     # Always reference those classes here with the fully qualified name to
     # allow them being patched by mock libraries!
     master = bandersnatch.master.Master(

--- a/src/bandersnatch/main.py
+++ b/src/bandersnatch/main.py
@@ -15,11 +15,17 @@ import bandersnatch.utils
 import bandersnatch.verify
 
 from .configuration import BandersnatchConfig
+from .filter import filter_project_plugins, filter_release_plugins
 
-logger = logging.getLogger(__name__)
+
+logger = logging.getLogger(__name__)  # pylint: disable=C0103
 
 
 def mirror(config):
+    # Load the filter plugins so the loading doesn't happen in the fast path
+    filter_project_plugins()
+    filter_release_plugins()
+    
     # Always reference those classes here with the fully qualified name to
     # allow them being patched by mock libraries!
     master = bandersnatch.master.Master(

--- a/tox.ini
+++ b/tox.ini
@@ -33,7 +33,7 @@ commands=
     pre-commit run --all-files --show-diff-on-failure
 
 [flake8]
-max_line_length = 88
+max_line_length = 160
 
 [isort]
 include_trailing_comma = True

--- a/tox.ini
+++ b/tox.ini
@@ -33,7 +33,7 @@ commands=
     pre-commit run --all-files --show-diff-on-failure
 
 [flake8]
-max_line_length = 160
+max_line_length = 88
 
 [isort]
 include_trailing_comma = True


### PR DESCRIPTION
This is to address an issue where the plugin class filter method had different arguments in different versions of bandersnatch.   This creates an issue where bandersnatch could load plugins from a different package and which had a plugin class with a filter method with arguments different than what bandersnatch was passing.  Which would generate an exception.

This change adds a version value to the pkg_resource group for the plugins.

This allows the value to be changed when a breaking change is made to the plugin base classes.  In order to insure the plugin classes match the expected classes used by the code calling the plugins.

This change sets the version of the plugin interface on master to v2 and updates the values in the setup.cfg file to match.  As a result, bandersnatch now loads the included bandersnatch_filter_plugins from the v2 pkg_resources group.

So the included plugins continue to work correctly and external plugin packages can provide the old plugins that are compatible with the current pypi 3.3.1 release of bandersnatch using the pre versioned resource group names as well as providing and other plugin classes registered with the v2 resource group that use the newer filter method.

Since this required changes to the setup.py I migrated to using a setup.cfg for the settings since it is parseable.

The [bandersnatch_safety_db](https://github.com/dwighthubbard/bandersnatch_safety_db) package is now configured this way as an example of the changes.