### PR TITLE
Move Configuration validation form mirror.mirror 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,8 @@ matrix:
       env: TOXENV=doc_build
     - python: 3.8
       env: TOXENV=lint
+    - python: 3.8
+      env: TOXENV=py3
     - python: nightly
       env: TOXENV=INTEGRATION
     - python: nightly

--- a/src/bandersnatch/tests/test_configuration.py
+++ b/src/bandersnatch/tests/test_configuration.py
@@ -1,9 +1,15 @@
+import configparser
 import os
 import unittest
 from tempfile import TemporaryDirectory
 from unittest import TestCase
 
-from bandersnatch.configuration import BandersnatchConfig, Singleton
+from bandersnatch.configuration import (
+    BandersnatchConfig,
+    SetConfigValues,
+    Singleton,
+    validate_config_values,
+)
 
 try:
     import importlib.resources
@@ -122,6 +128,16 @@ class TestBandersnatchConf(TestCase):
 
         instance2 = BandersnatchConfig()
         self.assertEqual(instance2.config["mirror"]["master"], "https://foo.bar.baz")
+
+    def test_validate_config_values(self):
+        default_values = SetConfigValues(
+            False, "", "", False, "sha256", "filesystem", False
+        )
+        no_options_configparser = configparser.ConfigParser()
+        no_options_configparser["mirror"] = {}
+        self.assertEqual(
+            default_values, validate_config_values(no_options_configparser)
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
- to configuration.validate_config_values
- Remove complexity from mirror function
- Move to file for code around what this actually does
- Unittest passing in no vaules so we always fallback to default

Spotted this when I sat down to work on #463