### PR TITLE
Move TravisCI to test on real Python3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ matrix:
     - python: 3.8
       env: TOXENV=py38
     - python: nightly
-      env: TOXENV=py39
+      env: TOXENV=py3
   allow_failures:
     - python: nightly
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,12 +18,11 @@ matrix:
       env: TOXENV=lint
     - python: 3.7
       env: TOXENV=py37
-    - python: 3.8-dev
+    - python: 3.8
       env: TOXENV=py38
     - python: nightly
-      env: TOXENV=py38
+      env: TOXENV=py39
   allow_failures:
-    - env: TOXENV=py38
     - python: nightly
 
 install:


### PR DESCRIPTION
- Lets expect Python 3.8 to pass ...
- Also move nightly tox env to expect Python3.9