### PR TITLE
Fix conf.py so Markdown docs can build properly

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -23,6 +23,10 @@ except ImportError:
 # If your documentation needs a minimal Sphinx version, state it here.
 needs_sphinx = "3.0"
 
+# Just a protection against an incompatible version of recommonmark.
+# The listed version is the minimal version required for that extension.
+needs_extensions = {"recommonmark": "0.5"}
+
 extensions = [
     "sphinx.ext.autodoc",
     "sphinx.ext.intersphinx",

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -11,6 +11,17 @@ try:
 except ImportError:
     doc_module = DocStub()
 
+try:
+    from recommonmark.parser import CommonMarkParser
+    from recommonmark.transform import AutoStructify
+
+    github_doc_root = "https://partner.git.corp.yahoo.com/pages/yahoo.platform_init"
+    USE_MARKDOWN = True
+except ImportError:
+    USE_MARKDOWN = False
+
+# If your documentation needs a minimal Sphinx version, state it here.
+needs_sphinx = "3.0"
 
 extensions = [
     "sphinx.ext.autodoc",
@@ -23,13 +34,16 @@ extensions = [
     "sphinx.ext.graphviz",
     "sphinx.ext.inheritance_diagram",
     "sphinx.ext.githubpages",
+    "recommonmark",
 ]
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]
 
 # The suffix of source filenames.
-source_suffix = ".rst"
+source_suffix = [".rst"]
+if USE_MARKDOWN:
+    source_suffix.append(".md")
 
 # The encoding of source files.
 # source_encoding = 'utf-8-sig'
@@ -256,19 +270,6 @@ html_theme = available_theme_settings[selected_theme]["theme"]
 html_theme_path = available_theme_settings[selected_theme]["path"]
 if available_theme_settings[selected_theme].get("options", None):
     html_theme_options = available_theme_settings[selected_theme]["options"]
-
-try:
-    from recommonmark.parser import CommonMarkParser
-    from recommonmark.transform import AutoStructify
-
-    # TODO: "source_parsers" is deprecated. Please use app.add_source_parser()
-    source_parsers = {".md": CommonMarkParser}
-
-    source_suffix = [".rst", ".md"]
-    github_doc_root = "https://partner.git.corp.yahoo.com/pages/yahoo.platform_init"
-    USE_MARKDOWN = True
-except ImportError:
-    USE_MARKDOWN = False
 
 # -- Options for LaTeX output ---------------------------------------------
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -12,7 +12,7 @@ except ImportError:
     doc_module = DocStub()
 
 try:
-    from recommonmark.parser import CommonMarkParser
+    from recommonmark.parser import CommonMarkParser  # noqa: F401
     from recommonmark.transform import AutoStructify
 
     github_doc_root = "https://partner.git.corp.yahoo.com/pages/yahoo.platform_init"


### PR DESCRIPTION
Related #556.

## Fix conf.py so Markdown docs can build properly 
Since the bump to Sphinx 3.x, all of the Markdown documentation wasn't building
since the Markdown configuration was outdated. Instead of using source_parsers,
you just add the recommonmark extension. Also for good measure, Sphinx 3.0 < is
now required.

## Add protection for incompatible recommommark versions 
recommonmark version 0.4.0 and below are incompatible with Sphinx 3.x and since
we moved to Sphinx 3.x, a safeguard should be added.

---

Here's the built docs:
https://ichard26-testbandersnatchdocs.readthedocs.io/en/sphinx3/