### PR TITLE
bugfix in runner.py:

### DIFF
--- a/src/runner.py
+++ b/src/runner.py
@@ -4,27 +4,36 @@
 
 import argparse
 import sys
-from subprocess import run
+from subprocess import run, CalledProcessError
 from time import sleep, time
 
 
 def main() -> None:
-    parser = argparse.ArgumentParser(
-        formatter_class=argparse.ArgumentDefaultsHelpFormatter
-    )
+    parser = argparse.ArgumentParser()
     parser.add_argument(
         "-c",
         "--config",
         default="/conf/bandersnatch.conf",
         help="Configuration location",
     )
-    parser.add_argument("interval", help="Time in seconds between runs")
+    parser.add_argument("interval", help="Time in seconds between runs", type=int)
     args = parser.parse_args()
 
     print(f"Running bandersnatch every {args.interval}s", file=sys.stderr)
     while True:
         start_time = time()
-        run(["/usr/bin/bandersnatch", "--config", args.conf, "mirror"])
+        try:
+            cmd = [
+                sys.executable,
+                "-m",
+                "bandersnatch.main",
+                "--config",
+                args.config,
+                "mirror",
+            ]
+            run(cmd, check=True)
+        except CalledProcessError:
+            sys.exit(1)
         run_time = time() - start_time
         if run_time < args.interval:
             sleep_time = args.interval - run_time


### PR DESCRIPTION
Hello there,

Maybe this could solve some of the problems (#393 ):

* Change type of interval argument to int
* Remove hardcoded the bandersnatch path; instead run it by using the `bandersnatch.main` module

I couldn't solve the configuration part, but I think that could be achievable through Dockerfile, maybe?.
