### PR TITLE
Add global-timeout flag

### DIFF
--- a/docs/mirror_configuration.md
+++ b/docs/mirror_configuration.md
@@ -58,6 +58,18 @@ Example:
 timeout = 10
 ```
 
+### global-timeout
+
+The global-timeout value is an integer that indicates the maximum runtime of individual asyncio coroutines.
+
+The default value for this setting is 18000 seconds, or 5 hours.
+
+Example:
+```ini
+[mirror]
+global-timeout = 18000
+```
+
 ### workers
 
 The workers value is an integer from from 1-10 that indicates the number of concurrent downloads.

--- a/src/bandersnatch/default.conf
+++ b/src/bandersnatch/default.conf
@@ -19,6 +19,11 @@ master = https://pypi.org
 ; catching up for ages.
 timeout = 10
 
+; The global aiohttp coroutine timeout for individual bandersnatch workers.
+; This is set incredibly high by default as individual coroutines need to be
+; equipped to handle mirroring PyPI.
+global-timeout = 10
+
 ; Number of worker threads to use for parallel downloads.
 ; Recommendations for worker thread setting:
 ; - leave the default of 3 to avoid overloading the pypi master
@@ -46,7 +51,11 @@ hash-index = false
 ; "false".
 stop-on-error = false
 
+; The storage backend that will be used to save data and metadata while
+; mirroring packages. By default, use the filesystem backend. Other options
+; currently include: 'swift'
 storage-backend = filesystem
+
 ; Advanced logging configuration. Uncomment and set to the location of a
 ; python logging format logging config file.
 ; log-config = /etc/bandersnatch-log.conf

--- a/src/bandersnatch/master.py
+++ b/src/bandersnatch/master.py
@@ -22,9 +22,12 @@ class XmlRpcError(aiohttp.ClientError):
 
 
 class Master:
-    def __init__(self, url: str, timeout: float = 10.0) -> None:
+    def __init__(
+        self, url: str, timeout: float = 10.0, global_timeout: float = 5 * 60 * 60.0
+    ) -> None:
         self.loop = asyncio.get_event_loop()
         self.timeout = timeout
+        self.global_timeout = global_timeout
         self.url = url
         if self.url.startswith("http://"):
             err = f"Master URL {url} is not https scheme"
@@ -36,7 +39,9 @@ class Master:
         custom_headers = {"User-Agent": USER_AGENT}
         skip_headers = {"User-Agent"}
         aiohttp_timeout = aiohttp.ClientTimeout(
-            total=10 * self.timeout, sock_connect=self.timeout, sock_read=self.timeout,
+            total=self.global_timeout,
+            sock_connect=self.timeout,
+            sock_read=self.timeout,
         )
         self.session = aiohttp.ClientSession(
             headers=custom_headers,

--- a/src/bandersnatch/mirror.py
+++ b/src/bandersnatch/mirror.py
@@ -531,7 +531,9 @@ async def mirror(config: configparser.ConfigParser) -> int:  # noqa: C901
     # Always reference those classes here with the fully qualified name to
     # allow them being patched by mock libraries!
     async with Master(
-        config.get("mirror", "master"), config.getfloat("mirror", "timeout")
+        config.get("mirror", "master"),
+        config.getfloat("mirror", "timeout"),
+        config.getfloat("mirror", "global-timeout", fallback=5 * 60 * 60.0),
     ) as master:
         mirror = Mirror(
             config.get("mirror", "directory"),

--- a/src/bandersnatch/tests/ci-swift.conf
+++ b/src/bandersnatch/tests/ci-swift.conf
@@ -5,6 +5,7 @@ directory = /tmp/pypi
 json = true
 master = https://pypi.org
 timeout = 10
+global-timeout = 18000
 workers = 3
 hash-index = true
 stop-on-error = true

--- a/src/bandersnatch/tests/ci.conf
+++ b/src/bandersnatch/tests/ci.conf
@@ -6,6 +6,7 @@ json = true
 cleanup = true
 master = https://pypi.org
 timeout = 10
+global-timeout = 18000
 workers = 3
 hash-index = true
 stop-on-error = true

--- a/src/bandersnatch/tests/plugins/test_storage_plugins.py
+++ b/src/bandersnatch/tests/plugins/test_storage_plugins.py
@@ -366,6 +366,7 @@ storage-backend = {0}
 master = https://pypi.org
 json = false
 timeout = 10
+global-timeout = 18000
 verifiers = 3
 diff-file = {{mirror_directory}}/mirrored-files
 diff-append-epoch = false

--- a/src/bandersnatch/tests/test_configuration.py
+++ b/src/bandersnatch/tests/test_configuration.py
@@ -57,6 +57,7 @@ class TestBandersnatchConf(TestCase):
             [
                 "cleanup",
                 "directory",
+                "global-timeout",
                 "hash-index",
                 "json",
                 "master",
@@ -81,6 +82,7 @@ class TestBandersnatchConf(TestCase):
             ("stop-on-error", bool),
             ("storage-backend", str),
             ("timeout", int),
+            ("global-timeout", int),
             ("workers", int),
         ]:
             self.assertIsInstance(

--- a/src/bandersnatch/unittest.conf
+++ b/src/bandersnatch/unittest.conf
@@ -18,6 +18,7 @@ master = https://pypi.org
 ; the client soon instead of having a process hang infinitely and have TCP not
 ; catching up for ages.
 timeout = 10
+global-timeout = 18000
 
 ; Number of worker threads to use for parallel downloads.
 ; Recommendations for worker thread setting:


### PR DESCRIPTION
- Add `global-timeout` configuration parameter for configuring
  `aiohttp`'s `total_timeout` setting
- Leave `timeout` as is for managing `sock_connect` and `sock_read`
- Update test configurations, ensure the value is set in tests
- Update documentation

Signed-off-by: Dan Ryan <dan.ryan@canonical.com>