### PR TITLE
Ensure use of `storage_backend` based path wrapper

### DIFF
--- a/src/bandersnatch/storage.py
+++ b/src/bandersnatch/storage.py
@@ -60,7 +60,7 @@ class Storage:
             self.configuration = BandersnatchConfig().config
         try:
             storage_backend = self.configuration["mirror"]["storage-backend"]
-        except KeyError:
+        except (KeyError, TypeError):
             storage_backend = "filesystem"
         if storage_backend != self.name:
             return


### PR DESCRIPTION
- When downloading, verifying or deleting content, make sure we
  use the `storage_backend` wrapped path plugin
- This is going to be really annoying and we probably should figure out
  how to centralize these kinds of calls in a more natural way
- Fixes #539

Signed-off-by: Dan Ryan <dan.ryan@canonical.com>