### PR TITLE
Windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,6 +89,9 @@ ENV/
 # Rope project settings
 .ropeproject
 
+# VSCode project settings
+.vscode/
+
 /.coverage
 .tox/
 artifacts/*.xml

--- a/src/bandersnatch/mirror.py
+++ b/src/bandersnatch/mirror.py
@@ -124,11 +124,12 @@ class Mirror:
         processing."""
         if self.todolist.exists():
             try:
-                saved_todo = iter(open(self.todolist, encoding="utf-8"))
-                int(next(saved_todo).strip())
-                for line in saved_todo:
-                    _, serial = line.strip().split()
-                    int(serial)
+                with open(self.todolist, encoding="utf-8") as f:
+                    saved_todo = iter(f)
+                    int(next(saved_todo).strip())
+                    for line in saved_todo:
+                        _, serial = line.strip().split()
+                        int(serial)
             except (StopIteration, ValueError):
                 # The todo list was inconsistent. This may happen if we get
                 # killed e.g. by the timeout wrapper. Just remove it - we'll

--- a/src/bandersnatch/package.py
+++ b/src/bandersnatch/package.py
@@ -30,10 +30,6 @@ if TYPE_CHECKING:  # pragma: no cover
 display_filter_log = True
 logger = logging.getLogger(__name__)
 
-# Bool to help with some Windows-related path operations
-if sys.platform == "win32":
-    is_windows = True
-
 
 class Package:
 

--- a/src/bandersnatch/package.py
+++ b/src/bandersnatch/package.py
@@ -4,7 +4,6 @@ import html
 import logging
 import os.path
 import sys
-from datetime import datetime
 from json import dump
 from pathlib import Path
 from shutil import rmtree
@@ -30,6 +29,10 @@ if TYPE_CHECKING:  # pragma: no cover
 # Bool to help us not spam the logs with certain log messages
 display_filter_log = True
 logger = logging.getLogger(__name__)
+
+# Bool to help with some Windows-related path operations
+if sys.platform == "win32":
+    is_windows = True
 
 
 class Package:
@@ -366,7 +369,7 @@ class Package:
 
     def _save_simple_page_version(self, simple_page_content: str) -> None:
         versions_path = self._prepare_versions_path()
-        timestamp = datetime.utcnow().isoformat() + "Z"
+        timestamp = utils.make_time_stamp()
         version_file_name = f"index_{self.serial}_{timestamp}.html"
         full_version_path = versions_path / version_file_name
         with utils.rewrite(full_version_path, "w", encoding="utf-8") as f:

--- a/src/bandersnatch/tests/test_delete.py
+++ b/src/bandersnatch/tests/test_delete.py
@@ -1,3 +1,4 @@
+import os
 from argparse import Namespace
 from configparser import ConfigParser
 from json import loads
@@ -13,34 +14,38 @@ from bandersnatch.utils import find
 
 EXPECTED_WEB_BEFORE_DELETION = """\
 json
-json/cooper
-json/unittest
+json{0}cooper
+json{0}unittest
 packages
-packages/69
-packages/69/cooper-6.9.tar.gz
-packages/69/unittest-6.9.tar.gz
-packages/7b
-packages/7b/cooper-6.9-py3-none-any.whl
-packages/7b/unittest-6.9-py3-none-any.whl
+packages{0}69
+packages{0}69{0}cooper-6.9.tar.gz
+packages{0}69{0}unittest-6.9.tar.gz
+packages{0}7b
+packages{0}7b{0}cooper-6.9-py3-none-any.whl
+packages{0}7b{0}unittest-6.9-py3-none-any.whl
 pypi
-pypi/cooper
-pypi/cooper/json
-pypi/unittest
-pypi/unittest/json
+pypi{0}cooper
+pypi{0}cooper{0}json
+pypi{0}unittest
+pypi{0}unittest{0}json
 simple
-simple/cooper
-simple/cooper/index.html
-simple/unittest
-simple/unittest/index.html\
-"""
+simple{0}cooper
+simple{0}cooper{0}index.html
+simple{0}unittest
+simple{0}unittest{0}index.html\
+""".format(
+    os.sep
+)
 EXPECTED_WEB_AFTER_DELETION = """\
 json
 packages
-packages/69
-packages/7b
+packages{0}69
+packages{0}7b
 pypi
 simple\
-"""
+""".format(
+    os.sep
+)
 MOCK_JSON_TEMPLATE = """{
     "releases": {
         "6.9": [

--- a/src/bandersnatch/tests/test_utils.py
+++ b/src/bandersnatch/tests/test_utils.py
@@ -15,6 +15,7 @@ from bandersnatch.utils import (  # isort:skip
     rewrite,
     unlink_parent_dir,
     user_agent,
+    WINDOWS,
 )
 
 
@@ -66,9 +67,7 @@ def test_rewrite(tmpdir, monkeypatch):
     assert open("sample").read() == "csdf"
     mode = os.stat("sample").st_mode
     # chmod doesn't work on windows machines. Permissions are pinned at 666
-    if sys.platform == "win32":
-        assert True
-    else:
+    if not WINDOWS:
         assert oct(mode) == "0o100644"
 
 

--- a/src/bandersnatch/tests/test_utils.py
+++ b/src/bandersnatch/tests/test_utils.py
@@ -1,7 +1,6 @@
 import os
 import os.path
 import re
-import sys
 from pathlib import Path
 from tempfile import TemporaryDirectory, gettempdir
 

--- a/src/bandersnatch/tests/test_utils.py
+++ b/src/bandersnatch/tests/test_utils.py
@@ -65,7 +65,11 @@ def test_rewrite(tmpdir, monkeypatch):
         f.write("csdf")
     assert open("sample").read() == "csdf"
     mode = os.stat("sample").st_mode
-    assert oct(mode) == "0o100644"
+    # chmod doesn't work on windows machines. Permissions are pinned at 666
+    if sys.platform == "win32":
+        assert True
+    else:
+        assert oct(mode) == "0o100644"
 
 
 def test_rewrite_fails(tmpdir, monkeypatch):

--- a/src/bandersnatch/tests/test_utils.py
+++ b/src/bandersnatch/tests/test_utils.py
@@ -1,6 +1,7 @@
 import os
 import os.path
 import re
+import sys
 from pathlib import Path
 from tempfile import TemporaryDirectory, gettempdir
 

--- a/src/bandersnatch/tests/test_verify.py
+++ b/src/bandersnatch/tests/test_verify.py
@@ -1,5 +1,5 @@
+import os
 from concurrent.futures import ThreadPoolExecutor
-from os import getpid
 from pathlib import Path
 from shutil import rmtree
 from tempfile import gettempdir
@@ -45,7 +45,7 @@ class FakeConfig:
 # TODO: Support testing sharded simple dirs
 class FakeMirror:
     def __init__(self, entropy: str = "") -> None:
-        self.mirror_base = Path(gettempdir()) / f"pypi_unittest_{getpid()}{entropy}"
+        self.mirror_base = Path(gettempdir()) / f"pypi_unittest_{os.getpid()}{entropy}"
         if self.mirror_base.exists():
             return
         self.web_base = self.mirror_base / "web"
@@ -132,27 +132,29 @@ async def test_async_verify(monkeypatch):
 def test_fake_mirror():
     expected_mirror_layout = """\
 web
-web/json
-web/json/bandersnatch
-web/json/black
-web/packages
-web/packages/8f
-web/packages/8f/1a
-web/packages/8f/1a/1aa0
-web/packages/8f/1a/1aa0/black-2019.6.9.tar.gz
-web/packages/8f/1a/6969
-web/packages/8f/1a/6969/bandersnatch-0.6.9.tar.gz
-web/packages/8f/1a/6969/black-2018.6.9.tar.gz
-web/pypi
-web/pypi/bandersnatch
-web/pypi/bandersnatch/json
-web/pypi/black
-web/pypi/black/json
-web/simple
-web/simple/bandersnatch
-web/simple/bandersnatch/index.html
-web/simple/black
-web/simple/black/index.html"""
+web{0}json
+web{0}json{0}bandersnatch
+web{0}json{0}black
+web{0}packages
+web{0}packages{0}8f
+web{0}packages{0}8f{0}1a
+web{0}packages{0}8f{0}1a{0}1aa0
+web{0}packages{0}8f{0}1a{0}1aa0{0}black-2019.6.9.tar.gz
+web{0}packages{0}8f{0}1a{0}6969
+web{0}packages{0}8f{0}1a{0}6969{0}bandersnatch-0.6.9.tar.gz
+web{0}packages{0}8f{0}1a{0}6969{0}black-2018.6.9.tar.gz
+web{0}pypi
+web{0}pypi{0}bandersnatch
+web{0}pypi{0}bandersnatch{0}json
+web{0}pypi{0}black
+web{0}pypi{0}black{0}json
+web{0}simple
+web{0}simple{0}bandersnatch
+web{0}simple{0}bandersnatch{0}index.html
+web{0}simple{0}black
+web{0}simple{0}black{0}index.html""".format(
+        os.sep
+    )
     fm = FakeMirror("_mirror_base_test")
     assert expected_mirror_layout == find(str(fm.mirror_base), True)
     fm.clean_up()
@@ -178,7 +180,7 @@ async def test_delete_unowned_files() -> None:
 async def test_get_latest_json(monkeypatch):
     config = FakeConfig()
     executor = ThreadPoolExecutor(max_workers=2)
-    json_path = Path(gettempdir()) / f"unittest_{getpid()}.json"
+    json_path = Path(gettempdir()) / f"unittest_{os.getpid()}.json"
     monkeypatch.setattr(bandersnatch.verify, "url_fetch", do_nothing)
     await get_latest_json(json_path, config, executor)
 

--- a/src/bandersnatch/utils.py
+++ b/src/bandersnatch/utils.py
@@ -5,6 +5,7 @@ import logging
 import os
 import os.path
 import platform
+import shutil
 import sys
 import tempfile
 from pathlib import Path
@@ -95,7 +96,7 @@ def rewrite(
         # put in place actually but also doesn't want to error out.
         return
     os.chmod(filepath_tmp, 0o100644)
-    os.rename(filepath_tmp, filepath)
+    shutil.move(filepath_tmp, filepath)
 
 
 def recursive_find_files(files: Set[Path], base_dir: Path):
@@ -142,5 +143,5 @@ def update_safe(filename: str, **kw: Any) -> Generator[IO, None, None]:
     if os.path.exists(filename) and filecmp.cmp(filename, filename_tmp, shallow=False):
         os.unlink(filename_tmp)
     else:
-        os.rename(filename_tmp, filename)
+        shutil.move(filename_tmp, filename)
         tf.has_changed = True  # type: ignore

--- a/src/bandersnatch/utils.py
+++ b/src/bandersnatch/utils.py
@@ -32,6 +32,7 @@ def user_agent() -> str:
 
 
 USER_AGENT = user_agent()
+WINDOWS = bool(platform.system() == 'Windows')
 
 
 def make_time_stamp() -> str:

--- a/src/bandersnatch/utils.py
+++ b/src/bandersnatch/utils.py
@@ -32,7 +32,7 @@ def user_agent() -> str:
 
 
 USER_AGENT = user_agent()
-WINDOWS = bool(platform.system() == 'Windows')
+WINDOWS = bool(platform.system() == "Windows")
 
 
 def make_time_stamp() -> str:

--- a/src/bandersnatch/utils.py
+++ b/src/bandersnatch/utils.py
@@ -35,7 +35,8 @@ USER_AGENT = user_agent()
 
 
 def make_time_stamp() -> str:
-    """Helper function that returns a timestamp suitable for use in a filename on any OS"""
+    """Helper function that returns a timestamp suitable for use
+    in a filename on any OS"""
     return f"{datetime.utcnow().isoformat()}Z".replace(":", "")
 
 

--- a/src/bandersnatch/utils.py
+++ b/src/bandersnatch/utils.py
@@ -8,6 +8,7 @@ import platform
 import shutil
 import sys
 import tempfile
+from datetime import datetime
 from pathlib import Path
 from typing import IO, Any, Generator, List, Set, Union
 from urllib.parse import urlparse
@@ -31,6 +32,11 @@ def user_agent() -> str:
 
 
 USER_AGENT = user_agent()
+
+
+def make_time_stamp() -> str:
+    """Helper function that returns a timestamp suitable for use in a filename on any OS"""
+    return f"{datetime.utcnow().isoformat()}Z".replace(":", "")
 
 
 def convert_url_to_path(url: str) -> str:

--- a/src/bandersnatch/verify.py
+++ b/src/bandersnatch/verify.py
@@ -3,12 +3,12 @@ import concurrent.futures
 import json
 import logging
 import os
+import shutil
 from argparse import Namespace
 from asyncio.queues import Queue
 from configparser import ConfigParser
 from functools import partial
 from pathlib import Path
-import shutil
 from sys import stderr
 from typing import List, Set  # noqa: F401
 from urllib.parse import urlparse

--- a/src/bandersnatch/verify.py
+++ b/src/bandersnatch/verify.py
@@ -8,6 +8,7 @@ from asyncio.queues import Queue
 from configparser import ConfigParser
 from functools import partial
 from pathlib import Path
+import shutil
 from sys import stderr
 from typing import List, Set  # noqa: F401
 from urllib.parse import urlparse
@@ -40,7 +41,7 @@ async def get_latest_json(
     new_json_path = json_path.parent / f"{json_path.name}.new"
     await url_fetch(url, new_json_path, executor)
     if new_json_path.exists():
-        os.rename(new_json_path, json_path)
+        shutil.move(new_json_path, json_path)
     else:
         logger.error(
             f"{str(new_json_path)} does not exist - Did not get new JSON metadata"


### PR DESCRIPTION
This pull request adds some Windows support and tries to fix some tests that otherwise fail when run on a Windows 10 system. Related to issue #459 
 * A lot of fixing paths to use the right separator
 * Ignoring a test of chmod (which doesn't work on Windows)
 * Replacing os.rename with shutil.move or else Windows freaks if it has to overwrite an existing file
 * Moves a file open operation into a 'with' context block to ensure it gets closed if an exception is thrown. This allows that file to later be unlinked without Windows complaining.

This doesn't solve all the failed tests, but if I run the tests in an elevated command prompt (so that symlinking works) I've whittled it down from 20 failures to 4 failures, and those failures don't seem to impact the functionality (too much). They are:

```
======================================================================== short test summary info ========================================================================
FAILED src/bandersnatch/tests/test_mirror.py::test_mirror_empty_resume_from_todo_list - AssertionError: assert '.lock\ngener...e\\index.html' == 'generation\n...e\\ind...
FAILED src/bandersnatch/tests/test_mirror.py::test_mirror_sync_package_error_no_early_exit - AssertionError: assert '.lock\ngener...e\\index.html' == 'generation\n...e...
FAILED src/bandersnatch/tests/test_package.py::test_cleanup_non_pep_503_paths - AssertionError: assert 0 == 1
FAILED src/bandersnatch/tests/test_utils.py::test_hash - AssertionError: assert '91ef8f60d130...7543b34bfb372' == '125765989403...cb48fa3e87ff8'
```

There are still some issues however. When I test this on my system, everything works, but bandersnatch errors out with:

```
Exception ignored in: <function _ProactorBasePipeTransport.__del__ at 0x0000018276D2FF70>                                      
Traceback (most recent call last):                                                                                             
  File "C:\Users\fwcarter\AppData\Local\Continuum\anaconda3\envs\btest\lib\asyncio\proactor_events.py", line 116, in __del__   
    self.close()                                                                                                               
  File "C:\Users\fwcarter\AppData\Local\Continuum\anaconda3\envs\btest\lib\asyncio\proactor_events.py", line 108, in close     
    self._loop.call_soon(self._call_connection_lost, None)                                                                     
  File "C:\Users\fwcarter\AppData\Local\Continuum\anaconda3\envs\btest\lib\asyncio\base_events.py", line 715, in call_soon     
    self._check_closed()                                                                                                       
  File "C:\Users\fwcarter\AppData\Local\Continuum\anaconda3\envs\btest\lib\asyncio\base_events.py", line 508, in _check_closed 
    raise RuntimeError('Event loop is closed')                                                                                 
RuntimeError: Event loop is closed                                                                                             
```

Also, it looks like some of the builds aren't passing for one reason or another.

In any case, this doesn't fix all the problems, but bandersnatch is at least useable on my system now and it's a step in the right direction.