### PR TITLE
Add an entry for storage module in docs/bandersnatch.rst

### DIFF
--- a/docs/bandersnatch.rst
+++ b/docs/bandersnatch.rst
@@ -68,6 +68,14 @@ bandersnatch.package module
    :undoc-members:
    :show-inheritance:
 
+bandersnatch.storage module
+---------------------------
+
+.. automodule:: bandersnatch.storage
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 bandersnatch.utils module
 -------------------------
 


### PR DESCRIPTION
The author of `src/bandersnatch/storage.py` seemed to have forgotten to add an entry for it in `docs/bandersnatch.rst` when the module was added. (nudge nudge @techalchemy :) This omission meant `sphinx-autodoc` didn't pick up the module when building the documentation.

See the updated docs here:
https://ichard26-testbandersnatchdocs.readthedocs.io/en/add_bandersnatch_storage_to_be_autodoced/

@cooperlees, I guess while this PR is open, should the plugins also be autodoc(ed) or should they stay undocumented for now?