### PR TITLE
Refactored filter loading into seperate class

### DIFF
--- a/src/bandersnatch/tests/plugins/test_blacklist_name.py
+++ b/src/bandersnatch/tests/plugins/test_blacklist_name.py
@@ -1,5 +1,4 @@
 import os
-from collections import defaultdict
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from unittest import TestCase
@@ -23,7 +22,6 @@ class TestBlacklistProject(TestCase):
     def setUp(self) -> None:
         self.cwd = os.getcwd()
         self.tempdir = TemporaryDirectory()
-        bandersnatch.filter.loaded_filter_plugins = defaultdict(list)
         os.chdir(self.tempdir.name)
 
     def tearDown(self) -> None:
@@ -42,7 +40,7 @@ enabled =
 """
         )
 
-        plugins = bandersnatch.filter.filter_project_plugins()
+        plugins = bandersnatch.filter.LoadedFilters().filter_project_plugins()
         names = [plugin.name for plugin in plugins]
         self.assertListEqual(names, ["blacklist_project"])
         self.assertEqual(len(plugins), 1)
@@ -56,7 +54,7 @@ enabled =
 """
         )
 
-        plugins = bandersnatch.filter.filter_project_plugins()
+        plugins = bandersnatch.filter.LoadedFilters().filter_project_plugins()
         names = [plugin.name for plugin in plugins]
         self.assertNotIn("blacklist_project", names)
 
@@ -67,7 +65,7 @@ enabled =
 """
         )
 
-        plugins = bandersnatch.filter.filter_project_plugins()
+        plugins = bandersnatch.filter.LoadedFilters().filter_project_plugins()
         names = [plugin.name for plugin in plugins]
         self.assertNotIn("blacklist_project", names)
 
@@ -118,7 +116,6 @@ class TestBlacklistRelease(TestCase):
     def setUp(self) -> None:
         self.cwd = os.getcwd()
         self.tempdir = TemporaryDirectory()
-        bandersnatch.filter.loaded_filter_plugins = defaultdict(list)
         os.chdir(self.tempdir.name)
 
     def tearDown(self) -> None:
@@ -137,7 +134,7 @@ enabled =
 """
         )
 
-        plugins = bandersnatch.filter.filter_release_plugins()
+        plugins = bandersnatch.filter.LoadedFilters().filter_release_plugins()
         names = [plugin.name for plugin in plugins]
         self.assertListEqual(names, ["blacklist_release"])
         self.assertEqual(len(plugins), 1)
@@ -151,7 +148,7 @@ enabled =
 """
         )
 
-        plugins = bandersnatch.filter.filter_release_plugins()
+        plugins = bandersnatch.filter.LoadedFilters().filter_release_plugins()
         names = [plugin.name for plugin in plugins]
         self.assertNotIn("blacklist_release", names)
 
@@ -172,6 +169,6 @@ packages =
         pkg.info = {"name": "foo"}
         pkg.releases = {"1.2.0": {}, "1.2.1": {}}
 
-        pkg._filter_releases()
+        pkg._filter_releases(mirror.filters.filter_release_plugins())
 
         self.assertEqual(pkg.releases, {"1.2.1": {}})

--- a/src/bandersnatch/tests/plugins/test_filename.py
+++ b/src/bandersnatch/tests/plugins/test_filename.py
@@ -1,5 +1,4 @@
 import os
-from collections import defaultdict
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from unittest import TestCase
@@ -21,7 +20,6 @@ class BasePluginTestCase(TestCase):
     def setUp(self) -> None:
         self.cwd = os.getcwd()
         self.tempdir = TemporaryDirectory()
-        bandersnatch.filter.loaded_filter_plugins = defaultdict(list)
         os.chdir(self.tempdir.name)
 
     def tearDown(self) -> None:
@@ -50,7 +48,7 @@ platforms =
     def test_plugin_compiles_patterns(self) -> None:
         mock_config(self.config_contents)
 
-        plugins = bandersnatch.filter.filter_release_plugins()
+        plugins = bandersnatch.filter.LoadedFilters().filter_release_plugins()
 
         assert any(
             type(plugin) == filename_name.ExcludePlatformFilter for plugin in plugins
@@ -64,8 +62,6 @@ platforms =
         linux packages
         """
         mock_config(self.config_contents)
-
-        bandersnatch.filter.filter_release_plugins()
 
         mirror = Mirror(Path("."), Master(url="https://foo.bar.com"))
         pkg = Package("foobar", 1, mirror)
@@ -153,7 +149,7 @@ platforms =
         rv = pkg.releases.values()
         keep_count = sum(f["flag"] == "KEEP" for r in rv for f in r)
 
-        pkg._filter_releases()
+        pkg._filter_releases(mirror.filters.filter_release_plugins())
 
         # we should have the same keep count and no drop
         rv = pkg.releases.values()

--- a/src/bandersnatch/tests/plugins/test_prerelease_name.py
+++ b/src/bandersnatch/tests/plugins/test_prerelease_name.py
@@ -1,6 +1,5 @@
 import os
 import re
-from collections import defaultdict
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from unittest import TestCase
@@ -22,7 +21,6 @@ class BasePluginTestCase(TestCase):
     def setUp(self) -> None:
         self.cwd = os.getcwd()
         self.tempdir = TemporaryDirectory()
-        bandersnatch.filter.loaded_filter_plugins = defaultdict(list)
         os.chdir(self.tempdir.name)
 
     def tearDown(self) -> None:
@@ -44,7 +42,7 @@ enabled =
     def test_plugin_includes_predefined_patterns(self) -> None:
         mock_config(self.config_contents)
 
-        plugins = bandersnatch.filter.filter_release_plugins()
+        plugins = bandersnatch.filter.LoadedFilters().filter_release_plugins()
 
         assert any(
             type(plugin) == prerelease_name.PreReleaseFilter for plugin in plugins
@@ -62,8 +60,6 @@ enabled =
     def test_plugin_check_match(self) -> None:
         mock_config(self.config_contents)
 
-        bandersnatch.filter.filter_release_plugins()
-
         mirror = Mirror(Path("."), Master(url="https://foo.bar.com"))
         pkg = Package("foo", 1, mirror)
         pkg.info = {"name": "foo", "version": "1.2.0"}
@@ -76,6 +72,6 @@ enabled =
             "1.2.0": {},
         }
 
-        pkg._filter_releases()
+        pkg._filter_releases(mirror.filters.filter_release_plugins())
 
         assert pkg.releases == {"1.2.0": {}}

--- a/src/bandersnatch/tests/plugins/test_whitelist_name.py
+++ b/src/bandersnatch/tests/plugins/test_whitelist_name.py
@@ -23,7 +23,6 @@ class TestWhitelistProject(TestCase):
     def setUp(self) -> None:
         self.cwd = os.getcwd()
         self.tempdir = TemporaryDirectory()
-        bandersnatch.filter.loaded_filter_plugins = defaultdict(list)
         bandersnatch.storage.loaded_storage_plugins = defaultdict(list)
         os.chdir(self.tempdir.name)
 
@@ -43,7 +42,7 @@ enabled =
 """
         )
 
-        plugins = bandersnatch.filter.filter_project_plugins()
+        plugins = bandersnatch.filter.LoadedFilters().filter_project_plugins()
         names = [plugin.name for plugin in plugins]
         self.assertListEqual(names, ["whitelist_project"])
         self.assertEqual(len(plugins), 1)
@@ -58,7 +57,7 @@ storage-backend = filesystem
 """
         )
 
-        plugins = bandersnatch.filter.filter_project_plugins()
+        plugins = bandersnatch.filter.LoadedFilters().filter_project_plugins()
         names = [plugin.name for plugin in plugins]
         self.assertNotIn("whitelist_project", names)
 

--- a/src/bandersnatch/tests/test_filter.py
+++ b/src/bandersnatch/tests/test_filter.py
@@ -1,19 +1,15 @@
 import os
 import unittest
-from collections import defaultdict
 from tempfile import TemporaryDirectory
 from unittest import TestCase
 
 from mock_config import mock_config
 
-import bandersnatch.filter
-
 from bandersnatch.filter import (  # isort:skip
     Filter,
     FilterProjectPlugin,
     FilterReleasePlugin,
-    filter_project_plugins,
-    filter_release_plugins,
+    LoadedFilters,
 )
 
 
