### PR TITLE
Make packages only store PEP 503 Simple API Directory

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -16,7 +16,7 @@ project_urls =
     Source Code = https://github.com/pypa/bandersnatch
     Change Log = https://github.com/pypa/bandersnatch/CHANGES.md
 url = https://github.com/pypa/bandersnatch/
-version = 4.0.0.dev1
+version = 4.0.0.dev2
 
 [options]
 include_package_data = True

--- a/src/bandersnatch/__init__.py
+++ b/src/bandersnatch/__init__.py
@@ -19,7 +19,7 @@ __version_info__ = _VersionInfo(
     major=4,
     minor=0,
     micro=0,
-    releaselevel="dev1",
+    releaselevel="dev2",
     serial=0,  # Not currently in use with Bandersnatch versioning
 )
 __version__ = __version_info__.version_str

--- a/src/bandersnatch/default.conf
+++ b/src/bandersnatch/default.conf
@@ -5,6 +5,9 @@ directory = /srv/pypi
 ; URL/pypi/PKG_NAME/json (Symlink) -> URL/json/PKG_NAME
 json = false
 
+; Cleanup legacy non PEP 503 normalized named simple directories
+cleanup = false
+
 ; The PyPI server which will be mirrored.
 ; master = https://test.python.org
 ; scheme for PyPI server MUST be https

--- a/src/bandersnatch/package.py
+++ b/src/bandersnatch/package.py
@@ -23,7 +23,7 @@ from .filter import filter_release_file_plugins  # isort:skip
 from .filter import filter_release_plugins  # isort:skip
 
 
-if TYPE_CHECKING:
+if TYPE_CHECKING:  # pragma: no cover
     from .mirror import Mirror
 
 

--- a/src/bandersnatch/package.py
+++ b/src/bandersnatch/package.py
@@ -7,11 +7,13 @@ import sys
 from datetime import datetime
 from json import dump
 from pathlib import Path
+from shutil import rmtree
 from typing import TYPE_CHECKING, Dict, List, Optional
 from urllib.parse import unquote, urlparse
 
 from aiohttp import ClientResponseError
 from packaging.utils import canonicalize_name
+from pkg_resources import safe_name
 
 from . import utils
 from .master import StalePage
@@ -35,11 +37,15 @@ class Package:
     tries = 0
     sleep_on_stale = 1
 
-    def __init__(self, name: str, serial: str, mirror: "Mirror") -> None:
-        self.name = name
+    def __init__(
+        self, name: str, serial: str, mirror: "Mirror", *, cleanup: bool = False
+    ) -> None:
+        self.name = canonicalize_name(name)
+        self.raw_name = name
+        self.normalized_name_legacy = safe_name(name).lower()
         self.serial = serial
-        self.normalized_name = canonicalize_name(name)
         self.mirror = mirror
+        self.cleanup = cleanup
 
     @property
     def json_file(self) -> Path:
@@ -50,21 +56,53 @@ class Package:
         return self.mirror.webdir / "pypi" / self.name / "json"
 
     @property
+    def normalized_legacy_simple_directory(self) -> Path:
+        if self.mirror.hash_index:
+            return (
+                self.mirror.webdir
+                / "simple"
+                / self.normalized_name_legacy[0]
+                / self.normalized_name_legacy
+            )
+        return self.mirror.webdir / "simple" / self.normalized_name_legacy
+
+    @property
+    def raw_simple_directory(self) -> Path:
+        if self.mirror.hash_index:
+            return self.mirror.webdir / "simple" / self.raw_name[0] / self.raw_name
+        return self.mirror.webdir / "simple" / self.raw_name
+
+    @property
     def simple_directory(self) -> Path:
         if self.mirror.hash_index:
             return self.mirror.webdir / "simple" / self.name[0] / self.name
         return self.mirror.webdir / "simple" / self.name
 
