### PR TITLE
Move bandersnatch *.conf to setup.cfg

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,0 @@
-include MANIFEST.in
-include CHANGES.md
-include requirements.txt

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,3 @@
 include MANIFEST.in
 include CHANGES.md
 include requirements.txt
-include src/bandersnatch/default.conf
-include src/bandersnatch/unittest.conf
-include src/bandersnatch/unittest-deprecated.conf

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,6 +35,9 @@ python_requires = >=3.6
 [options.packages.find]
 where=src
 
+[options.package_data]
+bandersnatch = *.conf
+
 [options.entry_points]
 bandersnatch_storage_plugins.v1.backend =
     swift_plugin = bandersnatch_storage_plugins.swift:SwiftStorage

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,7 +19,6 @@ url = https://github.com/pypa/bandersnatch/
 version = 4.1.0.dev0
 
 [options]
-include_package_data = True
 install_requires =
     aiohttp
     aiohttp-xmlrpc


### PR DESCRIPTION
- Remove from MANIFEST.in and to package_data
- See if this helps the docker building

Testing:
1)
```
python3 -m venv /tmp/build_bs
/tmp/build_bs/bin/pip install --upgrade setuptools pip wheel
/tmp/build_bs/bin/python setup.py sdist
...
copying src/bandersnatch/default.conf -> bandersnatch-4.0.3/src/bandersnatch
copying src/bandersnatch/unittest.conf -> bandersnatch-4.0.3/src/bandersnatch
...
```

2)
```
tar xvzf bandersnatch-4.0.3.tar.gz
cooper-mbp1:dist cooper$ find bandersnatch-4.0.3 -name '*.conf'
bandersnatch-4.0.3/src/bandersnatch/unittest.conf
bandersnatch-4.0.3/src/bandersnatch/default.conf
```

Might help with #509 