### PR TITLE
Add "sync" command

### DIFF
--- a/src/bandersnatch/main.py
+++ b/src/bandersnatch/main.py
@@ -93,6 +93,16 @@ def _verify_parser(subparsers: argparse._SubParsersAction) -> None:
     v.set_defaults(op="verify")
 
 
+def _sync_parser(subparsers: argparse._SubParsersAction) -> None:
+    m = subparsers.add_parser(
+        "sync", help="Synchronize specific packages with the PyPI master server.",
+    )
+    m.add_argument(
+        "package", nargs="+", help="The name of package to sync",
+    )
+    m.set_defaults(op="sync")
+
+
 async def async_main(args: argparse.Namespace, config: ConfigParser) -> int:
     if args.op.lower() == "delete":
         async with bandersnatch.master.Master(
@@ -103,6 +113,8 @@ async def async_main(args: argparse.Namespace, config: ConfigParser) -> int:
             return await bandersnatch.delete.delete_packages(config, args, master)
     elif args.op.lower() == "verify":
         return await bandersnatch.verify.metadata_verify(config, args)
+    elif args.op.lower() == "sync":
+        return await bandersnatch.mirror.mirror(config, args.package)
 
     if args.force_check:
         storage_plugin = next(iter(storage_backend_plugins()))
@@ -152,6 +164,7 @@ def main(loop: Optional[asyncio.AbstractEventLoop] = None) -> int:
     _delete_parser(subparsers)
     _mirror_parser(subparsers)
     _verify_parser(subparsers)
+    _sync_parser(subparsers)
 
     if len(sys.argv) < 2:
         parser.print_help()

--- a/src/bandersnatch/main.py
+++ b/src/bandersnatch/main.py
@@ -98,7 +98,7 @@ def _sync_parser(subparsers: argparse._SubParsersAction) -> None:
         "sync", help="Synchronize specific packages with the PyPI master server.",
     )
     m.add_argument(
-        "package", nargs="+", help="The name of package to sync",
+        "packages", metavar="package", nargs="+", help="The name of package to sync",
     )
     m.set_defaults(op="sync")
 
@@ -114,7 +114,7 @@ async def async_main(args: argparse.Namespace, config: ConfigParser) -> int:
     elif args.op.lower() == "verify":
         return await bandersnatch.verify.metadata_verify(config, args)
     elif args.op.lower() == "sync":
-        return await bandersnatch.mirror.mirror(config, args.package)
+        return await bandersnatch.mirror.mirror(config, args.packages)
 
     if args.force_check:
         storage_plugin = next(iter(storage_backend_plugins()))

--- a/src/bandersnatch/mirror.py
+++ b/src/bandersnatch/mirror.py
@@ -129,8 +129,13 @@ class Mirror:
             self.sync_index_page()
             self.wrapup_successful_sync()
         else:
+            # Synchronize specific packages. This method doesn't update the self.statusfile
+
+            # Pass serial number 0 to bypass the stale serial check in Package class
+            SERIAL_DONT_CARE = 0
             self.packages_to_sync = {
-                utils.bandersnatch_safe_name(name): 1 for name in specific_packages
+                utils.bandersnatch_safe_name(name): SERIAL_DONT_CARE
+                for name in specific_packages
             }
             await self.sync_packages()
             self.sync_index_page()

--- a/src/bandersnatch/mirror.py
+++ b/src/bandersnatch/mirror.py
@@ -114,7 +114,7 @@ class Mirror:
         return self.homedir / "todo"
 
     async def synchronize(
-        self, specific_packages: List[str] = None
+        self, specific_packages: Optional[List[str]] = None
     ) -> Dict[str, Set[str]]:
         logger.info(f"Syncing with {self.master.url}.")
         self.now = datetime.datetime.utcnow()
@@ -441,7 +441,7 @@ class Mirror:
 
 
 async def mirror(
-    config: configparser.ConfigParser, specific_packages: List[str] = None
+    config: configparser.ConfigParser, specific_packages: Optional[List[str]] = None
 ) -> int:
     # Load the filter plugins so the loading doesn't happen in the fast path
     filter_project_plugins()

--- a/src/bandersnatch/mirror.py
+++ b/src/bandersnatch/mirror.py
@@ -129,7 +129,8 @@ class Mirror:
             self.sync_index_page()
             self.wrapup_successful_sync()
         else:
-            # Synchronize specific packages. This method doesn't update the self.statusfile
+            # Synchronize specific packages. This method doesn't update the
+            # self.statusfile
 
             # Pass serial number 0 to bypass the stale serial check in Package class
             SERIAL_DONT_CARE = 0

--- a/src/bandersnatch/tests/test_sync.py
+++ b/src/bandersnatch/tests/test_sync.py
@@ -1,0 +1,47 @@
+from os import sep
+
+import asynctest
+import pytest
+
+from bandersnatch import utils
+
+
+@pytest.mark.asyncio
+async def test_sync_specific_packages(mirror):
+    FAKE_SERIAL = b"112233"
+    with open("status", "wb") as f:
+        f.write(FAKE_SERIAL)
+    # Package names should be normalized by synchronize()
+    specific_packages = ["Foo"]
+    mirror.master.all_packages = asynctest.CoroutineMock(return_value={"foo": 1})
+    mirror.json_save = True
+    # Recall bootstrap so we have the json dirs
+    mirror._bootstrap()
+    await mirror.synchronize(specific_packages)
+
+    assert """\
+json{0}foo
+packages{0}2.7{0}f{0}foo{0}foo.whl
+packages{0}any{0}f{0}foo{0}foo.zip
+pypi{0}foo{0}json
+simple{0}foo{0}index.html
+simple{0}index.html""".format(
+        sep
+    ) == utils.find(
+        mirror.webdir, dirs=False
+    )
+    assert (
+        open("web{0}simple{0}index.html".format(sep)).read()
+        == """\
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Simple Index</title>
+  </head>
+  <body>
+    <a href="foo/">foo</a><br/>
+  </body>
+</html>"""
+    )
+    # The "sync" method shouldn't update the serial
+    assert open("status", "rb").read() == FAKE_SERIAL


### PR DESCRIPTION
Related issue: #560 

This PR added a `sync` sub command, which allows user to sync one or more packages .

```console
usage: bandersnatch sync [-h] package [package ...]

positional arguments:
  package     The name of package to sync

optional arguments:
  -h, --help  show this help message and exit
```

After a synchronization, bandersnatch refreshes global index files, while keeps status(serial) file intact. 

Would you please review the PR. If this implementation meets the requirement, I'll add some tests then.