### PR TITLE
Remove Travis 3.8 tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: python
-dist: xenial
 
 env:
   global:
@@ -8,18 +7,19 @@ env:
 matrix:
   fast_finish: true
   include:
-    - python: 3.7
+    - python: 3.8
       env: TOXENV=doc_build
-    - python: 3.7
+    - python: 3.8
       env: TOXENV=lint
-    - python: 3.8
+    - python: nightly
       env: TOXENV=INTEGRATION
-    - python: 3.8
-      env: TOXENV=py38
     - python: nightly
       env: TOXENV=py3
   allow_failures:
     - python: nightly
+      env: TOXENV=INTEGRATION
+    - python: nightly
+      env: TOXENV=py3
 
 install:
     - pip install --upgrade pip setuptools


### PR DESCRIPTION
- Travis is still on 3.8.0 while GitHub Actions is on 3.8.2
- Remove to stop uneeded duplication on old version of 3.8
- Add an integration run to nightly + allow to fail
- Don't hard code the dist to allow travis to change in the future as they upgrade