### PR TITLE
Refactored the removal of releases for release_plugins to happen inside of Package

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -58,12 +58,12 @@ bandersnatch_filter_plugins.v2.release =
     prerelease_release = bandersnatch_filter_plugins.prerelease_name:PreReleaseFilter
     regex_release = bandersnatch_filter_plugins.regex_name:RegexReleaseFilter
     latest_release = bandersnatch_filter_plugins.latest_name:LatestReleaseFilter
-    exclude_platform = bandersnatch_filter_plugins.filename_name:ExcludePlatformFilter
 
 # This entrypoint group must match the value of bandersnatch.filter.RELEASE_FILE_PLUGIN_RESOURCE
 bandersnatch_filter_plugins.v2.release_file =
     regex_release_file_metadata = bandersnatch_filter_plugins.metadata_filter:RegexReleaseFileMetadataFilter
     version_range_release_file_metadata = bandersnatch_filter_plugins.metadata_filter:VersionRangeReleaseFileMetadataFilter
+    exclude_platform = bandersnatch_filter_plugins.filename_name:ExcludePlatformFilter
 
 console_scripts =
     bandersnatch = bandersnatch.main:main

--- a/src/bandersnatch/tests/plugins/test_blacklist_name.py
+++ b/src/bandersnatch/tests/plugins/test_blacklist_name.py
@@ -171,6 +171,6 @@ packages =
             "releases": {"1.2.0": {}, "1.2.1": {}},
         }
 
-        pkg._filter_releases(mirror.filters.filter_release_plugins())
+        pkg._filter_all_releases(mirror.filters.filter_release_plugins())
 
         self.assertEqual(pkg.releases, {"1.2.1": {}})

--- a/src/bandersnatch/tests/plugins/test_filename.py
+++ b/src/bandersnatch/tests/plugins/test_filename.py
@@ -42,13 +42,13 @@ platforms =
     windows
     freebsd
     macos
-    linux-armv7l
+    linux_armv7l
 """
 
     def test_plugin_compiles_patterns(self) -> None:
         mock_config(self.config_contents)
 
-        plugins = bandersnatch.filter.LoadedFilters().filter_release_plugins()
+        plugins = bandersnatch.filter.LoadedFilters().filter_release_file_plugins()
 
         assert any(
             type(plugin) == filename_name.ExcludePlatformFilter for plugin in plugins
@@ -151,12 +151,12 @@ platforms =
         rv = pkg.releases.values()
         keep_count = sum(f["flag"] == "KEEP" for r in rv for f in r)
 
-        pkg._filter_releases(mirror.filters.filter_release_plugins())
+        pkg._filter_all_releases_files(mirror.filters.filter_release_file_plugins())
 
         # we should have the same keep count and no drop
         rv = pkg.releases.values()
         assert sum(f["flag"] == "KEEP" for r in rv for f in r) == keep_count
-        assert all(f["flag"] == "DROP" for r in rv for f in r) is False
+        assert sum(f["flag"] == "DROP" for r in rv for f in r) == 0
 
         # the release "0.2" should have been deleted since there is no more file in it
         assert len(pkg.releases.keys()) == 2

--- a/src/bandersnatch/tests/plugins/test_latest_release.py
+++ b/src/bandersnatch/tests/plugins/test_latest_release.py
@@ -73,7 +73,7 @@ keep = 2
             },
         }
 
-        pkg._filter_releases(mirror.filters.filter_release_plugins())
+        pkg._filter_all_releases(mirror.filters.filter_release_plugins())
 
         assert pkg.releases == {"1.1.3": {}, "2.0.0": {}}
 
@@ -96,7 +96,7 @@ keep = 2
             },
         }
 
-        pkg._filter_releases(mirror.filters.filter_release_plugins())
+        pkg._filter_all_releases(mirror.filters.filter_release_plugins())
 
         assert pkg.releases == {"2.0.1b2": {}, "2.0.0": {}}
 
@@ -141,7 +141,7 @@ enabled =
             },
         }
 
-        pkg._filter_releases(mirror.filters.filter_release_plugins())
+        pkg._filter_all_releases(mirror.filters.filter_release_plugins())
 
         assert pkg.releases == {
             "1.0.0": {},

--- a/src/bandersnatch/tests/plugins/test_prerelease_name.py
+++ b/src/bandersnatch/tests/plugins/test_prerelease_name.py
@@ -74,6 +74,6 @@ enabled =
             },
         }
 
-        pkg._filter_releases(mirror.filters.filter_release_plugins())
+        pkg._filter_all_releases(mirror.filters.filter_release_plugins())
 
         assert pkg.releases == {"1.2.0": {}}

--- a/src/bandersnatch/tests/plugins/test_regex_name.py
+++ b/src/bandersnatch/tests/plugins/test_regex_name.py
@@ -67,7 +67,7 @@ releases =
             "releases": {"foo-1.2.0rc2": {}, "foo-1.2.0": {}, "foo-1.2.0alpha2": {}},
         }
 
-        pkg._filter_releases(mirror.filters.filter_release_plugins())
+        pkg._filter_all_releases(mirror.filters.filter_release_plugins())
 
         assert pkg.releases == {"foo-1.2.0": {}}
 

--- a/src/bandersnatch/tests/test_filter.py
+++ b/src/bandersnatch/tests/test_filter.py
@@ -62,7 +62,6 @@ enabled = all
             "blacklist_release",
             "prerelease_release",
             "regex_release",
-            "exclude_platform",
             "latest_release",
         ]
 

--- a/src/bandersnatch_filter_plugins/blacklist_name.py
+++ b/src/bandersnatch_filter_plugins/blacklist_name.py
@@ -134,15 +134,13 @@ class BlacklistRelease(FilterReleasePlugin):
         return list(filtered_requirements)
 
     def filter(self, metadata: Dict) -> bool:
+        """
+        Returns False if version fails the filter,
+        i.e. matches a blocklist version specifier
+        """
         name = metadata["info"]["name"]
-        releases = metadata["releases"]
-        for version in list(releases.keys()):
-            if self._check_match(name, version):
-                del releases[version]
-        if not releases:
-            return False
-        else:
-            return True
+        version = metadata["version"]
+        return not self._check_match(name, version)
 
     def _check_match(self, name: str, version_string: str) -> bool:
         """

