### PR TITLE
Add more detailed platform choices

### DIFF
--- a/src/bandersnatch/tests/plugins/test_filename.py
+++ b/src/bandersnatch/tests/plugins/test_filename.py
@@ -53,7 +53,9 @@ enabled =
 [blacklist]
 platforms =
     windows
-    freebsd macos
+    freebsd
+    macos
+    linux-armv7l
 """
 
     def test_plugin_compiles_patterns(self):
@@ -65,7 +67,13 @@ platforms =
             type(plugin) == filename_name.ExcludePlatformFilter for plugin in plugins
         )
 
-    def test_exclude_platform_keep_linux(self):
+    def test_exclude_platform(self):
+        """
+        Tests the platform filter for what it will keep and excluded
+        based on the config provided. It is expected to drop all windows,
+        freebsd and macos packages while only dropping linux-armv7l from
+        linux packages
+        """
         _mock_config(self.config_contents)
 
         bandersnatch.filter.filter_release_plugins()
@@ -104,6 +112,16 @@ platforms =
                     "packagetype": "bdist_wheel",
                     "filename": "foobar-1.0-linux.tar.gz",
                     "flag": "KEEP",
+                },
+                {
+                    "packagetype": "bdist_wheel",
+                    "filename": "foobar-1.0-manylinux1_i686.whl",
+                    "flag": "KEEP",
+                },
+                {
+                    "packagetype": "bdist_wheel",
+                    "filename": "foobar-1.0-linux_armv7l.whl",
+                    "flag": "DROP",
                 },
                 {
                     "packagetype": "bdist_wheel",

--- a/src/bandersnatch_filter_plugins/filename_name.py
+++ b/src/bandersnatch_filter_plugins/filename_name.py
@@ -16,6 +16,19 @@ class ExcludePlatformFilter(FilterReleasePlugin):
     _patterns: List[str] = []
     _packagetypes: List[str] = []
 
+    _windowsPlatformTypes = [".win32", "-win32", "win_amd64", "win-amd64"]
+
+    _linuxPlatformTypes = [
+        "linux-i686",  # PEP 425
+        "linux-x86_64",  # PEP 425
+        "linux_armv7l",  # https://github.com/pypa/warehouse/pull/2010
+        "linux_armv6l",  # https://github.com/pypa/warehouse/pull/2012
+        "manylinux1_i686",  # PEP 513
+        "manylinux1_x86_64",  # PEP 513
+        "manylinux2010_i686",  # PEP 571
+        "manylinux2010_x86_64",  # PEP 571
+    ]
+
     def initialize_plugin(self):
         """
         Initialize the plugin reading patterns from the config.
@@ -39,7 +52,7 @@ class ExcludePlatformFilter(FilterReleasePlugin):
             if lplatform in ("windows", "win"):
                 # PEP 425
                 # see also setuptools/package_index.py
-                self._patterns.extend([".win32", "-win32", "win_amd64", "win-amd64"])
+                self._patterns.extend(self._windowsPlatformTypes)
                 # PEP 527
                 self._packagetypes.extend(["bdist_msi", "bdist_wininst"])
 
@@ -52,17 +65,15 @@ class ExcludePlatformFilter(FilterReleasePlugin):
                 self._patterns.extend([".freebsd", "-freebsd"])
 
             elif lplatform in ("linux"):
-                self._patterns.extend(
-                    [
-                        "linux-i686",  # PEP 425
-                        "linux-x86_64",  # PEP 425
-                        "linux_armv7l",  # https://github.com/pypa/warehouse/pull/2010
-                        "linux_armv6l",  # https://github.com/pypa/warehouse/pull/2012
-                        "manylinux1_",  # PEP 513
-                        "manylinux2010_",  # PEP 571
-                    ]
-                )
+                self._patterns.extend(self.linuxPlatformTypes)
                 self._packagetypes.extend(["bdist_rpm"])
+
+            # check for platform specific architectures
+            elif lplatform in self._windowsPlatformTypes:
+                self._patterns.extend([lplatform])
+
+            elif lplatform in self._linuxPlatformTypes:
+                self._patterns.extend([lplatform])
 
         logger.info(f"Initialized {self.name} plugin with {self._patterns!r}")
 

--- a/src/bandersnatch_filter_plugins/filename_name.py
+++ b/src/bandersnatch_filter_plugins/filename_name.py
@@ -65,7 +65,7 @@ class ExcludePlatformFilter(FilterReleasePlugin):
                 self._patterns.extend([".freebsd", "-freebsd"])
 
             elif lplatform in ("linux"):
-                self._patterns.extend(self.linuxPlatformTypes)
+                self._patterns.extend(self._linuxPlatformTypes)
                 self._packagetypes.extend(["bdist_rpm"])
 
             # check for platform specific architectures


### PR DESCRIPTION
I required more detailed platform selection to minimise the size of my mirrors. This will allow you to blacklist specific platforms within a platform set. For example you can exclude linux-armv7l but still mirror all other linux platforms.