@@ -28,7 +24,6 @@ class TestBandersnatchFilter(TestCase):
     def setUp(self) -> None:
         self.cwd = os.getcwd()
         self.tempdir = TemporaryDirectory()
-        bandersnatch.filter.loaded_filter_plugins = defaultdict(list)
         os.chdir(self.tempdir.name)
 
     def tearDown(self) -> None:
@@ -51,7 +46,7 @@ enabled = all
             "whitelist_project",
         ]
 
-        plugins = filter_project_plugins()
+        plugins = LoadedFilters().filter_project_plugins()
         names = [plugin.name for plugin in plugins]
         for name in builtin_plugin_names:
             self.assertIn(name, names)
@@ -71,7 +66,7 @@ enabled = all
             "latest_release",
         ]
 
-        plugins = filter_release_plugins()
+        plugins = LoadedFilters().filter_release_plugins()
         names = [plugin.name for plugin in plugins]
         for name in builtin_plugin_names:
             self.assertIn(name, names)
@@ -84,10 +79,10 @@ enabled =
 """
         )
 
-        plugins = list(filter_release_plugins())
+        plugins = LoadedFilters().filter_release_plugins()
         self.assertEqual(len(plugins), 0)
 
-        plugins = list(filter_project_plugins())
+        plugins = LoadedFilters().filter_project_plugins()
         self.assertEqual(len(plugins), 0)
 
     def test__filter_base_clases(self) -> None:

--- a/src/bandersnatch/tests/test_mirror.py
+++ b/src/bandersnatch/tests/test_mirror.py
@@ -10,7 +10,6 @@ import pytest
 
 from bandersnatch import utils
 from bandersnatch.configuration import BandersnatchConfig, Singleton
-from bandersnatch.filter import filter_project_plugins
 from bandersnatch.mirror import Mirror
 from bandersnatch.package import Package
 from bandersnatch.utils import WINDOWS
@@ -121,8 +120,10 @@ def test_mirror_filter_packages_match(tmpdir: Path) -> None:
     packages to sync.
     """
     test_configuration = """\
+[plugins]
+enabled =
+    blacklist_project
 [blacklist]
-plugins = blacklist_project
 packages =
     example1
 """
@@ -130,8 +131,6 @@ packages =
     with open("test.conf", "w") as testconfig_handle:
         testconfig_handle.write(test_configuration)
     BandersnatchConfig("test.conf")
-    for plugin in filter_project_plugins():
-        plugin.initialize_plugin()
     m = Mirror(tmpdir, mock.Mock())
     m.packages_to_sync = {"example1": "", "example2": ""}
     m._filter_packages()
@@ -144,6 +143,9 @@ def test_mirror_filter_packages_nomatch_package_with_spec(tmpdir: Path) -> None:
     list of packages.
     """
     test_configuration = """\
+[plugins]
+enable =
+    blacklist_project
 [blacklist]
 packages =
     example3>2.0.0
@@ -152,8 +154,6 @@ packages =
     with open("test.conf", "w") as testconfig_handle:
         testconfig_handle.write(test_configuration)
     BandersnatchConfig("test.conf")
-    for plugin in filter_project_plugins():
-        plugin.initialize_plugin()
     m = Mirror(tmpdir, mock.Mock())
     m.packages_to_sync = {"example1": "", "example3": ""}
     m._filter_packages()

--- a/src/bandersnatch/verify.py
+++ b/src/bandersnatch/verify.py
@@ -13,7 +13,7 @@ from sys import stderr
 from typing import List, Optional, Set
 from urllib.parse import urlparse
 
-from .filter import filter_release_plugins
+from .filter import LoadedFilters
 from .master import Master
 from .storage import storage_backend_plugins
 from .utils import convert_url_to_path, hash, recursive_find_files, unlink_parent_dir
@@ -115,7 +115,7 @@ async def verify(
         return
 
     # apply releases filter plugins like class Package
-    for plugin in filter_release_plugins() or []:
+    for plugin in LoadedFilters().filter_release_plugins() or []:
         plugin.filter(pkg["info"])
 
     for release_version in pkg[releases_key]:


### PR DESCRIPTION
Moved the filter loading into a class that loads all available plugins at once to avoid reading the config file everytime a plugin group wants to be loaded.