### PR TITLE
Added new allowlist filter

### DIFF
--- a/docs/filtering_configuration.md
+++ b/docs/filtering_configuration.md
@@ -48,9 +48,9 @@ This is useful to avoid syncing broken or malicious packages.
 
 ### packages
 
-The packages setting is a list of python [pep440 version specifier](https://www.python.org/dev/peps/pep-0440/#id51) of packages to not be mirrored.
+The packages setting is a list of python [pep440 version specifier](https://www.python.org/dev/peps/pep-0440/#id51) of packages to not be mirrored. Enable version specifier filtering for whitelist and blacklist packages through enabling the 'blacklist_release' and 'allowlist_release' plugins, respectively.
 
-Any packages matching the version specifier will not be downloaded.
+Any packages matching the version specifier for blacklist packages will not be downloaded. Any packages not matching the version specifier for whitelist packages will not be downloaded.
 
 Example:
 
@@ -58,7 +58,9 @@ Example:
 [plugins]
 enabled =
     blacklist_project
+    blacklist_release
     whitelist_project
+    allowlist_release
 
 [blacklist]
 packages =
@@ -67,7 +69,7 @@ packages =
 
 [whitelist]
 packages =
-    black
+    black==18.5
     ptr
 ```
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -58,6 +58,7 @@ bandersnatch_filter_plugins.v2.release =
     prerelease_release = bandersnatch_filter_plugins.prerelease_name:PreReleaseFilter
     regex_release = bandersnatch_filter_plugins.regex_name:RegexReleaseFilter
     latest_release = bandersnatch_filter_plugins.latest_name:LatestReleaseFilter
+    allowlist_release = bandersnatch_filter_plugins.whitelist_name:AllowlistRelease
 
 # This entrypoint group must match the value of bandersnatch.filter.RELEASE_FILE_PLUGIN_RESOURCE
 bandersnatch_filter_plugins.v2.release_file =

--- a/src/bandersnatch/tests/plugins/test_whitelist_name.py
+++ b/src/bandersnatch/tests/plugins/test_whitelist_name.py
@@ -10,6 +10,7 @@ import bandersnatch.filter
 import bandersnatch.storage
 from bandersnatch.master import Master
 from bandersnatch.mirror import Mirror
+from bandersnatch.package import Package
 
 
 class TestWhitelistProject(TestCase):
@@ -105,3 +106,74 @@ packages =
 
         self.assertIn("foo", mirror.packages_to_sync.keys())
         self.assertNotIn("foo2", mirror.packages_to_sync.keys())
+
+
+class TestAllowlistRelease(TestCase):
+    """
+    Tests for the bandersnatch filtering classes
+    """
+
+    tempdir = None
+    cwd = None
+
+    def setUp(self) -> None:
+        self.cwd = os.getcwd()
+        self.tempdir = TemporaryDirectory()
+        os.chdir(self.tempdir.name)
+
+    def tearDown(self) -> None:
+        if self.tempdir:
+            assert self.cwd
+            os.chdir(self.cwd)
+            self.tempdir.cleanup()
+            self.tempdir = None
+
+    def test__plugin__loads__explicitly_enabled(self) -> None:
+        mock_config(
+            """\
+[plugins]
+enabled =
+    allowlist_release
+"""
+        )
+
+        plugins = bandersnatch.filter.LoadedFilters().filter_release_plugins()
+        names = [plugin.name for plugin in plugins]
+        self.assertListEqual(names, ["allowlist_release"])
+        self.assertEqual(len(plugins), 1)
+
+    def test__plugin__doesnt_load__explicitly__disabled(self) -> None:
+        mock_config(
+            """\
+[plugins]
+enabled =
+    allowlist_package
+"""
+        )
+
+        plugins = bandersnatch.filter.LoadedFilters().filter_release_plugins()
+        names = [plugin.name for plugin in plugins]
+        self.assertNotIn("allowlist_release", names)
+
+    def test__filter__matches__release(self) -> None:
+        mock_config(
+            """\
+[plugins]
+enabled =
+    allowlist_release
+[whitelist]
+packages =
+    foo==1.2.0
+"""
+        )
+
+        mirror = Mirror(Path("."), Master(url="https://foo.bar.com"))
+        pkg = Package("foo", 1, mirror)
+        pkg._metadata = {
+            "info": {"name": "foo"},
+            "releases": {"1.2.0": {}, "1.2.1": {}},
+        }
+
+        pkg._filter_all_releases(mirror.filters.filter_release_plugins())
+
+        self.assertEqual(pkg.releases, {"1.2.0": {}})

--- a/src/bandersnatch_filter_plugins/whitelist_name.py
+++ b/src/bandersnatch_filter_plugins/whitelist_name.py
@@ -1,7 +1,10 @@
 import logging
 from typing import Any, Dict, List, Set
 
-from bandersnatch.filter import FilterProjectPlugin
+from packaging.requirements import Requirement
+from packaging.version import InvalidVersion, Version
+
+from bandersnatch.filter import FilterProjectPlugin, FilterReleasePlugin
 
 logger = logging.getLogger("bandersnatch")
 
@@ -77,3 +80,93 @@ class WhitelistProject(FilterProjectPlugin):
             logger.info(f"Package {name!r} is whitelisted")
             return False
         return True
+
+
+class AllowlistRelease(FilterReleasePlugin):
+    name = "allowlist_release"
+    # Requires iterable default
+    allowlist_package_names: List[Requirement] = []
+
+    def initialize_plugin(self) -> None:
+        """
+        Initialize the plugin
+        """
+        # Generate a list of allowlisted packages from the configuration and
+        # store it into self.allowlist_package_names attribute so this
+        # operation doesn't end up in the fastpath.
+        if not self.allowlist_package_names:
+            self.allowlist_release_requirements = (
+                self._determine_filtered_package_requirements()
+            )
+            logger.info(
+                f"Initialized release plugin {self.name}, filtering "
+                + f"{self.allowlist_release_requirements}"
+            )
+
+    def _determine_filtered_package_requirements(self) -> List[Requirement]:
+        """
+        Parse the configuration file for [whitelist]packages
+
+        Returns
+        -------
+        list of packaging.requirements.Requirement
+            For all PEP440 package specifiers
+        """
+        filtered_requirements: Set[Requirement] = set()
+        try:
+            lines = self.configuration["whitelist"]["packages"]
+            package_lines = lines.split("\n")
+        except KeyError:
+            package_lines = []
+        for package_line in package_lines:
+            package_line = package_line.strip()
+            if not package_line or package_line.startswith("#"):
+                continue
+            filtered_requirements.add(Requirement(package_line))
+        return list(filtered_requirements)
+
+    def filter(self, metadata: Dict) -> bool:
+        """
+        Returns False if version fails the filter,
+        i.e. doesn't matches an allowlist version specifier
+        """
+        name = metadata["info"]["name"]
+        version = metadata["version"]
+        return self._check_match(name, version)
+
+    def _check_match(self, name: str, version_string: str) -> bool:
+        """
+        Check if the package name and version matches against an allowlisted
+        package version specifier.
+
+        Parameters
+        ==========
+        name: str
+            Package name
+
+        version: str
+            Package version
+
+        Returns
+        =======
+        bool:
+            True if it matches, False otherwise.
+        """
+        if not name or not version_string:
+            return False
+
+        try:
+            version = Version(version_string)
+        except InvalidVersion:
+            logger.debug(f"Package {name}=={version_string} has an invalid version")
+            return False
+        for requirement in self.allowlist_release_requirements:
+            if name != requirement.name:
+                continue
+            if version in requirement.specifier:
+                logger.debug(
+                    f"MATCH: Release {name}=={version} matches specifier "
+                    f"{requirement.specifier}"
+                )
+                return True
+        return False


### PR DESCRIPTION
The user can add project specifiers to whitelist packages if they enable this new plugin, 'allowlist_release'.