### PR TITLE
Refactor verify to use Master for HTTP calls

### DIFF
--- a/src/bandersnatch/delete.py
+++ b/src/bandersnatch/delete.py
@@ -12,10 +12,11 @@ from urllib.parse import urlparse
 
 from packaging.utils import canonicalize_name
 
-from bandersnatch.storage import storage_backend_plugins
-from bandersnatch.verify import get_latest_json
+from .master import Master
+from .storage import storage_backend_plugins
+from .verify import get_latest_json
 
-logger = logging.getLogger(__name__)  # pylint: disable=C0103
+logger = logging.getLogger(__name__)
 
 
 def delete_path(blob_path: Path, dry_run: bool = False) -> int:
@@ -37,7 +38,7 @@ def delete_path(blob_path: Path, dry_run: bool = False) -> int:
     return 0
 
 
-async def delete_packages(config: ConfigParser, args: Namespace) -> int:
+async def delete_packages(config: ConfigParser, args: Namespace, master: Master) -> int:
     loop = asyncio.get_event_loop()
     workers = args.workers or config.getint("mirror", "workers")
     executor = concurrent.futures.ThreadPoolExecutor(max_workers=workers)
@@ -66,7 +67,7 @@ async def delete_packages(config: ConfigParser, args: Namespace) -> int:
                 continue
 
             logger.error(f"{json_full_path} does not exist. Pulling from PyPI")
-            await get_latest_json(json_full_path, config, executor, False)
+            await get_latest_json(master, json_full_path, config, executor, False)
             if not json_full_path.exists():
                 logger.error(f"Unable to HTTP get JSON for {json_full_path}")
                 continue

--- a/src/bandersnatch/main.py
+++ b/src/bandersnatch/main.py
@@ -12,6 +12,7 @@ from typing import Optional
 import bandersnatch.configuration
 import bandersnatch.delete
 import bandersnatch.log
+import bandersnatch.master
 import bandersnatch.mirror
 import bandersnatch.verify
 from bandersnatch.storage import storage_backend_plugins
@@ -94,7 +95,12 @@ def _verify_parser(subparsers: argparse._SubParsersAction) -> None:
 
 async def async_main(args: argparse.Namespace, config: ConfigParser) -> int:
     if args.op.lower() == "delete":
-        return await bandersnatch.delete.delete_packages(config, args)
+        async with bandersnatch.master.Master(
+            config.get("mirror", "master"),
+            config.getfloat("mirror", "timeout"),
+            config.getfloat("mirror", "global-timeout", fallback=None),
+        ) as master:
+            return await bandersnatch.delete.delete_packages(config, args, master)
     elif args.op.lower() == "verify":
         return await bandersnatch.verify.metadata_verify(config, args)
 

--- a/src/bandersnatch/mirror.py
+++ b/src/bandersnatch/mirror.py
@@ -19,7 +19,6 @@ from .package import Package
 from .storage import storage_backend_plugins
 
 LOG_PLUGINS = True
-FIVE_HOURS_FLOAT = 5 * 60 * 60.0
 logger = logging.getLogger(__name__)
 
 
@@ -469,7 +468,7 @@ async def mirror(config: configparser.ConfigParser) -> int:
     async with Master(
         config.get("mirror", "master"),
         config.getfloat("mirror", "timeout"),
-        config.getfloat("mirror", "global-timeout", fallback=FIVE_HOURS_FLOAT),
+        config.getfloat("mirror", "global-timeout", fallback=None),
     ) as master:
         mirror = Mirror(
             config.get("mirror", "directory"),

--- a/src/bandersnatch/tests/test_delete.py
+++ b/src/bandersnatch/tests/test_delete.py
@@ -10,6 +10,7 @@ from urllib.parse import urlparse
 import pytest
 
 from bandersnatch.delete import delete_packages, delete_path
+from bandersnatch.master import Master
 from bandersnatch.utils import find
 
 EXPECTED_WEB_BEFORE_DELETION = """\
@@ -95,6 +96,7 @@ def test_delete_path() -> None:
 async def test_delete_packages() -> None:
     args = _fake_args()
     config = _fake_config()
+    master = Master("https://unittest.org")
 
     with TemporaryDirectory() as td:
         td_path = Path(td)
@@ -133,11 +135,11 @@ async def test_delete_packages() -> None:
         assert find(web_path) == EXPECTED_WEB_BEFORE_DELETION
 
         args.dry_run = True
-        assert await delete_packages(config, args) == 0
+        assert await delete_packages(config, args, master) == 0
 
         args.dry_run = False
         with patch("bandersnatch.delete.logger.info") as mock_log:
-            assert await delete_packages(config, args) == 0
+            assert await delete_packages(config, args, master) == 0
             assert mock_log.call_count == 1
 
         # See we've deleted it all
@@ -147,6 +149,7 @@ async def test_delete_packages() -> None:
 @pytest.mark.asyncio
 async def test_delete_packages_no_exist() -> None:
     args = _fake_args()
+    master = Master("https://unittest.org")
     with patch("bandersnatch.delete.logger.error") as mock_log:
-        assert await delete_packages(_fake_config(), args) == 0
+        assert await delete_packages(_fake_config(), args, master) == 0
         assert mock_log.call_count == len(args.pypi_packages)

--- a/src/bandersnatch/tests/test_master.py
+++ b/src/bandersnatch/tests/test_master.py
@@ -1,3 +1,6 @@
+from pathlib import Path
+from tempfile import gettempdir
+
 import asynctest
 import pytest
 
@@ -63,6 +66,13 @@ async def test_master_raises_if_serial_too_small(master):
 async def test_master_doesnt_raise_if_serial_equal(master):
     get_ag = master.get("/asdf", 1)
     await get_ag.asend(None)
+
+
+@pytest.mark.asyncio
+async def test_master_url_fetch(master):
+    fetch_path = Path(gettempdir()) / "unittest_url_fetch"
+    await master.url_fetch("https://unittest.org/asdf", fetch_path)
+    assert master.session.get.called
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
- Move url_fetch to Master
- Pass in a Master object into verify
- Handle None for session timeout which fallsback to default of 5 hours
- Change delete to use Master() as well

Test: Make tests pass again + add one tests for fetch_url

Addresses parts of #463 
- We could still move more to mirror library potentially.