### PR TITLE
[delete] Add new subcommand to delete package artifacts

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -15,7 +15,7 @@ project_urls =
     Source Code = https://github.com/pypa/bandersnatch
     Change Log = https://github.com/pypa/bandersnatch/CHANGES.md
 url = https://github.com/pypa/bandersnatch/
-version = 3.5.0
+version = 3.6.0.dev0
 
 [options]
 include_package_data = True

--- a/src/bandersnatch/__init__.py
+++ b/src/bandersnatch/__init__.py
@@ -17,9 +17,9 @@ class _VersionInfo(NamedTuple):
 
 __version_info__ = _VersionInfo(
     major=3,
-    minor=5,
+    minor=6,
     micro=0,
-    releaselevel="",
+    releaselevel="dev0",
     serial=0,  # Not currently in use with Bandersnatch versioning
 )
 __version__ = __version_info__.version_str

--- a/src/bandersnatch/delete.py
+++ b/src/bandersnatch/delete.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+
+import asyncio
+import concurrent.futures
+import logging
+from argparse import Namespace
+from configparser import ConfigParser
+from json import JSONDecodeError, load
+from pathlib import Path
+from shutil import rmtree
+from typing import Awaitable, List
+from urllib.parse import urlparse
+
+from packaging.utils import canonicalize_name
+
+from bandersnatch.verify import get_latest_json
+
+logger = logging.getLogger(__name__)  # pylint: disable=C0103
+
+
+def delete_path(blob_path: Path, dry_run: bool = False) -> int:
+    if dry_run:
+        logger.info(f" rm {blob_path}")
+        return 0
+
+    if not blob_path.exists():
+        logger.debug(f"{blob_path} does not exist. Skipping")
+        return 0
+
+    try:
+        if blob_path.is_dir():
+            rmtree(blob_path)
+        else:
+            blob_path.unlink()
+    except (OSError):
+        logger.exception(f"Unable to delete {blob_path}")
+        return 1
+
+    return 0
+
+
+async def delete_packages(config: ConfigParser, args: Namespace) -> int:
+    loop = asyncio.get_event_loop()
+    workers = args.workers or config.getint("mirror", "workers")
+    executor = concurrent.futures.ThreadPoolExecutor(max_workers=workers)
+    mirror_base_path = Path(config.get("mirror", "directory"))
+    web_base_path = mirror_base_path / "web"
+    json_base_path = web_base_path / "json"
+    simple_path = web_base_path / "simple"
+
+    delete_coros: List[Awaitable] = []
+    for package in args.pypi_packages:
+        canon_name = canonicalize_name(package)
+        json_full_path = json_base_path / f"{canon_name}.json"
+        logger.debug(f"Looking up {canon_name} metadata @ {json_full_path}")
+
+        if not json_full_path.exists():
+            if args.dry_run:
+                logger.error(
+                    f"Skipping {json_full_path} as dry run and no JSON file exists"
+                )
+                continue
+
+            logger.error(f"{json_full_path} does not exist. Pulling from PyPI")
+            await get_latest_json(json_full_path, config, executor, False)
+            if not json_full_path.exists():
+                logger.error(f"Unable to HTTP get JSON for {json_full_path}")
+                continue
+
+        with json_full_path.open("r") as jfp:
+            try:
+                package_data = load(jfp)
+            except JSONDecodeError:
+                logger.exception(f"Skipping {canon_name} @ {json_full_path}")
+                continue
+
+        for _release, blobs in package_data["releases"].items():
+            for blob in blobs:
+                url_parts = urlparse(blob["url"])
+                blob_path = web_base_path / url_parts.path[1:]
+                delete_coros.append(
+                    loop.run_in_executor(executor, delete_path, blob_path, args.dry_run)
+                )
+
+        # Attempt to delete json, normal simple path + hash simple path
+        package_simple_path = simple_path / canon_name
+        package_hash_path = simple_path / canon_name[0] / canon_name
+        for package_path in (json_full_path, package_simple_path, package_hash_path):
+            delete_coros.append(
+                loop.run_in_executor(executor, delete_path, package_path, args.dry_run)
+            )
+
+    if args.dry_run:
+        logger.info("-- bandersnatch delete DRY RUN --")
+    if delete_coros:
+        logger.info(f"Attempting to remove {len(delete_coros)} files")
+        return sum(await asyncio.gather(*delete_coros))
+    return 0

--- a/src/bandersnatch/delete.py
+++ b/src/bandersnatch/delete.py
@@ -32,7 +32,11 @@ def delete_path(blob_path: Path, dry_run: bool = False) -> int:
             rmtree(blob_path)
         else:
             blob_path.unlink()
