### PR TITLE
The PyPA has adopted the PSF code of conduct

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ https://github.com/pypa/bandersnatch/issues/new
 
 Everyone interacting in the bandersnatch project's codebases, issue trackers,
 chat rooms, and mailing lists is expected to follow the
-[PyPA Code of Conduct](https://www.pypa.io/en/latest/code-of-conduct/).
+[PSF Code of Conduct](https://github.com/pypa/.github/blob/main/CODE_OF_CONDUCT.md).
 
 ### Kudos
 

--- a/docs/CODE_OF_CONDUCT.md
+++ b/docs/CODE_OF_CONDUCT.md
@@ -2,4 +2,4 @@
 
 Everyone interacting in the bandersnatch project's codebases, issue trackers,
 chat rooms, and mailing lists is expected to follow the
-[PyPA Code of Conduct](https://www.pypa.io/en/latest/code-of-conduct/).
+[PSF Code of Conduct](https://github.com/pypa/.github/blob/main/CODE_OF_CONDUCT.md).

--- a/docs/CODE_OF_CONDUCT.md
+++ b/docs/CODE_OF_CONDUCT.md
@@ -1,5 +1,0 @@
-## Code of Conduct
-
-Everyone interacting in the bandersnatch project's codebases, issue trackers,
-chat rooms, and mailing lists is expected to follow the
-[PSF Code of Conduct](https://github.com/pypa/.github/blob/main/CODE_OF_CONDUCT.md).

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -4,7 +4,7 @@ So you want to help out? **Awesome**. Go you!
 ## Code of Conduct
 Everyone interacting in the bandersnatch project's codebases, issue trackers,
 chat rooms, and mailing lists is expected to follow the
-[PyPA Code of Conduct](https://www.pypa.io/en/latest/code-of-conduct/).
+[PSF Code of Conduct](https://github.com/pypa/.github/blob/main/CODE_OF_CONDUCT.md).
 
 ## Getting Started
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -27,5 +27,4 @@ Contents:
     mirror_configuration
     filtering_configuration
     CONTRIBUTING
-    CODE_OF_CONDUCT
     modules


### PR DESCRIPTION
For details, see:

* https://discuss.python.org/t/implementing-pep-609-pypa-governance/4745