### PR TITLE
Match prerelease versions with multiple digit suffixes

### DIFF
--- a/src/bandersnatch_filter_plugins/prerelease_name.py
+++ b/src/bandersnatch_filter_plugins/prerelease_name.py
@@ -12,7 +12,7 @@ class PreReleaseFilter(FilterReleasePlugin):
     """
 
     name = "prerelease_release"
-    PRERELEASE_PATTERNS = (r".+rc\d$", r".+a(lpha)?\d$", r".+b(eta)?\d$", r".+dev\d$")
+    PRERELEASE_PATTERNS = (r".+rc\d+$", r".+a(lpha)?\d+$", r".+b(eta)?\d+$", r".+dev\d+$")
     patterns = None
 
     def initialize_plugin(self):

--- a/src/bandersnatch_filter_plugins/prerelease_name.py
+++ b/src/bandersnatch_filter_plugins/prerelease_name.py
@@ -12,7 +12,12 @@ class PreReleaseFilter(FilterReleasePlugin):
     """
 
     name = "prerelease_release"
-    PRERELEASE_PATTERNS = (r".+rc\d+$", r".+a(lpha)?\d+$", r".+b(eta)?\d+$", r".+dev\d+$")
+    PRERELEASE_PATTERNS = (
+        r".+rc\d+$",
+        r".+a(lpha)?\d+$",
+        r".+b(eta)?\d+$",
+        r".+dev\d+$"
+    )
     patterns = None
 
     def initialize_plugin(self):


### PR DESCRIPTION
Extend PRERELEASE_PATTERNS to match multiple digits after the prerelease tag.
- Some packages have versions beyond 9 e.g. https://pypi.org/project/scikit-vis/0.0.2.dev12/  
- Some packages use a date scheme as the suffix e.g. https://pypi.org/project/lalsuite/6.57.1.dev20190613/