### PR TITLE
Add a differential file list capability

### DIFF
--- a/docs/mirror_configuration.md
+++ b/docs/mirror_configuration.md
@@ -134,3 +134,28 @@ Example:
 [mirror]
 root_uri = https://example.com
 ```
+
+
+### diff-file
+
+The diff file is a string containing the filename to log the files that were downloaded during the mirror.
+This file can then be used to synchronize external disks or send the files through some other mechanism to offline systems.
+
+Example:
+```ini
+[mirror]
+diff-file = /srv/pypi/mirrored-files
+```
+
+
+
+### diff-append-epoch
+
+The diff append epoch is a boolean (true/false) setting that indicates if the diff-file should be appended with the current epoch time. 
+This can be used to track diffs over time so the diff file doesn't get cobbered each run.  It is only used when diff-file is used.
+
+Example:
+```ini
+[mirror]
+diff-append-epoch = true
+```

--- a/docs/mirror_configuration.md
+++ b/docs/mirror_configuration.md
@@ -151,7 +151,7 @@ diff-file = /srv/pypi/mirrored-files
 
 ### diff-append-epoch
 
-The diff append epoch is a boolean (true/false) setting that indicates if the diff-file should be appended with the current epoch time. 
+The diff append epoch is a boolean (true/false) setting that indicates if the diff-file should be appended with the current epoch time.
 This can be used to track diffs over time so the diff file doesn't get cobbered each run.  It is only used when diff-file is used.
 
 Example:

--- a/docs/mirror_configuration.md
+++ b/docs/mirror_configuration.md
@@ -151,7 +151,7 @@ diff-file = /srv/pypi/mirrored-files
 
 ### diff-append-epoch
 
-The diff append epoch is a boolean (true/false) setting that indicates if the diff-file should be appended with the current epoch time.
+The diff append epoch is a boolean (true/false) setting that indicates if the diff-file should be appended with the current epoch time. 
 This can be used to track diffs over time so the diff file doesn't get cobbered each run.  It is only used when diff-file is used.
 
 Example:

--- a/docs/mirror_configuration.md
+++ b/docs/mirror_configuration.md
@@ -140,6 +140,15 @@ root_uri = https://example.com
 
 The diff file is a string containing the filename to log the files that were downloaded during the mirror.
 This file can then be used to synchronize external disks or send the files through some other mechanism to offline systems.
+You can then sync the list of files to an attached drive or ssh destination such as a diode:
+```
+rsync -av --files-from=/srv/pypi/mirrored-files / /mnt/usb/
+```
+
+You can also use this file list as an input to 7zip to create split archives for transfers, allowing you to size the files as you needed:
+```
+7za a -i@"/srv/pypi/mirrored-files" -spf -v100m path_to_new_zip.7z
+```
 
 Example:
 ```ini

--- a/src/bandersnatch/default.conf
+++ b/src/bandersnatch/default.conf
@@ -67,9 +67,9 @@ verifiers = 3
 
 ; Configure a file to write out the list of files downloaded during the mirror.
 ; This is useful for situations when mirroring to offline systems where a process
-; is required to only sync new files to the upstream mirror. 
-; The file be be named as set in the diff-file, and overwritten unless the 
-; diff-append-epoch setting is set to true.  If this is true, the epoch date will 
+; is required to only sync new files to the upstream mirror.
+; The file be be named as set in the diff-file, and overwritten unless the
+; diff-append-epoch setting is set to true.  If this is true, the epoch date will
 ; be appended to the filename (i.e. /path/to/diff-1568129735)
 ; diff-file = /srv/pypi/mirrored-files
-; diff-append-epoch = true 
+; diff-append-epoch = true

--- a/src/bandersnatch/default.conf
+++ b/src/bandersnatch/default.conf
@@ -67,9 +67,9 @@ verifiers = 3
 
 ; Configure a file to write out the list of files downloaded during the mirror.
 ; This is useful for situations when mirroring to offline systems where a process