--- a/src/bandersnatch_filter_plugins/filename_name.py
+++ b/src/bandersnatch_filter_plugins/filename_name.py
@@ -1,12 +1,12 @@
 import logging
 from typing import Dict, List
 
-from bandersnatch.filter import FilterReleasePlugin
+from bandersnatch.filter import FilterReleaseFilePlugin
 
 logger = logging.getLogger("bandersnatch")
 
 
-class ExcludePlatformFilter(FilterReleasePlugin):
+class ExcludePlatformFilter(FilterReleaseFilePlugin):
     """
     Filters releases based on regex patters defined by the user.
     """
@@ -78,31 +78,11 @@ class ExcludePlatformFilter(FilterReleasePlugin):
         logger.info(f"Initialized {self.name} plugin with {self._patterns!r}")
 
     def filter(self, metadata: Dict) -> bool:
-        releases = metadata["releases"]
         """
-        Remove files from `releases` that match any pattern.
+        Returns False if file matches any of the filename patterns
         """
-
-        # Make a copy of releases keys
-        # as we may delete packages during iteration
-        removed = 0
-        versions = list(releases.keys())
-        for version in versions:
-            new_files = []
-            for file_desc in releases[version]:
-                if self._check_match(file_desc):
-                    removed += 1
-                else:
-                    new_files.append(file_desc)
-            if len(new_files) == 0:
-                del releases[version]
-            else:
-                releases[version] = new_files
-        logger.debug(f"{self.name}: filenames removed: {removed}")
-        if not releases:
-            return False
-        else:
-            return True
+        file = metadata["release_file"]
+        return not self._check_match(file)
 
     def _check_match(self, file_desc: Dict) -> bool:
         """

--- a/src/bandersnatch_filter_plugins/prerelease_name.py
+++ b/src/bandersnatch_filter_plugins/prerelease_name.py
@@ -1,6 +1,6 @@
 import logging
 import re
-from typing import Dict
+from typing import Dict, List, Pattern
 
 from bandersnatch.filter import FilterReleasePlugin
 
@@ -19,7 +19,7 @@ class PreReleaseFilter(FilterReleasePlugin):
         r".+b(eta)?\d+$",
         r".+dev\d+$",
     )
-    patterns = None
+    patterns: List[Pattern] = []
 
     def initialize_plugin(self) -> None:
         """
@@ -34,13 +34,7 @@ class PreReleaseFilter(FilterReleasePlugin):
 
     def filter(self, metadata: Dict) -> bool:
         """
-        Remove all release versions that match any of the specified patterns.
+        Returns False if version fails the filter, i.e. follows a prerelease pattern
         """
-        releases = metadata["releases"]
-        for version in list(releases.keys()):
-            if any(pattern.match(version) for pattern in self.patterns):  # type: ignore
-                del releases[version]
-        if not releases:
-            return False
-        else:
-            return True
+        version = metadata["version"]
+        return not any(pattern.match(version) for pattern in self.patterns)

--- a/src/bandersnatch_filter_plugins/regex_name.py
+++ b/src/bandersnatch_filter_plugins/regex_name.py
@@ -36,17 +36,10 @@ class RegexReleaseFilter(FilterReleasePlugin):
 
     def filter(self, metadata: Dict) -> bool:
         """
-        Remove all release versions that match any of the specified patterns.
+        Returns False if version fails the filter, i.e. follows a regex pattern
         """
-        releases = metadata["releases"]
-
-        for version in list(releases.keys()):
-            if any(pattern.match(version) for pattern in self.patterns):
-                del releases[version]
-        if not releases:
-            return False
-        else:
-            return True
+        version = metadata["version"]
+        return not any(pattern.match(version) for pattern in self.patterns)
 
 
 class RegexProjectFilter(FilterProjectPlugin):


### PR DESCRIPTION
Plugins apart of the release_plugin group no longer remove the releases that are passed into the filter.  Release removal is done now in a new function of the Package class ._filter_all_releases().  Also changed the plugin group of the exclude_platform filter to release_file_plugin.

Tests updated to account for new API.  Corrected a linux platform specifier in TestExcludePlatformFilter based on https://github.com/pypa/warehouse/pull/2010