-    @property
-    def normalized_simple_directory(self) -> Path:
-        if self.mirror.hash_index:
-            return (
-                self.mirror.webdir
-                / "simple"
-                / self.normalized_name[0]
-                / self.normalized_name
-            )
-        return self.mirror.webdir / "simple" / self.normalized_name
+    async def cleanup_non_pep_503_paths(self) -> None:
+        """
+        Before 4.0 we use to store backwards compatible named dirs for older pip
+        This function checks for them and cleans them up
+        """
+        if not self.cleanup:
+            return
+
+        for deprecated_dir in (
+            self.raw_simple_directory,
+            self.normalized_legacy_simple_directory,
+        ):
+            if deprecated_dir != self.simple_directory:
+                if not deprecated_dir.exists():
+                    continue
+
+                logger.info(
+                    f"Attempting to cleanup non PEP 503 simple dir: {deprecated_dir}"
+                )
+                try:
+                    rmtree(deprecated_dir)
+                except Exception:
+                    logger.exception(
+                        f"Unable to cleanup non PEP 503 dir {deprecated_dir}"
+                    )
 
     def save_json_metadata(self, package_info: Dict) -> bool:
         """
@@ -81,13 +119,12 @@ class Package:
             return False
 
         symlink_dir = self.json_pypi_symlink.parent
-        if not symlink_dir.exists():
-            symlink_dir.mkdir()
-        try:
-            # If symlink already exists throw a FileExistsError
-            self.json_pypi_symlink.symlink_to(self.json_file)
-        except FileExistsError:
-            pass
+        symlink_dir.mkdir(exist_ok=True)
+        # Lets always ensure symlink is pointing to correct self.json_file
+        # In 4.0 we move to normalized name only so want to overwrite older symlinks
+        if self.json_pypi_symlink.exists():
+            self.json_pypi_symlink.unlink()
+        self.json_pypi_symlink.symlink_to(self.json_file)
 
         return True
 
@@ -145,9 +182,8 @@ class Package:
                         self.sleep_on_stale *= 2
                         continue
                     logger.error(
-                        "Stale serial for {} ({}) not updating. Giving up.".format(
-                            self.name, self.serial
-                        )
+                        f"Stale serial for {self.name} ({self.serial}) "
+                        + "not updating. Giving up."
                     )
                     self.mirror.errors = True
         except Exception:
@@ -157,6 +193,9 @@ class Package:
         if self.mirror.errors and stop_on_error:
             logger.error("Exiting early after error.")
             sys.exit(1)
+
+        # Cleanup non normalized name directory
+        await self.cleanup_non_pep_503_paths()
 
     def _filter_metadata(self, metadata: Dict) -> bool:
         """
@@ -281,7 +320,7 @@ class Package:
             "  </head>\n"
             "  <body>\n"
             "    <h1>Links for {0}</h1>\n"
-        ).format(self.name)
+        ).format(self.raw_name)
 
         # Get a list of all of the files.
         release_files: List[Dict] = []
@@ -313,19 +352,17 @@ class Package:
         return simple_page_content
 
     def sync_simple_page(self) -> None:
-        logger.info(
-            f"Storing index page: {self.name} - in {self.normalized_simple_directory}"
-        )
+        logger.info(f"Storing index page: {self.name} - in {self.simple_directory}")
         simple_page_content = self.generate_simple_page()
-        self.normalized_simple_directory.mkdir(exist_ok=True, parents=True)
+        self.simple_directory.mkdir(exist_ok=True, parents=True)
 
         if self.mirror.keep_index_versions > 0:
             self._save_simple_page_version(simple_page_content)
         else:
-            normalized_simple_page = self.normalized_simple_directory / "index.html"
-            with utils.rewrite(normalized_simple_page, "w", encoding="utf-8") as f:
+            simple_page = self.simple_directory / "index.html"
+            with utils.rewrite(simple_page, "w", encoding="utf-8") as f:
                 f.write(simple_page_content)
-            self.mirror.diff_file_list.append(normalized_simple_page)
+            self.mirror.diff_file_list.append(simple_page)
 
     def _save_simple_page_version(self, simple_page_content: str) -> None:
         versions_path = self._prepare_versions_path()