-; is required to only sync new files to the upstream mirror.
-; The file be be named as set in the diff-file, and overwritten unless the
-; diff-append-epoch setting is set to true.  If this is true, the epoch date will
+; is required to only sync new files to the upstream mirror. 
+; The file be be named as set in the diff-file, and overwritten unless the 
+; diff-append-epoch setting is set to true.  If this is true, the epoch date will 
 ; be appended to the filename (i.e. /path/to/diff-1568129735)
 ; diff-file = /srv/pypi/mirrored-files
-; diff-append-epoch = true
+; diff-append-epoch = true 

--- a/src/bandersnatch/default.conf
+++ b/src/bandersnatch/default.conf
@@ -64,3 +64,12 @@ verifiers = 3
 ; keep_index_versions = 0
 
 ; vim: set ft=cfg:
+
+; Configure a file to write out the list of files downloaded during the mirror.
+; This is useful for situations when mirroring to offline systems where a process
+; is required to only sync new files to the upstream mirror. 
+; The file be be named as set in the diff-file, and overwritten unless the 
+; diff-append-epoch setting is set to true.  If this is true, the epoch date will 
+; be appended to the filename (i.e. /path/to/diff-1568129735)
+; diff-file = /srv/pypi/mirrored-files
+; diff-append-epoch = true 

--- a/src/bandersnatch/main.py
+++ b/src/bandersnatch/main.py
@@ -18,6 +18,7 @@ import bandersnatch.verify
 
 from .configuration import BandersnatchConfig
 from .filter import filter_project_plugins, filter_release_plugins
+from .utils import update_safe
 
 logger = logging.getLogger(__name__)  # pylint: disable=C0103
 
@@ -103,9 +104,11 @@ def mirror(config):
     logger.info("{} packages had changes".format(len(changed_packages)))
     for package_name, changes in changed_packages.items():
         for change in changes:
-            with open(mirror.diff_full_path, 'a') as diff:
-                diff.write("{}{}".format(change, os.linesep))
+            mirror.diff_file_list.append(os.path.join(str(mirror.homedir), change))
         logger.debug(f"{package_name} added: {changes}")
+    with open(mirror.diff_full_path, 'w', encoding="utf-8") as f:
+        for filename in mirror.diff_file_list:
+            f.write("{}{}".format(os.path.abspath(filename), os.linesep))
 
 
 def main():

--- a/src/bandersnatch/main.py
+++ b/src/bandersnatch/main.py
@@ -18,7 +18,6 @@ import bandersnatch.verify
 
 from .configuration import BandersnatchConfig
 from .filter import filter_project_plugins, filter_release_plugins
-from .utils import update_safe
 
 logger = logging.getLogger(__name__)  # pylint: disable=C0103
 

--- a/src/bandersnatch/main.py
+++ b/src/bandersnatch/main.py
@@ -3,9 +3,9 @@ import asyncio
 import configparser
 import logging
 import logging.config
+import os
 import shutil
 import sys
-import os
 import time
 from pathlib import Path
 from tempfile import gettempdir
@@ -107,8 +107,8 @@ def mirror(config):
             mirror.diff_file_list.append(os.path.join(str(mirror.homedir), change))
         logger.debug(f"{package_name} added: {changes}")
     if diff_full_path:
-        logger.info("Writing diff file to {}".format(mirror.diff_full_path))
-        with open(mirror.diff_full_path, 'w', encoding="utf-8") as f:
+        logger.info(f"Writing diff file to {mirror.diff_full_path}")
+        with open(mirror.diff_full_path, "w", encoding="utf-8") as f:
             for filename in mirror.diff_file_list:
                 f.write("{}{}".format(os.path.abspath(filename), os.linesep))
 

--- a/src/bandersnatch/main.py
+++ b/src/bandersnatch/main.py
@@ -3,9 +3,9 @@ import asyncio
 import configparser
 import logging
 import logging.config
-import os
 import shutil
 import sys
+import os
 import time
 from pathlib import Path
 from tempfile import gettempdir
@@ -107,8 +107,8 @@ def mirror(config):
             mirror.diff_file_list.append(os.path.join(str(mirror.homedir), change))
         logger.debug(f"{package_name} added: {changes}")
     if diff_full_path:
-        logger.info(f"Writing diff file to {mirror.diff_full_path}")
-        with open(mirror.diff_full_path, "w", encoding="utf-8") as f:
+        logger.info("Writing diff file to {}".format(mirror.diff_full_path))
+        with open(mirror.diff_full_path, 'w', encoding="utf-8") as f:
             for filename in mirror.diff_file_list:
                 f.write("{}{}".format(os.path.abspath(filename), os.linesep))
 

--- a/src/bandersnatch/main.py
+++ b/src/bandersnatch/main.py
@@ -49,6 +49,15 @@ def mirror(config):
         root_uri = None
 
     try:
+        diff_file = config.get("mirror", "diff-file")
+    except configparser.NoOptionError:
+        diff_file = None
+
+    try:
+        diff_append_epoch = config.get("mirror", "diff-append-epoch")
+    except configparser.NoOptionError:
+        diff_append_epoch = None
+    try:
         digest_name = config.get("mirror", "digest_name")
     except configparser.NoOptionError:
         digest_name = "sha256"
@@ -69,6 +78,8 @@ def mirror(config):
         root_uri=root_uri,
         digest_name=digest_name,
         keep_index_versions=config.getint("mirror", "keep_index_versions", fallback=0),
+        diff_file=diff_file,
+        diff_append_epoch=diff_append_epoch,
     )
 
     changed_packages = mirror.synchronize()

--- a/src/bandersnatch/main.py
+++ b/src/bandersnatch/main.py
@@ -106,9 +106,11 @@ def mirror(config):
         for change in changes:
             mirror.diff_file_list.append(os.path.join(str(mirror.homedir), change))
         logger.debug(f"{package_name} added: {changes}")
-    with open(mirror.diff_full_path, 'w', encoding="utf-8") as f:
-        for filename in mirror.diff_file_list:
-            f.write("{}{}".format(os.path.abspath(filename), os.linesep))
+    if diff_full_path:
+        logger.info("Writing diff file to {}".format(mirror.diff_full_path))
+        with open(mirror.diff_full_path, 'w', encoding="utf-8") as f:
+            for filename in mirror.diff_file_list:
+                f.write("{}{}".format(os.path.abspath(filename), os.linesep))
 
 
 def main():

--- a/src/bandersnatch/mirror.py
+++ b/src/bandersnatch/mirror.py
@@ -59,6 +59,10 @@ class Mirror:
     # https://files.pythonhosted.org
     root_uri = None
 
+    diff_file = None
+    diff_append_epoch = False
+    diff_full_path = None
+
     def __init__(
         self,
         homedir,
@@ -70,6 +74,9 @@ class Mirror:
         digest_name=None,
         root_uri=None,
         keep_index_versions=0,
+        diff_file=None,
+        diff_append_epoch=False,
+        diff_full_path=None,
         flock_timeout=1,
     ):
         logger.info(f"{USER_AGENT}")
@@ -79,6 +86,9 @@ class Mirror:
         self.json_save = json_save
         self.hash_index = hash_index
         self.root_uri = root_uri
+        self.diff_file = diff_file
+        self.diff_append_epoch = diff_append_epoch
+        self.diff_full_path = diff_full_path
         self.keep_index_versions = keep_index_versions
         self.digest_name = digest_name if digest_name else "sha256"
         self.workers = workers

--- a/src/bandersnatch/mirror.py
+++ b/src/bandersnatch/mirror.py
@@ -78,7 +78,7 @@ class Mirror:
         diff_append_epoch=False,
         diff_full_path=None,
         flock_timeout=1,
-        diff_file_list=[],
+        diff_file_list=[]
     ):
         logger.info(f"{USER_AGENT}")
         self.homedir = Path(homedir)

--- a/src/bandersnatch/mirror.py
+++ b/src/bandersnatch/mirror.py
@@ -78,7 +78,7 @@ class Mirror:
         diff_append_epoch=False,
         diff_full_path=None,
         flock_timeout=1,
-        diff_file_list=[],
+        diff_file_list=None,
     ):
         logger.info(f"{USER_AGENT}")
         self.homedir = Path(homedir)
