### PR TITLE
Install base requirements before unittests on GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,10 @@ jobs:
       run: |
         python -m pip install --upgrade pip setuptools tox
 
+    - name: Install base bandersnatch requirements
+      run: |
+        python -m pip install -r requirements.txt
+
     - name: Run Unittests
       run: |
         export TOXENV=py$(echo -n "${{ matrix.python-version }}" | tr -d '.')
@@ -32,6 +36,5 @@ jobs:
       env:
        TOXENV: INTEGRATION
       run: |
-        pip install -r requirements.txt
-        pip install .
+        python -m pip install .
         python test_runner.py


### PR DESCRIPTION
- We should have all the deps installed before unittests to ensure we can import everything

This was found during the refactor from threads + requests to aiohttp (splitting the PRs so the cut over is as small as possible)