### PR TITLE
Raise error for bad response (#494)

### DIFF
--- a/src/bandersnatch/master.py
+++ b/src/bandersnatch/master.py
@@ -41,6 +41,7 @@ class Master:
             skip_auto_headers=skip_headers,
             timeout=aiohttp_timeout,
             trust_env=True,
+            raise_for_status=True,
         )
         return self
 

--- a/src/bandersnatch/tests/test_master.py
+++ b/src/bandersnatch/tests/test_master.py
@@ -1,5 +1,6 @@
 import asynctest
 import pytest
+from asynctest import asynctest
 
 import bandersnatch
 from bandersnatch.master import Master, StalePage, XmlRpcError
@@ -69,3 +70,13 @@ async def test_master_doesnt_raise_if_serial_equal(master):
 async def test_xmlrpc_user_agent(master):
     client = await master._gen_xmlrpc_client()
     assert f"bandersnatch {bandersnatch.__version__}" in client.headers["User-Agent"]
+
+
+@pytest.mark.asyncio
+async def test_session_raise_for_status(master):
+    patcher = asynctest.patch("aiohttp.ClientSession", autospec=True)
+    with patcher as create_session:
+        async with master:
+            pass
+        assert len(create_session.call_args_list) == 1
+        assert create_session.call_args_list[0][1]["raise_for_status"]


### PR DESCRIPTION
I am not sure about the unit test. I think we should only test correct argument is passed to aiohttp, whether aiohttp actually raise the exception should tested in aiohttp itself.