@@ -93,7 +93,7 @@ class Mirror:
         self.keep_index_versions = keep_index_versions
         self.digest_name = digest_name if digest_name else "sha256"
         self.workers = workers
-        self.diff_file_list = []
+        self.diff_file_list = diff_file_list or []
         if self.workers > 10:
             raise ValueError("Downloading with more than 10 workers is not allowed.")
         self._bootstrap(flock_timeout)

--- a/src/bandersnatch/mirror.py
+++ b/src/bandersnatch/mirror.py
@@ -78,6 +78,7 @@ class Mirror:
         diff_append_epoch=False,
         diff_full_path=None,
         flock_timeout=1,
+        diff_file_list=[]
     ):
         logger.info(f"{USER_AGENT}")
         self.homedir = Path(homedir)
@@ -92,6 +93,7 @@ class Mirror:
         self.keep_index_versions = keep_index_versions
         self.digest_name = digest_name if digest_name else "sha256"
         self.workers = workers
+        self.diff_file_list = []
         if self.workers > 10:
             raise ValueError("Downloading with more than 10 workers is not allowed.")
         self._bootstrap(flock_timeout)
@@ -307,6 +309,7 @@ class Mirror:
                     # We're really trusty that this is all encoded in UTF-8. :/
                     f.write(f'    <a href="{pkg}/">{pkg}</a><br/>\n')
             f.write("  </body>\n</html>")
+        self.diff_file_list.append(str(simple_dir / "index.html"))
 
     def wrapup_successful_sync(self):
         if self.errors:

--- a/src/bandersnatch/mirror.py
+++ b/src/bandersnatch/mirror.py
@@ -78,7 +78,7 @@ class Mirror:
         diff_append_epoch=False,
         diff_full_path=None,
         flock_timeout=1,
-        diff_file_list=[]
+        diff_file_list=[],
     ):
         logger.info(f"{USER_AGENT}")
         self.homedir = Path(homedir)

--- a/src/bandersnatch/package.py
+++ b/src/bandersnatch/package.py
@@ -17,6 +17,7 @@ from packaging.utils import canonicalize_name
 from . import utils
 from .filter import filter_release_plugins
 from .master import StalePage
+from .utils import update_safe
 
 # Bool to help us not spam the logs with certain log messages
 display_filter_log = True
@@ -80,6 +81,7 @@ class Package:
         try:
             with utils.rewrite(self.json_file) as jf:
                 dump(package_info, jf, indent=4, sort_keys=True)
+            self.mirror.diff_file_list.append(self.json_file)
         except Exception as e:
             logger.error(
                 "Unable to write json to {}: {}".format(self.json_file, str(e))
@@ -268,6 +270,7 @@ class Package:
             simple_page = self.simple_directory / "index.html"
             with utils.rewrite(simple_page, "w", encoding="utf-8") as f:
                 f.write(simple_page_content)
+            self.mirror.diff_file_list.append(simple_page)
 
             # This exists for compatibility with pip 8.0 to 8.1.1 which did not
             # correctly implement PEP 503 wrt to normalization and so needs a
@@ -282,6 +285,7 @@ class Package:
                 simple_page = self.normalized_legacy_simple_directory / "index.html"
                 with utils.rewrite(simple_page, "w", encoding="utf-8") as f:
                     f.write(simple_page_content)
+                self.mirror.diff_file_list.append(simple_page)
 
         if not self.normalized_simple_directory.exists():
             self.normalized_simple_directory.mkdir(parents=True)
@@ -292,6 +296,7 @@ class Package:
             normalized_simple_page = self.normalized_simple_directory / "index.html"
             with utils.rewrite(normalized_simple_page, "w", encoding="utf-8") as f:
                 f.write(simple_page_content)
+            self.mirror.diff_file_list.append(normalized_simple_page)
 
     def _save_simple_page_version(self, simple_page_content):
         versions_path = self._prepare_versions_path()
@@ -300,6 +305,7 @@ class Package:
         full_version_path = versions_path / version_file_name
         with utils.rewrite(full_version_path, "w", encoding="utf-8") as f:
             f.write(simple_page_content)
+        self.mirror.diff_file_list.append(full_version_path)
 
         symlink_path = self.normalized_legacy_simple_directory / "index.html"
         if symlink_path.exists() or symlink_path.is_symlink():

--- a/src/bandersnatch/package.py
+++ b/src/bandersnatch/package.py
@@ -17,7 +17,6 @@ from packaging.utils import canonicalize_name
 from . import utils
 from .filter import filter_release_plugins
 from .master import StalePage
-from .utils import update_safe
 
 # Bool to help us not spam the logs with certain log messages
 display_filter_log = True

--- a/src/bandersnatch/tests/test_main.py
+++ b/src/bandersnatch/tests/test_main.py
@@ -61,9 +61,9 @@ def test_main_reads_config_values(mirror_mock):
         "json_save": False,
         "digest_name": "sha256",
         "keep_index_versions": 0,
-        "diff_file": None,
-        "diff_full_path": None,
+        "diff_file": "/srv/pypi/mirrored-files",
         "diff_append_epoch": False,
+        "diff_full_path": "/srv/pypi/mirrored-files",
     } == kwargs
     assert mirror_mock().synchronize.called
 

