### PR TITLE
Restore missing docs CI + Tune CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: [3.6, 3.7]
+        python-version: [3.6, 3.7, 3.8]
         os: [macOS-latest, ubuntu-latest]
 
     steps:
@@ -22,12 +22,6 @@ jobs:
     - name: Install latest pip, setuptools + tox
       run: |
         python -m pip install --upgrade pip setuptools tox
-
-    - name: Run Lint
-      env:
-       TOXENV: lint
-      run: |
-        python test_runner.py
 
     - name: Run Unittests
       run: |

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,10 @@ env:
 matrix:
   fast_finish: true
   include:
+    - python: 3.7
+      env: TOXENV=doc_build
+    - python: 3.7
+      env: TOXENV=lint
     - python: 3.8
       env: TOXENV=INTEGRATION
     - python: 3.8

--- a/docs/bandersnatch.rst
+++ b/docs/bandersnatch.rst
@@ -8,79 +8,87 @@ bandersnatch.configuration module
 ---------------------------------
 
 .. automodule:: bandersnatch.configuration
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+bandersnatch.delete module
+--------------------------
+
+.. automodule:: bandersnatch.delete
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 bandersnatch.filter module
 --------------------------
 
 .. automodule:: bandersnatch.filter
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 bandersnatch.log module
 -----------------------
 
 .. automodule:: bandersnatch.log
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 bandersnatch.main module
 ------------------------
 
 .. automodule:: bandersnatch.main
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 bandersnatch.master module
 --------------------------
 
 .. automodule:: bandersnatch.master
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 bandersnatch.mirror module
 --------------------------
 
 .. automodule:: bandersnatch.mirror
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 bandersnatch.package module
 ---------------------------
 
 .. automodule:: bandersnatch.package
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 bandersnatch.utils module
 -------------------------
 
 .. automodule:: bandersnatch.utils
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 bandersnatch.verify module
 --------------------------
 
 .. automodule:: bandersnatch.verify
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 
 Module contents
 ---------------
 
 .. automodule:: bandersnatch
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:


### PR DESCRIPTION
- Have TravisCI run doc tests to ensure we don't break
- Have doc_build and lint in 3.7 to give tools more time to be 3.8 ready (should still lint and build docs the same)
- Add 3.8 to GitHub Actions
- Remove lint from GitHub and only run on TravisCI (no need to run on every platform)