### PR TITLE
Move to `docutils==0.15.1.post1`

### DIFF
--- a/requirements_docs.txt
+++ b/requirements_docs.txt
@@ -1,4 +1,4 @@
-docutils==0.15.1
+docutils==0.15.1.post1
 pyparsing==2.4.1.1
 python-dateutil==2.8.0
 packaging==19.0


### PR DESCRIPTION
- 0.15.1 Py3 version/wheel + sdist seem gone ...

Addresses #293 