### PR TITLE
[refactor] Move mirror logic out of main.py into mirror.py

### DIFF
--- a/src/bandersnatch/main.py
+++ b/src/bandersnatch/main.py
@@ -1,118 +1,22 @@
 import argparse
 import asyncio
-import configparser
 import logging
 import logging.config
-import os
 import shutil
 import sys
-import time
 from pathlib import Path
 from tempfile import gettempdir
 
 import bandersnatch.log
-import bandersnatch.master
 import bandersnatch.mirror
-import bandersnatch.utils
 import bandersnatch.verify
 
 from .configuration import BandersnatchConfig
-from .filter import filter_project_plugins, filter_release_plugins
 
 logger = logging.getLogger(__name__)  # pylint: disable=C0103
 
 
-def mirror(config):
-    # Load the filter plugins so the loading doesn't happen in the fast path
-    filter_project_plugins()
-    filter_release_plugins()
-
-    # Always reference those classes here with the fully qualified name to
-    # allow them being patched by mock libraries!
-    master = bandersnatch.master.Master(
-        config.get("mirror", "master"), config.getfloat("mirror", "timeout")
-    )
-
-    # `json` boolean is a new optional option in 2.1.2 - want to support it
-    # not existing in old configs and display an error saying that this will
-    # error in the not to distance release
-    try:
-        json_save = config.getboolean("mirror", "json")
-    except configparser.NoOptionError:
-        logger.error(
-            "Please update your config to include a json "
-            + "boolean in the [mirror] section. Setting to False"
-        )
-        json_save = False
-
-    try:
-        root_uri = config.get("mirror", "root_uri")
-    except configparser.NoOptionError:
-        root_uri = None
-
-    try:
-        diff_file = config.get("mirror", "diff-file")
-    except configparser.NoOptionError:
-        diff_file = None
-
-    try:
-        diff_append_epoch = config.getboolean("mirror", "diff-append-epoch")
-    except configparser.NoOptionError:
-        diff_append_epoch = False
-
-    if diff_file:
-        os.makedirs(os.path.dirname(diff_file), exist_ok=True)
-        if diff_append_epoch:
-            diff_full_path = "{}-{}".format(diff_file, int(time.time()))
-        else:
-            diff_full_path = diff_file
-    else:
-        diff_full_path = None
-
-    if diff_full_path:
-        if os.path.isfile(diff_full_path):
-            os.unlink(diff_full_path)
-
-    try:
-        digest_name = config.get("mirror", "digest_name")
-    except configparser.NoOptionError:
-        digest_name = "sha256"
-    if digest_name not in ("md5", "sha256"):
-        raise ValueError(
-            f"Supplied digest_name {digest_name} is not supported! Please "
-            + "update digest_name to one of ('sha256', 'md5') in the [mirror] "
-            + "section."
-        )
-
-    mirror = bandersnatch.mirror.Mirror(
-        config.get("mirror", "directory"),
-        master,
-        stop_on_error=config.getboolean("mirror", "stop-on-error"),
-        workers=config.getint("mirror", "workers"),
-        hash_index=config.getboolean("mirror", "hash-index"),
-        json_save=json_save,
-        root_uri=root_uri,
-        digest_name=digest_name,
-        keep_index_versions=config.getint("mirror", "keep_index_versions", fallback=0),
-        diff_file=diff_file,
-        diff_append_epoch=diff_append_epoch,
-        diff_full_path=diff_full_path,
-    )
-
-    changed_packages = mirror.synchronize()
-    logger.info("{} packages had changes".format(len(changed_packages)))
-    for package_name, changes in changed_packages.items():
-        for change in changes:
-            mirror.diff_file_list.append(os.path.join(str(mirror.homedir), change))
-        logger.debug(f"{package_name} added: {changes}")
-    if diff_full_path:
-        logger.info(f"Writing diff file to {mirror.diff_full_path}")
-        with open(mirror.diff_full_path, "w", encoding="utf-8") as f:
-            for filename in mirror.diff_file_list:
-                f.write("{}{}".format(os.path.abspath(filename), os.linesep))
-
-
-def main():
+def main() -> int:
     parser = argparse.ArgumentParser(description="PyPI PEP 381 mirroring client.")
     parser.add_argument(
         "--version", action="version", version=f"%(prog)s {bandersnatch.__version__}"
@@ -204,7 +108,9 @@ def main():
     if args.op == "verify":
         loop = asyncio.get_event_loop()
         try:
-            loop.run_until_complete(bandersnatch.verify.metadata_verify(config, args))
+            return loop.run_until_complete(
+                bandersnatch.verify.metadata_verify(config, args)
+            )
         finally:
             loop.close()
     else:
@@ -228,8 +134,8 @@ def main():
                     f"No status file to move ({status_file}) - Full sync will occur"
                 )
 
