### PR TITLE
Fix deletion of finished Packages

### DIFF
--- a/src/bandersnatch/package.py
+++ b/src/bandersnatch/package.py
@@ -90,7 +90,6 @@ class Package:
             self.raw_simple_directory,
             self.normalized_legacy_simple_directory,
         ):
-            logger.debug(f"Checking if {deprecated_dir} != {self.simple_directory}")
             # Had to compare path strs as Windows did not match path objects ...
             if str(deprecated_dir) != str(self.simple_directory):
                 if not deprecated_dir.exists():
@@ -170,7 +169,8 @@ class Package:
 
                     await self.sync_release_files()
                     self.sync_simple_page()
-                    self.mirror.record_finished_package(self.name)
+                    # XMLRPC PyPI Endpoint stores raw_name so we need to provide it
+                    self.mirror.record_finished_package(self.raw_name)
                     break
                 except StalePage:
                     self.tries += 1

--- a/src/bandersnatch/tests/ci.conf
+++ b/src/bandersnatch/tests/ci.conf
@@ -18,6 +18,7 @@ enabled =
 
 [whitelist]
 packages =
+    ACMPlus
     black
     peerme
     pyaib

--- a/src/bandersnatch/tests/conftest.py
+++ b/src/bandersnatch/tests/conftest.py
@@ -35,7 +35,7 @@ def never_sleep(request):
 @pytest.fixture
 def package_json():
     return {
-        "info": {"name": "foo", "version": "0.1"},
+        "info": {"name": "Foo", "version": "0.1"},
         "last_serial": 654_321,
         "releases": {
             "0.1": [


### PR DESCRIPTION
- XMLRPC returns the raw_name
- Keeping raw_name to store this in the Simple HTML

Tests:
- Added new test `test_package_sync_handles_non_pep_503_in_packages_to_sync` that failed with using Foo as a package to sync
  - This test does not use all normal PyTest fixtures on purpose
- Added more asserts around Mirror.errors
- Returned Foo from mocked out XMLRPC return
- Fixed a few tests with other little bugs uncovered by `assert not mirror.errors`
- Added `ACMPlus` to CI Integration run

Addresses part of #470
- Still need to workout if we want to normalize all the plugin names and compare the XMLRPC returned lists with their normalized named to avoid typos etc.