### PR TITLE
Fix typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ This will pull latest build. Please use a specific tag if desired.
 - Docker image includes `/bandersnatch/src/runner.py` to periodically
   run a `bandersnatch mirror`
   - Please `/bandersnatch/src/runner.py --help` for usage
-- With docker, we reccomend bind mounting in a read only `bandersnatch.conf`
+- With docker, we recommend bind mounting in a read only `bandersnatch.conf`
   - Defaults to `/conf/bandersnatch.conf`
 
 ```shell

--- a/docs/mirror_configuration.md
+++ b/docs/mirror_configuration.md
@@ -73,7 +73,7 @@ Recommendations for the workers setting:
 
 The hash-index is a boolean (true/false) ot determine if package hashing should be used.
 
-The Recommended setting: the default of false for full pip/pypi compatability.
+The Recommended setting: the default of false for full pip/pypi compatibility.
 
 ```eval_rst
 .. warning:: Package index directory hashing is incompatible with pip, and so this should only be used in an environment where it is behind an application that can translate URIs to filesystem locations.


### PR DESCRIPTION
Hi,

This tiny PR will fix : 

- 1 typo in `README.md`
- 1 typo in `docs/mirror_configuration.md`



Bye! :robot: