### PR TITLE
Add GH Action for pushing to Docker Hub on Release

### DIFF
--- a/.github/workflows/docker_upload.yml
+++ b/.github/workflows/docker_upload.yml
@@ -17,3 +17,4 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
           snapshot: true
+          tag_names: true


### PR DESCRIPTION
Added the Github Action for automating pushing the `pypa/bandersnatch`
image to Docker Hub when a new release in published.

Closes https://github.com/pypa/bandersnatch/issues/88