### PR TITLE
Fix example of platform filtering in docs

### DIFF
--- a/docs/filtering_configuration.md
+++ b/docs/filtering_configuration.md
@@ -112,6 +112,7 @@ This filter allows advanced users not interesting in Windows/macOS/Linux specifi
 [plugins]
 enabled =
     exclude_platform
+[blacklist]
 platforms =
     windows
 ```


### PR DESCRIPTION
The sample configuration snippet related to platform filtering was missing the blacklist section.