-    except (OSError):
+    except FileNotFoundError:
+        # Due to using threads in executors we sometimes have a
+        # race condition if canonicalize_name == passed in name
+        pass
+    except OSError:
         logger.exception(f"Unable to delete {blob_path}")
         return 1
 
@@ -46,12 +50,16 @@ async def delete_packages(config: ConfigParser, args: Namespace) -> int:
     mirror_base_path = Path(config.get("mirror", "directory"))
     web_base_path = mirror_base_path / "web"
     json_base_path = web_base_path / "json"
+    pypi_base_path = web_base_path / "pypi"
     simple_path = web_base_path / "simple"
 
     delete_coros: List[Awaitable] = []
     for package in args.pypi_packages:
         canon_name = canonicalize_name(package)
-        json_full_path = json_base_path / f"{canon_name}.json"
+        need_nc_paths = canon_name != package
+        json_full_path = json_base_path / canon_name
+        json_full_path_nc = json_base_path / package if need_nc_paths else None
+        legacy_json_path = pypi_base_path / canon_name
         logger.debug(f"Looking up {canon_name} metadata @ {json_full_path}")
 
         if not json_full_path.exists():
@@ -84,8 +92,24 @@ async def delete_packages(config: ConfigParser, args: Namespace) -> int:
 
         # Attempt to delete json, normal simple path + hash simple path
         package_simple_path = simple_path / canon_name
+        package_simple_path_nc = simple_path / package if need_nc_paths else None
         package_hash_path = simple_path / canon_name[0] / canon_name
-        for package_path in (json_full_path, package_simple_path, package_hash_path):
+        package_hash_path_nc = (
+            simple_path / canon_name[0] / package if need_nc_paths else None
+        )
+        # Try cleanup non canon name if they differ
+        for package_path in (
+            json_full_path,
+            legacy_json_path,
+            package_simple_path,
+            package_simple_path_nc,
+            package_hash_path,
+            package_hash_path_nc,
+            json_full_path_nc,
+        ):
+            if not package_path:
+                continue
+
             delete_coros.append(
                 loop.run_in_executor(executor, delete_path, package_path, args.dry_run)
             )

