### PR TITLE
pyup.yml - Apply all yamllint suggestions

### DIFF
--- a/.pyup.yml
+++ b/.pyup.yml
@@ -1,17 +1,15 @@
+---
 branch: master
 
 requirements:
   - requirements.txt:
     update: all
-    pin: True
+    pin: true
   - requirements_docs.txt:
     update: all
-    pin: True
+    pin: true
   - requirements_test.txt:
     update: all
-    pin: True
+    pin: true
   - setup.cfg:
-    update: False
-
-assignees:
-  - cooper
+    update: false


### PR DESCRIPTION
- Remove the following
```
cooper-mbp1:bandersnatch cooper$ /tmp/bb/bin/yamllint .pyup.yml
.pyup.yml
  1:1       warning  missing document start "---"  (document-start)
  6:10      warning  truthy value should be one of [false, true]  (truthy)
  9:10      warning  truthy value should be one of [false, true]  (truthy)
  12:10     warning  truthy value should be one of [false, true]  (truthy)
  14:13     warning  truthy value should be one of [false, true]  (truthy)
```
- Remove assignees

More attempts to find a fix for https://github.com/pyupio/pyup/issues/350