### PR TITLE
Move swift deps to be a true extra install

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.5.0
+    rev: v3.1.0
     hooks:
     -   id: trailing-whitespace
     -   id: end-of-file-fixer
@@ -13,7 +13,7 @@ repos:
     -   id: black
         args: [--target-version, py36]
 -   repo: https://github.com/asottile/pyupgrade
-    rev: v2.3.0
+    rev: v2.4.4
     hooks:
     -   id: pyupgrade
         args: [--py36-plus]

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ RUN mkdir /conf && chmod 777 /conf
 ADD setup.cfg /bandersnatch
 ADD setup.py /bandersnatch
 ADD requirements.txt /bandersnatch
+ADD requirements_swift.txt /bandersnatch
 ADD README.md /bandersnatch
 ADD CHANGES.md /bandersnatch
 COPY src /bandersnatch/src
@@ -14,8 +15,8 @@ COPY src /bandersnatch/src
 # Reccomended to bind mount /conf - `runner.py` defaults to look for /conf/bandersnatch.conf
 # ADD bandersnatch.conf /etc
 
-RUN pip install --upgrade pip setuptools wheel
-RUN pip install --upgrade -r /bandersnatch/requirements.txt
-RUN pip -v install /bandersnatch/
+RUN pip --no-cache-dir install --upgrade pip setuptools wheel
+RUN pip --no-cache-dir install --upgrade -r /bandersnatch/requirements.txt -r /bandersnatch/requirements_swift.txt
+RUN pip --no-cache-dir -v install /bandersnatch/[swift]
 
 CMD ["python", "/bandersnatch/src/runner.py", "3600"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,13 +6,10 @@ chardet==3.0.4
 filelock==3.0.12
 idna==2.9
 importlib_resources==1.5.0; python_version < '3.7'
-keystoneauth1==4.0.0
 lxml==4.5.1
 multidict==4.7.6
-openstackclient==4.0.0
 packaging==20.4
 pyparsing==2.4.7
-python-swiftclient==3.9.0
 setuptools==46.4.0
 six==1.15.0
 yarl==1.4.2

--- a/requirements_swift.txt
+++ b/requirements_swift.txt
@@ -1,0 +1,3 @@
+keystoneauth1==4.0.0
+openstackclient==4.0.0
+python-swiftclient==3.9.0

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -6,12 +6,9 @@ coverage==5.1
 flake8==3.8.2
 flake8-bugbear==20.1.4
 freezegun==0.3.15
-keystoneauth1==4.0.0
-openstackclient==4.0.0
 pre-commit==2.4.0
 pytest==5.4.2
 pytest-asyncio==0.12.0
 pytest-timeout==1.3.4
-python-swiftclient==3.9.0
 setuptools==46.4.0
 tox==3.15.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,7 +16,7 @@ project_urls =
     Source Code = https://github.com/pypa/bandersnatch
     Change Log = https://github.com/pypa/bandersnatch/CHANGES.md
 url = https://github.com/pypa/bandersnatch/
-version = 4.1.0.dev0
+version = 4.1.0.dev1
 
 [options]
 install_requires =
@@ -92,9 +92,9 @@ doc_build =
     # git+https://github.com/python/python-docs-theme.git#egg=python-docs-theme
 
 swift =
-    python-swiftclient
-    openstackclient
     keystoneauth1
+    openstackclient
+    python-swiftclient
 
 [isort]
 atomic = true

--- a/src/bandersnatch/storage.py
+++ b/src/bandersnatch/storage.py
@@ -332,10 +332,13 @@ def load_storage_plugins(
 
     plugins = set()
     for entry_point in pkg_resources.iter_entry_points(group=entrypoint_group):
-        plugin_class = entry_point.load()
-        plugin_instance = plugin_class(config=config)
-        if plugin_instance.name == enabled_plugin:
-            plugins.add(plugin_instance)
+        try:
+            plugin_class = entry_point.load()
+            plugin_instance = plugin_class(config=config)
+            if plugin_instance.name == enabled_plugin:
+                plugins.add(plugin_instance)
+        except ModuleNotFoundError as me:
+            logging.error(f"Unable to load entry point {entry_point}: {me}")
 
     loaded_storage_plugins[entrypoint_group] = list(plugins)
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = lint,py37
+envlist = lint,py3
 
 [testenv]
 passenv = CI TRAVIS TRAVIS_*
@@ -9,6 +9,7 @@ commands =
     coverage html
     codecov
 deps = -r requirements_test.txt
+extras = swift
 
 [testenv:doc_build]
 basepython=python3


### PR DESCRIPTION
- Lets not cause default install to have all the swift deps
- Have tox install the extra swift deps
- Lets have docker include swift support so it can be enabled
- Lets disable the cache dir in docker build
- Also updated pre-commit

Fixes #534