### PR TITLE
Replace xmlrpc2 with aiohttp-xmlrpc

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 aiohttp==3.6.2
+aiohttp-xmlrpc==0.7.6
 async-timeout==3.0.1
 attrs==19.3.0
 certifi==2019.11.28
@@ -6,6 +7,7 @@ chardet==3.0.4
 filelock==3.0.12
 idna==2.8
 idna-ssl==1.1.0
+lxml==4.4.2
 multidict==4.7.4
 packaging==20.0
 pyparsing==2.4.6
@@ -15,5 +17,4 @@ setuptools==45.0.0
 six==1.13.0
 typing-extensions==3.7.4.1
 urllib3==1.25.7
-xmlrpc2==0.3.1
 yarl==1.4.2

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,3 +1,4 @@
+asynctest==0.13.0
 black==19.10b0
 codecov==2.0.15
 coverage==5.0.3

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,6 +5,7 @@ classifiers =
     Programming Language :: Python :: 3 :: Only
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
 description = Mirroring tool that implements the client (mirror) side of PEP 381
 long_description = file:README.md
 long_description_content_type = text/markdown
@@ -21,11 +22,11 @@ version = 3.6.0
 include_package_data = True
 install_requires =
     aiohttp
+    aiohttp-xmlrpc
     filelock
     packaging
     requests
     setuptools>40.0.0
-    xmlrpc2
 package_dir =
     =src
 packages = find:

--- a/src/bandersnatch/master.py
+++ b/src/bandersnatch/master.py
@@ -92,7 +92,7 @@ class Master:
         try:
             client = await self._gen_xmlrpc_client()
             method = getattr(client, method_name)
-            return asyncio.wait_for(method(**kwargs), self.timeout)
+            return await asyncio.wait_for(method(**kwargs), self.timeout)
         except asyncio.TimeoutError as te:
             logger.error(f"Call to {method_name} @ {self.xmlrpc_url} timed out: {te}")
         finally:

--- a/src/bandersnatch/mirror.py
+++ b/src/bandersnatch/mirror.py
@@ -175,7 +175,6 @@ class Mirror:
                     logger.debug(f"{package_name} not found in packages to sync")
                 else:
                     del self.packages_to_sync[package_name]
-                    # logger.debug(f"{package_name} filtered")
 
     def determine_packages_to_sync(self):
         """

--- a/src/bandersnatch/mirror.py
+++ b/src/bandersnatch/mirror.py
@@ -83,7 +83,7 @@ class Mirror:
         flock_timeout=1,
         diff_file_list=None,
     ):
-        self.loop = asyncio.new_event_loop()
+        self.loop = asyncio.get_event_loop()
         self.homedir = Path(homedir)
         self.master = master
         self.stop_on_error = stop_on_error
@@ -249,8 +249,6 @@ class Mirror:
                 "Cancelling, all downloads are forcibly stopped, data may be corrupted"
             )
             thread_pool.shutdown(wait=False)
-        finally:
-            self.loop.close()
 
     def record_finished_package(self, name):
         with self._finish_lock:

--- a/src/bandersnatch/tests/test_mirror.py
+++ b/src/bandersnatch/tests/test_mirror.py
@@ -4,6 +4,7 @@ from os import sep
 from pathlib import Path
 from tempfile import TemporaryDirectory
 
+import asynctest
 import pytest
 from requests import HTTPError
 
@@ -191,8 +192,7 @@ def test_mirror_with_same_homedir_needs_lock(mirror, tmpdir):
 
 
 def test_mirror_empty_master_gets_index(mirror):
-    mirror.master.all_packages = mock.Mock()
-    mirror.master.all_packages.return_value = {}
+    mirror.master.all_packages = asynctest.asynctest.CoroutineMock(return_value={})
 
     mirror.synchronize()
 
@@ -263,8 +263,7 @@ web{0}simple{0}index.html""".format(
 
 
 def test_mirror_sync_package(mirror, requests):
-    mirror.master.all_packages = mock.Mock()
-    mirror.master.all_packages.return_value = {"foo": 1}
+    mirror.master.all_packages = asynctest.CoroutineMock(return_value={"foo": 1})
     mirror.json_save = True
     # Recall bootstrap so we have the json dirs
     mirror._bootstrap()
@@ -304,8 +303,7 @@ simple{0}index.html""".format(
 
 
 def test_mirror_sync_package_error_no_early_exit(mirror, requests):
-    mirror.master.all_packages = mock.Mock()
-    mirror.master.all_packages.return_value = {"foo": 1}
+    mirror.master.all_packages = asynctest.CoroutineMock(return_value={"foo": 1})
 
     requests.prepare(
         {
@@ -369,8 +367,7 @@ web{0}simple{0}index.html""".format(
 
 
 def test_mirror_sync_package_error_early_exit(mirror, requests):
-    mirror.master.all_packages = mock.Mock()
-    mirror.master.all_packages.return_value = {"foo": 1}
+    mirror.master.all_packages = asynctest.CoroutineMock(return_value={"foo": 1})
 
     requests.prepare(
         {
@@ -420,8 +417,9 @@ web{0}simple{0}index.html""".format(
 
 
 def test_mirror_sync_package_with_hash(mirror_hash_index, requests):
-    mirror_hash_index.master.all_packages = mock.Mock()
-    mirror_hash_index.master.all_packages.return_value = {"foo": 1}
+    mirror_hash_index.master.all_packages = asynctest.CoroutineMock(
+        return_value={"foo": 1}
+    )
 
     requests.prepare(
         {
@@ -477,9 +475,7 @@ simple{0}index.html""".format(
 
 
 def test_mirror_serial_current_no_sync_of_packages_and_index_page(mirror, requests):
-
-    mirror.master.changed_packages = mock.Mock()
-    mirror.master.changed_packages.return_value = {}
+    mirror.master.changed_packages = asynctest.CoroutineMock(return_value={})
     mirror.synced_serial = 1
 
     mirror.synchronize()

--- a/tox.ini
+++ b/tox.ini
@@ -35,4 +35,4 @@ commands=
 
 [isort]
 include_trailing_comma = True
-known_third_party = aiohttp,cloud_sptheme,filelock,freezegun,guzzle_sphinx_theme,packaging,pkg_resources,pypa_theme,pytest,recommonmark,requests,setuptools,sphinx_bootstrap_theme,sphinx_rtd_theme,xmlrpc2
+known_third_party = aiohttp,aiohttp_xmlrpc,asynctest,cloud_sptheme,filelock,freezegun,guzzle_sphinx_theme,packaging,pkg_resources,pypa_theme,pytest,recommonmark,requests,setuptools,sphinx_bootstrap_theme,sphinx_rtd_theme


### PR DESCRIPTION
- Async def up Master PyPI XML RPC Calls
- Wrap calls in `asyncio.run_until_complete` in `mirror.py`
- Pull in asynctest + use CoroutingMock's until we're >= 3.8

See integration tests still pass