### PR TITLE
Add unittest for new utils.safe_name

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ attrs==19.3.0
 chardet==3.0.4
 filelock==3.0.12
 idna==2.9
+importlib_resources==1.4.0; python_version < '3.7'
 lxml==4.5.0
 multidict==4.7.5
 packaging==20.3

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,6 +24,7 @@ install_requires =
     aiohttp
     aiohttp-xmlrpc
     filelock
+    importlib_resources; python_version < '3.7'
     packaging
     setuptools>40.0.0
 package_dir =

--- a/src/bandersnatch/package.py
+++ b/src/bandersnatch/package.py
@@ -40,7 +40,7 @@ class Package:
     ) -> None:
         self.name = canonicalize_name(name)
         self.raw_name = name
-        self.normalized_name_legacy = utils.safe_name(name).lower()
+        self.normalized_name_legacy = utils.bandersnatch_safe_name(name)
         self.serial = serial
         self.mirror = mirror
         self.cleanup = cleanup

--- a/src/bandersnatch/tests/test_utils.py
+++ b/src/bandersnatch/tests/test_utils.py
@@ -8,6 +8,7 @@ import aiohttp
 import pytest
 
 from bandersnatch.utils import (  # isort:skip
+    bandersnatch_safe_name,
     convert_url_to_path,
     hash,
     recursive_find_files,
@@ -111,3 +112,8 @@ def test_user_agent():
         + fr"\(aiohttp {aiohttp.__version__}\)",
         user_agent(),
     )
+
+
+def test_bandersnatch_safe_name():
+    bad_name = "Flake_8_Fake"
+    assert "flake-8-fake" == bandersnatch_safe_name(bad_name)

--- a/src/bandersnatch/utils.py
+++ b/src/bandersnatch/utils.py
@@ -32,6 +32,7 @@ def user_agent() -> str:
     return template.format(**locals())
 
 
+SAFE_NAME_REGEX = re.compile(r"[^A-Za-z0-9.]+")
 USER_AGENT = user_agent()
 WINDOWS = bool(platform.system() == "Windows")
 
@@ -156,8 +157,12 @@ def update_safe(filename: str, **kw: Any) -> Generator[IO, None, None]:
         tf.has_changed = True  # type: ignore
 
 
-def safe_name(name):
+def bandersnatch_safe_name(name: str) -> str:
     """Convert an arbitrary string to a standard distribution name
     Any runs of non-alphanumeric/. characters are replaced with a single '-'.
+
+    - This was copied from `pkg_resources` (part of `setuptools`)
+
+    bandersnatch also lower cases the returned name
     """
-    return re.sub("[^A-Za-z0-9.]+", "-", name)
+    return SAFE_NAME_REGEX.sub("-", name).lower()


### PR DESCRIPTION
- Add missing dependencies for importlib_resources from #479
- Rename utils.safe_name to bandersnatch_safe_name
- Also now pre-compile the safe_name regex
- Add unittest for bandersnatch_safe_name