@@ -336,14 +373,14 @@ class Package:
             f.write(simple_page_content)
         self.mirror.diff_file_list.append(full_version_path)
 
-        symlink_path = self.normalized_simple_directory / "index.html"
+        symlink_path = self.simple_directory / "index.html"
         if symlink_path.exists() or symlink_path.is_symlink():
             symlink_path.unlink()
 
         symlink_path.symlink_to(full_version_path)
 
     def _prepare_versions_path(self) -> Path:
-        versions_path = Path(self.normalized_simple_directory) / "versions"
+        versions_path = Path(self.simple_directory) / "versions"
         try:
             versions_path.mkdir()
         except FileExistsError:
@@ -383,10 +420,8 @@ class Package:
                 return None
             else:
                 logger.info(
-                    "Checksum mismatch with local file {}: "
-                    "expected {} got {}, will re-download.".format(
-                        path, sha256sum, existing_hash
-                    )
+                    f"Checksum mismatch with local file {path}: expected {sha256sum} "
+                    + f"got {existing_hash}, will re-download."
                 )
                 path.unlink()
 

--- a/src/bandersnatch/tests/ci.conf
+++ b/src/bandersnatch/tests/ci.conf
@@ -3,6 +3,7 @@
 [mirror]
 directory = /tmp/pypi
 json = true
+cleanup = true
 master = https://pypi.org
 timeout = 10
 workers = 3

--- a/src/bandersnatch/tests/conftest.py
+++ b/src/bandersnatch/tests/conftest.py
@@ -33,7 +33,41 @@ def never_sleep(request):
 
 
 @pytest.fixture
