### PR TITLE
Remove non all PEP503 conformant paths

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -3,7 +3,7 @@
    contain the root `toctree` directive.
 
 Bandersnatch documentation
-============
+==========================
 
 bandersnatch is a PyPI mirror client according to `PEP 381`
 http://www.python.org/dev/peps/pep-0381/.
@@ -12,6 +12,11 @@ Bandersnatch hits the XMLRPC API of pypi.org to get all packages with serial
 or packages since the last run's serial. bandersnatch then uses the JSON API
 of PyPI to get shasums and release file paths to download and workout where
 to layout the package files on a POSIX file system.
+
+As of 4.0 bandersnatch:
+- Is fully asyncio based (mainly via aiohttp)
+- Only stores PEP503 nomalized packages names for the /simple API
+- Only stores JSON in normailzed package name path too
 
 Contents:
 

--- a/src/bandersnatch/tests/test_package.py
+++ b/src/bandersnatch/tests/test_package.py
@@ -194,46 +194,6 @@ async def test_package_sync_with_normalized_simple_page(mirror):
         )
     )
 
-    # Legacy partial normalization as implemented by pip prior to 8.1.2
-    assert (
-        open("web/simple/foo.bar-thing-other/index.html").read()
-        == """\
-<!DOCTYPE html>
-<html>
-  <head>
-    <title>Links for Foo.bar-thing_other</title>
-  </head>
-  <body>
-    <h1>Links for Foo.bar-thing_other</h1>
-    {}
-  </body>
-</html>
-<!--SERIAL 654321-->\
-""".format(
-            EXPECTED_REL_HREFS
-        )
-    )
-
-    # Legacy unnormalized as implemented by pip prior to 6.0
-    assert (
-        open("web/simple/Foo.bar-thing_other/index.html").read()
-        == """\
-<!DOCTYPE html>
-<html>
-  <head>
-    <title>Links for Foo.bar-thing_other</title>
-  </head>
-  <body>
-    <h1>Links for Foo.bar-thing_other</h1>
-    {}
-  </body>
-</html>
-<!--SERIAL 654321-->\
-""".format(
-            EXPECTED_REL_HREFS
-        )
-    )
-
 
 @pytest.mark.asyncio
 async def test_package_sync_simple_page_root_uri(mirror):


### PR DESCRIPTION
- PEP503 says we only need to store the normalized path / name for packages
- Moderns pip supports this
- Lets remove the legacy normalization and 1.5 non normalized directories for simple html
- Also make package.py full mypy / PEP484 compliant

Have made a note in documentation about this.

Tests:
- Update tests to only expect normalized directories

Fixes #138