### PR TITLE
Turn warnings into errors while building docs to catch potentially dangerous documentation changes

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -144,7 +144,7 @@ html_short_title = "Bandersnatch documentation"
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ["_static"]
+# html_static_path = ["_static"]
 
 # Add any extra paths that contain custom files (such as robots.txt or
 # .htaccess) here, relative to this directory. These files are copied
@@ -365,7 +365,6 @@ texinfo_documents = [
 intersphinx_mapping = {
     "python": ("http://docs.python.org/3", None),
     "urllib3": ("http://urllib3.readthedocs.org/en/latest", None),
-    "requests": ("http://docs.python-requests.org/en/latest/", None),
 }
 
 # Useful external link shortcuts

--- a/tox.ini
+++ b/tox.ini
@@ -15,7 +15,7 @@ extras = swift
 basepython=python3
 commands =
     {envpython} {envbindir}/sphinx-apidoc -f -o docs src/bandersnatch
-    {envpython} {envbindir}/sphinx-build -a -b html docs docs/html
+    {envpython} {envbindir}/sphinx-build -a -W -b html docs docs/html
 changedir = {toxinidir}
 deps =
     -r requirements_docs.txt


### PR DESCRIPTION
Turning warnings during the documentation build test will allow the test to catch
potentially dangerous documentation changes even when the doc build passes.

Resolves #556.