-def master():
+def package_json():
+    return {
+        "info": {"name": "foo", "version": "0.1"},
+        "last_serial": 654_321,
+        "releases": {
+            "0.1": [
+                {
+                    "url": "https://pypi.example.com/packages/any/f/foo/foo.zip",
+                    "filename": "foo.zip",
+                    "digests": {
+                        "md5": "6bd3ddc295176f4dca196b5eb2c4d858",
+                        "sha256": (
+                            "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                        ),
+                    },
+                    "md5_digest": "b6bcb391b040c4468262706faf9d3cce",
+                },
+                {
+                    "url": "https://pypi.example.com/packages/2.7/f/foo/foo.whl",
+                    "filename": "foo.whl",
+                    "digests": {
+                        "md5": "6bd3ddc295176f4dca196b5eb2c4d858",
+                        "sha256": (
+                            "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                        ),
+                    },
+                    "md5_digest": "6bd3ddc295176f4dca196b5eb2c4d858",
+                },
+            ]
+        },
+    }
+
+
+@pytest.fixture
+def master(package_json):
     from bandersnatch.master import Master
 
     class FakeReader:
@@ -54,36 +88,7 @@ def master():
             return FakeReader()
 
         async def json(self, *args):
-            return {
-                "info": {"name": "foo", "version": "0.1"},
-                "last_serial": 654_321,
-                "releases": {
-                    "0.1": [
-                        {
-                            "url": "https://pypi.example.com/packages/any/f/foo/foo.zip",
-                            "filename": "foo.zip",
-                            "digests": {
-                                "md5": "6bd3ddc295176f4dca196b5eb2c4d858",
-                                "sha256": (
-                                    "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
-                                ),
-                            },
-                            "md5_digest": "b6bcb391b040c4468262706faf9d3cce",
-                        },
-                        {
-                            "url": "https://pypi.example.com/packages/2.7/f/foo/foo.whl",
-                            "filename": "foo.whl",
-                            "digests": {
-                                "md5": "6bd3ddc295176f4dca196b5eb2c4d858",
-                                "sha256": (
-                                    "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
-                                ),
-                            },
-                            "md5_digest": "6bd3ddc295176f4dca196b5eb2c4d858",
-                        },
-                    ]
-                },
-            }
+            return package_json
 
     master = Master("https://pypi.example.com")
     master.rpc = mock.Mock()

--- a/src/bandersnatch/tests/test_configuration.py
+++ b/src/bandersnatch/tests/test_configuration.py
@@ -49,6 +49,7 @@ class TestBandersnatchConf(TestCase):
         self.assertListEqual(
             options,
             [
+                "cleanup",
                 "directory",
                 "hash-index",
                 "json",

--- a/src/bandersnatch/tests/test_main.py
+++ b/src/bandersnatch/tests/test_main.py
@@ -72,6 +72,7 @@ def test_main_reads_config_values(mirror_mock: mock.MagicMock):
         "diff_file": "/tmp/pypi/mirrored-files",
         "diff_append_epoch": False,
         "diff_full_path": "/tmp/pypi/mirrored-files",
+        "cleanup": False,
     } == kwargs
 
 

--- a/src/bandersnatch/tests/test_package.py
+++ b/src/bandersnatch/tests/test_package.py
@@ -2,6 +2,7 @@ import os.path
 import unittest.mock as mock
 from datetime import datetime
 from pathlib import Path
+from tempfile import gettempdir
 from typing import List
 
 import pytest
@@ -38,6 +39,14 @@ async def test_cleanup_non_pep_503_paths(mirror):
     with mock.patch("bandersnatch.package.rmtree") as mocked_rmtree:
         await package.cleanup_non_pep_503_paths()
         assert mocked_rmtree.call_count == 1
+
+
+def test_save_json_metadata(mirror, package_json):
+    package = Package("foo", 11, mirror)
+    package.json_file.parent.mkdir(parents=True)
+    package.json_pypi_symlink.parent.mkdir(parents=True)
+    package.json_pypi_symlink.symlink_to(Path(gettempdir()))
+    assert package.save_json_metadata(package_json)
 
 
 @pytest.mark.asyncio

--- a/src/bandersnatch/tests/test_package.py
+++ b/src/bandersnatch/tests/test_package.py
@@ -26,6 +26,21 @@ def touch_files(paths: List[Path]):
 
 
 @pytest.mark.asyncio
+async def test_cleanup_non_pep_503_paths(mirror):
+    raw_package_name = "CatDogPython69"
+    package = Package(raw_package_name, 11, mirror)
+    await package.cleanup_non_pep_503_paths()
+
+    # Create a non normailized directory
+    touch_files([Path(f"web/simple/{raw_package_name}/index.html")])
+
+    package.cleanup = True
+    with mock.patch("bandersnatch.package.rmtree") as mocked_rmtree:
+        await package.cleanup_non_pep_503_paths()
+        assert mocked_rmtree.call_count == 1
+
+
+@pytest.mark.asyncio
 async def test_package_sync_404_json_info_keeps_package_on_non_deleting_mirror(mirror,):
     mirror.master.package_releases = mock.Mock()
     mirror.master.package_releases.return_value = {}

--- a/src/bandersnatch/unittest.conf
+++ b/src/bandersnatch/unittest.conf
@@ -5,6 +5,9 @@ directory = /srv/pypi
 ; URL/pypi/PKG_NAME/json (Symlink) -> URL/json/PKG_NAME
 json = false
 
+; Cleanup legacy non PEP 503 normalized named simple directories
+cleanup = false
+
 ; The PyPI server which will be mirrored.
 ; master = https://test.python.org
 ; scheme for PyPI server MUST be https

--- a/src/bandersnatch/verify.py
+++ b/src/bandersnatch/verify.py
@@ -57,7 +57,7 @@ async def delete_unowned_files(
     dry_run: bool,
 ) -> int:
     loop = asyncio.get_event_loop()
-    packages_path = Path(mirror_base) / "web/packages"
+    packages_path = Path(mirror_base) / "web" / "packages"
     all_fs_files = set()  # type: Set[Path]
     await loop.run_in_executor(
         executor, recursive_find_files, all_fs_files, packages_path


### PR DESCRIPTION
- No longer need to store the Simple API other than PEP normalized name
- Add a cleanup function to remove uneeded directories from existing mirrors

Tests:
- Add a unit test for cleanup
- Ensure current unittests pass
- See CI run pass