-        mirror(config)
+        return bandersnatch.mirror.mirror(config)
 
 
 if __name__ == "__main__":
-    main()
+    exit(main())

--- a/src/bandersnatch/mirror.py
+++ b/src/bandersnatch/mirror.py
@@ -1,9 +1,11 @@
 import asyncio
 import atexit
 import concurrent.futures
+import configparser
 import datetime
 import logging
 import os
+import time
 from concurrent.futures import thread as futures_thread
 from pathlib import Path
 from threading import RLock
@@ -12,7 +14,8 @@ from typing import List
 from filelock import FileLock, Timeout
 from packaging.utils import canonicalize_name
 
-from .filter import filter_project_plugins
+from .filter import filter_project_plugins, filter_release_plugins
+from .master import Master
 from .package import Package
 from .utils import USER_AGENT, rewrite, update_safe
 
@@ -404,3 +407,96 @@ class Mirror:
     def _save(self):
         with self.statusfile.open("w", encoding="ascii") as f:
             f.write(str(self.synced_serial))
+
+
+def mirror(config) -> int:
+    # Load the filter plugins so the loading doesn't happen in the fast path
+    filter_project_plugins()
+    filter_release_plugins()
+
+    # Always reference those classes here with the fully qualified name to
+    # allow them being patched by mock libraries!
+    master = Master(
+        config.get("mirror", "master"), config.getfloat("mirror", "timeout")
+    )
+
+    # `json` boolean is a new optional option in 2.1.2 - want to support it
+    # not existing in old configs and display an error saying that this will
+    # error in the not to distance release
+    try:
+        json_save = config.getboolean("mirror", "json")
+    except configparser.NoOptionError:
+        logger.error(
+            "Please update your config to include a json "
+            + "boolean in the [mirror] section. Setting to False"
+        )
+        json_save = False
+
+    try:
+        root_uri = config.get("mirror", "root_uri")
+    except configparser.NoOptionError:
+        root_uri = None
+
+    try:
+        diff_file = config.get("mirror", "diff-file")
+    except configparser.NoOptionError:
+        diff_file = None
+
+    try:
+        diff_append_epoch = config.getboolean("mirror", "diff-append-epoch")
+    except configparser.NoOptionError:
+        diff_append_epoch = False
+
+    if diff_file:
+        os.makedirs(os.path.dirname(diff_file), exist_ok=True)
+        if diff_append_epoch:
+            diff_full_path = "{}-{}".format(diff_file, int(time.time()))
+        else:
+            diff_full_path = diff_file
+    else:
+        diff_full_path = ""
+
+    if diff_full_path:
+        if os.path.isfile(diff_full_path):
+            os.unlink(diff_full_path)
+
+    try:
+        digest_name = config.get("mirror", "digest_name")
+    except configparser.NoOptionError:
+        digest_name = "sha256"
+    if digest_name not in ("md5", "sha256"):
+        raise ValueError(
+            f"Supplied digest_name {digest_name} is not supported! Please "
+            + "update digest_name to one of ('sha256', 'md5') in the [mirror] "
+            + "section."
+        )
+
+    mirror = Mirror(
+        config.get("mirror", "directory"),
+        master,
+        stop_on_error=config.getboolean("mirror", "stop-on-error"),
+        workers=config.getint("mirror", "workers"),
+        hash_index=config.getboolean("mirror", "hash-index"),
+        json_save=json_save,
+        root_uri=root_uri,
+        digest_name=digest_name,
+        keep_index_versions=config.getint("mirror", "keep_index_versions", fallback=0),
+        diff_file=diff_file,
+        diff_append_epoch=diff_append_epoch,
+        diff_full_path=diff_full_path,
+    )
+
+    changed_packages = mirror.synchronize()
+    logger.info("{} packages had changes".format(len(changed_packages)))
+    for package_name, changes in changed_packages.items():
+        for change in changes:
+            mirror.diff_file_list.append(os.path.join(str(mirror.homedir), change))
+        logger.debug(f"{package_name} added: {changes}")
+
+    if mirror.diff_full_path:
+        logger.info(f"Writing diff file to {mirror.diff_full_path}")
+        with open(mirror.diff_full_path, "w", encoding="utf-8") as f:
+            for filename in mirror.diff_file_list:
+                f.write("{}{}".format(os.path.abspath(filename), os.linesep))
+
+    return 0


### PR DESCRIPTION
- Planning to add another sub command and main.py is to long
- Lets move the mirror logic to mirror.py
- Lets also ensure we always return an int and error when we should ...

Make Unit tests and CI pass to ensure we're good.