--- a/src/bandersnatch/tests/test_delete.py
+++ b/src/bandersnatch/tests/test_delete.py
@@ -12,8 +12,8 @@ from bandersnatch.utils import find
 
 EXPECTED_WEB_BEFORE_DELETION = """\
 json
-json/cooper.json
-json/unittest.json
+json/cooper
+json/unittest
 packages
 packages/69
 packages/69/cooper-6.9.tar.gz
@@ -21,6 +21,11 @@ packages/69/unittest-6.9.tar.gz
 packages/7b
 packages/7b/cooper-6.9-py3-none-any.whl
 packages/7b/unittest-6.9-py3-none-any.whl
+pypi
+pypi/cooper
+pypi/cooper/json
+pypi/unittest
+pypi/unittest/json
 simple
 simple/cooper
 simple/cooper/index.html
@@ -32,6 +37,7 @@ json
 packages
 packages/69
 packages/7b
+pypi
 simple\
 """
 MOCK_JSON_TEMPLATE = """{
@@ -89,6 +95,8 @@ def test_delete_packages() -> None:
         web_path = td_path / "web"
         json_path = web_path / "json"
         json_path.mkdir(parents=True)
+        pypi_path = web_path / "pypi"
+        pypi_path.mkdir(parents=True)
         simple_path = web_path / "simple"
 
         # Setup web tree with some json, package index.html + fake blobs
@@ -99,9 +107,12 @@ def test_delete_packages() -> None:
             package_index_path.touch()
 
             package_json_str = MOCK_JSON_TEMPLATE.replace("PKGNAME", package_name)
-            package_json_path = json_path / f"{package_name}.json"
+            package_json_path = json_path / package_name
             with package_json_path.open("w") as pjfp:
                 pjfp.write(package_json_str)
+            legacy_json_path = pypi_path / package_name / "json"
+            legacy_json_path.parent.mkdir()
+            legacy_json_path.symlink_to(package_json_path)
 
             package_json = loads(package_json_str)
             for _version, blobs in package_json["releases"].items():

--- a/src/bandersnatch/tests/test_delete.py
+++ b/src/bandersnatch/tests/test_delete.py
@@ -1,0 +1,134 @@
+import asyncio
+from argparse import Namespace
+from configparser import ConfigParser
+from json import loads
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest.mock import patch
+from urllib.parse import urlparse
+
+from bandersnatch.delete import delete_packages, delete_path
+from bandersnatch.utils import find
+
+EXPECTED_WEB_BEFORE_DELETION = """\
+json
+json/cooper.json
+json/unittest.json
+packages
+packages/69
+packages/69/cooper-6.9.tar.gz
+packages/69/unittest-6.9.tar.gz
+packages/7b
+packages/7b/cooper-6.9-py3-none-any.whl
+packages/7b/unittest-6.9-py3-none-any.whl
+simple
+simple/cooper
+simple/cooper/index.html
+simple/unittest
+simple/unittest/index.html\
+"""
+EXPECTED_WEB_AFTER_DELETION = """\
+json
+packages
+packages/69
+packages/7b
+simple\
+"""
+MOCK_JSON_TEMPLATE = """{
+    "releases": {
+        "6.9": [
+            {"url": "https://files.ph.org/packages/7b/PKGNAME-6.9-py3-none-any.whl"},
+            {"url": "https://files.ph.org/packages/69/PKGNAME-6.9.tar.gz"}
+        ]
+    }
+}
+"""
+
+
+def _fake_args() -> Namespace:
+    return Namespace(dry_run=True, pypi_packages=["cooper", "unittest"], workers=0)
+
+
+def _fake_config() -> ConfigParser:
+    cp = ConfigParser()
+    cp.add_section("mirror")
+    cp["mirror"]["directory"] = "/tmp/unittest"
+    cp["mirror"]["workers"] = "1"
+    return cp
+
+
+def test_delete_path() -> None:
+    with TemporaryDirectory() as td:
+        td_path = Path(td)
+        fake_path = td_path / "unittest-file.tgz"
+        with patch("bandersnatch.delete.logger.info") as mock_log:
+            assert delete_path(fake_path, True) == 0
+            assert mock_log.call_count == 1
+
+        with patch("bandersnatch.delete.logger.debug") as mock_log:
+            assert delete_path(fake_path, False) == 0
+            assert mock_log.call_count == 1
+
+        fake_path.touch()
+        # Remove file
+        assert delete_path(fake_path, False) == 0
+        # File should be gone - We should log that via debug
+        with patch("bandersnatch.delete.logger.debug") as mock_log:
+            assert delete_path(fake_path, False) == 0
+            assert mock_log.call_count == 1
+
+
+def test_delete_packages() -> None:
+    args = _fake_args()
+    config = _fake_config()
+    loop = asyncio.get_event_loop()
+
+    with TemporaryDirectory() as td:
+        td_path = Path(td)
+        config["mirror"]["directory"] = td
+        web_path = td_path / "web"
+        json_path = web_path / "json"
+        json_path.mkdir(parents=True)
+        simple_path = web_path / "simple"
+
+        # Setup web tree with some json, package index.html + fake blobs
+        for package_name in args.pypi_packages:
+            package_simple_path = simple_path / package_name
+            package_simple_path.mkdir(parents=True)
+            package_index_path = package_simple_path / "index.html"
+            package_index_path.touch()
+
+            package_json_str = MOCK_JSON_TEMPLATE.replace("PKGNAME", package_name)
+            package_json_path = json_path / f"{package_name}.json"
+            with package_json_path.open("w") as pjfp:
+                pjfp.write(package_json_str)
+
+            package_json = loads(package_json_str)
+            for _version, blobs in package_json["releases"].items():
+                for blob in blobs:
+                    url_parts = urlparse(blob["url"])
+                    blob_path = web_path / url_parts.path[1:]
+                    blob_path.parent.mkdir(parents=True, exist_ok=True)
+                    blob_path.touch()
+
+        # See we have a correct mirror setup
+        assert find(web_path) == EXPECTED_WEB_BEFORE_DELETION
+
+        args.dry_run = True
+        assert loop.run_until_complete(delete_packages(config, args)) == 0
+
+        args.dry_run = False
+        with patch("bandersnatch.delete.logger.info") as mock_log:
+            assert loop.run_until_complete(delete_packages(config, args)) == 0
+            assert mock_log.call_count == 1
+
+        # See we've deleted it all
+        assert find(web_path) == EXPECTED_WEB_AFTER_DELETION
+
+
+def test_delete_packages_no_exist() -> None:
+    loop = asyncio.get_event_loop()
+    args = _fake_args()
+    with patch("bandersnatch.delete.logger.error") as mock_log:
+        assert loop.run_until_complete(delete_packages(_fake_config(), args)) == 0
+        assert mock_log.call_count == len(args.pypi_packages)

--- a/test_runner.py
+++ b/test_runner.py
@@ -27,6 +27,15 @@ MIRROR_BASE = MIRROR_ROOT / "web"
 TGZ_SHA256 = "bc9430dae93f8bc53728773545cbb646a6b5327f98de31bdd6e1a2b2c6e805a9"
 TOX_EXE = Path(which("tox") or "tox")
 
+# Make Global so we can check exists before delete
+A_BLACK_WHL = (
+    MIRROR_BASE
+    / "packages"
+    / "30"
+    / "62"
+    / "cf549544a5fe990bbaeca21e9c419501b2de7a701ab0afb377bc81676600"
+    / "black-19.3b0-py36-none-any.whl"
+)
 
 def check_ci() -> int:
     black_index = MIRROR_BASE / "simple/b/black/index.html"
@@ -34,7 +43,9 @@ def check_ci() -> int:
     peerme_json = MIRROR_BASE / "json/peerme"
     peerme_tgz = (
         MIRROR_BASE
-        / "packages/8f/1a/"
+        / "packages"
+        / "8f"
+        / "1a"
         / "1aa000db9c5a799b676227e845d2b64fe725328e05e3d3b30036f50eb316"
         / "peerme-1.0.0-py36-none-any.whl"
     )
@@ -60,6 +71,10 @@ def check_ci() -> int:
         print(f"{EOP} {black_index} exists ... delete failed?")
         return 73
 
+    if A_BLACK_WHL.exists():
+        print(f"{EOP} {A_BLACK_WHL} exists ... delete failed?")
+        return 74
+
     rmtree(MIRROR_ROOT)
 
     print("Bandersnatch PyPI CI finished successfully!")
@@ -75,6 +90,11 @@ def do_ci(conf: Path) -> int:
     cmds = (str(BANDERSNATCH_EXE), "--config", str(conf), "--debug", "mirror")
     print(f"bandersnatch cmd: {' '.join(cmds)}")
     run(cmds, check=True)
+
+    print(f"Checking if {A_BLACK_WHL} exists")
+    if not A_BLACK_WHL.exists():
+        print(f"{EOP} {A_BLACK_WHL} does not exist after mirroring ...")
+        return 68
 
     print("Starting to deleting black from mirror ...")
     del_cmds = (

--- a/test_runner.py
+++ b/test_runner.py
@@ -28,7 +28,7 @@ TGZ_SHA256 = "bc9430dae93f8bc53728773545cbb646a6b5327f98de31bdd6e1a2b2c6e805a9"
 TOX_EXE = Path(which("tox") or "tox")
 
 
-def do_ci_verify():
+def check_ci() -> int:
     black_index = MIRROR_BASE / "simple/b/black/index.html"
     peerme_index = MIRROR_BASE / "simple/p/peerme/index.html"
     peerme_json = MIRROR_BASE / "json/peerme"
@@ -56,10 +56,9 @@ def do_ci_verify():
         print(f"{EOP} Bad peerme 1.0.0 sha256: {peerme_tgz_sha256} != {TGZ_SHA256}")
         return 72
 
-    with black_index.open("r") as bifp:
-        if "a href" not in bifp.read():
-            print(f"{EOP} {black_index} has no hyperlinks")
-            return 73
+    if black_index.exists():
+        print(f"{EOP} {black_index} exists ... delete failed?")
+        return 73
 
     rmtree(MIRROR_ROOT)
 
@@ -77,7 +76,19 @@ def do_ci(conf: Path) -> int:
     print(f"bandersnatch cmd: {' '.join(cmds)}")
     run(cmds, check=True)
 
-    return do_ci_verify()
+    print("Starting to deleting black from mirror ...")
+    del_cmds = (
+        str(BANDERSNATCH_EXE),
+        "--config",
+        str(conf),
+        "--debug",
+        "delete",
+        "black",
+    )
+    print(f"bandersnatch delete cmd: {' '.join(cmds)}")
+    run(del_cmds, check=True)
+
+    return check_ci()
 
 
 def platform_config() -> Path:

--- a/test_runner.py
+++ b/test_runner.py
@@ -37,6 +37,7 @@ A_BLACK_WHL = (
     / "black-19.3b0-py36-none-any.whl"
 )
 
+
 def check_ci() -> int:
     black_index = MIRROR_BASE / "simple/b/black/index.html"
     peerme_index = MIRROR_BASE / "simple/p/peerme/index.html"


### PR DESCRIPTION
- Look at PyPI JSON and delete all the local files if they exist
- Support dryrun

Add unittests in `test_delete.py` and add the deletion of `black` to CI run.

Helps with #307 by giving people a way to clean out downloaded packages.