--- a/src/bandersnatch/tests/test_main.py
+++ b/src/bandersnatch/tests/test_main.py
@@ -61,9 +61,9 @@ def test_main_reads_config_values(mirror_mock):
         "json_save": False,
         "digest_name": "sha256",
         "keep_index_versions": 0,
-        "diff_file": "/srv/pypi/mirrored-files",
+        "diff_file": "/tmp/pypi/mirrored-files",
         "diff_append_epoch": False,
-        "diff_full_path": "/srv/pypi/mirrored-files",
+        "diff_full_path": "/tmp/pypi/mirrored-files",
     } == kwargs
     assert mirror_mock().synchronize.called
 

--- a/src/bandersnatch/tests/test_main.py
+++ b/src/bandersnatch/tests/test_main.py
@@ -61,6 +61,9 @@ def test_main_reads_config_values(mirror_mock):
         "json_save": False,
         "digest_name": "sha256",
         "keep_index_versions": 0,
+        "diff_file": None,
+        "diff_full_path": None,
+        "diff_append_epoch": False,
     } == kwargs
     assert mirror_mock().synchronize.called
 

--- a/src/bandersnatch/unittest.conf
+++ b/src/bandersnatch/unittest.conf
@@ -69,7 +69,7 @@ verifiers = 3
 ; The file be be named as set in the diff-file, and overwritten unless the
 ; diff-append-epoch setting is set to true.  If this is true, the epoch date will
 ; be appended to the filename (i.e. /path/to/diff-1568129735)
-diff-file = /srv/pypi/mirrored-files
+diff-file = /tmp/pypi/mirrored-files
 diff-append-epoch = false
 
 ; Enable filtering plugins

--- a/src/bandersnatch/unittest.conf
+++ b/src/bandersnatch/unittest.conf
@@ -63,6 +63,15 @@ verifiers = 3
 ; If unset defaults to 0.
 ; keep_index_versions = 0
 
+; Configure a file to write out the list of files downloaded during the mirror.
+; This is useful for situations when mirroring to offline systems where a process
+; is required to only sync new files to the upstream mirror.
+; The file be be named as set in the diff-file, and overwritten unless the
+; diff-append-epoch setting is set to true.  If this is true, the epoch date will
+; be appended to the filename (i.e. /path/to/diff-1568129735)
+diff-file = /srv/pypi/mirrored-files
+diff-append-epoch = false
+
 ; Enable filtering plugins
 [plugins]
 ; Enable all or specific plugins - e.g. whitelist_project


### PR DESCRIPTION
This PR adds a differential file list capability to bandersnatch.
The capability is useful in cases where a user wants to synchronize pypi to an offline server without having to determine the diffs each time a mirror command is executed.  The diff file can be used to only send diff to a synchronization disk, or to send new files through a diode to an offline or upstream pypi mirror.

