### PR TITLE
Casefold package names in blacklist/whitelist plugins

### DIFF
--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -7,7 +7,7 @@ flake8==3.8.3
 flake8-bugbear==20.1.4
 freezegun==0.3.15
 pre-commit==2.6.0
-pytest==6.0.0rc1
+pytest==6.0.0
 pytest-asyncio==0.14.0
 pytest-timeout==1.4.2
 setuptools==49.2.0

--- a/src/bandersnatch/tests/test_filter.py
+++ b/src/bandersnatch/tests/test_filter.py
@@ -119,6 +119,34 @@ enabled =
             error = True
         self.assertFalse(error)
 
+    def test__filter_project_blacklist_whitelist__pep503_normalize(self) -> None:
+        mock_config(
+            """\
+[plugins]
+enabled =
+    blacklist_project
+    whitelist_project
+
+[blacklist]
+packages =
+    SampleProject
+    trove----classifiers
+
+[whitelist]
+packages =
+    SampleProject
+    trove----classifiers
+"""
+        )
+
+        plugins = LoadedFilters().filter_release_plugins()
+        for plugin in plugins:
+            if plugin.name not in ("blacklist_project", "whitelist_project"):
+                continue
+
+            self.assertTrue(plugin.check_match(name="sampleproject"))
+            self.assertTrue(plugin.check_match(name="trove-classifiers"))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/src/bandersnatch/tests/test_filter.py
+++ b/src/bandersnatch/tests/test_filter.py
@@ -1,4 +1,5 @@
 import os
+import sys
 import unittest
 from tempfile import TemporaryDirectory
 from unittest import TestCase
@@ -25,6 +26,8 @@ class TestBandersnatchFilter(TestCase):
         self.cwd = os.getcwd()
         self.tempdir = TemporaryDirectory()
         os.chdir(self.tempdir.name)
+        sys.stderr.write(self.tempdir.name)
+        sys.stderr.flush()
 
     def tearDown(self) -> None:
         if self.tempdir:
@@ -139,13 +142,18 @@ packages =
 """
         )
 
-        plugins = LoadedFilters().filter_release_plugins()
-        for plugin in plugins:
-            if plugin.name not in ("blacklist_project", "whitelist_project"):
-                continue
+        plugins = {
+            plugin.name: plugin for plugin in LoadedFilters().filter_project_plugins()
+        }
 
-            self.assertTrue(plugin.check_match(name="sampleproject"))
-            self.assertTrue(plugin.check_match(name="trove-classifiers"))
+        self.assertTrue(plugins["blacklist_project"].check_match(name="sampleproject"))
+        self.assertTrue(
+            plugins["blacklist_project"].check_match(name="trove-classifiers")
+        )
+        self.assertFalse(plugins["whitelist_project"].check_match(name="sampleproject"))
+        self.assertFalse(
+            plugins["whitelist_project"].check_match(name="trove-classifiers")
+        )
 
 
 if __name__ == "__main__":

--- a/src/bandersnatch_filter_plugins/blacklist_name.py
+++ b/src/bandersnatch_filter_plugins/blacklist_name.py
@@ -44,7 +44,7 @@ class BlacklistProject(FilterProjectPlugin):
         except KeyError:
             package_lines = []
         for package_line in package_lines:
-            package_line = package_line.strip()
+            package_line = package_line.strip().casefold()
             if not package_line or package_line.startswith("#"):
                 continue
             package_requirement = Requirement(package_line)
@@ -84,7 +84,7 @@ class BlacklistProject(FilterProjectPlugin):
         if not name:
             return False
 
-        if name in self.blacklist_package_names:
+        if name.casefold() in self.blacklist_package_names:
             logger.info(f"Package {name!r} is blacklisted")
             return True
         return False

--- a/src/bandersnatch_filter_plugins/blacklist_name.py
+++ b/src/bandersnatch_filter_plugins/blacklist_name.py
@@ -2,6 +2,7 @@ import logging
 from typing import Any, Dict, List, Set
 
 from packaging.requirements import Requirement
+from packaging.utils import canonicalize_name
 from packaging.version import InvalidVersion, Version
 
 from bandersnatch.filter import FilterProjectPlugin, FilterReleasePlugin
@@ -44,7 +45,7 @@ class BlacklistProject(FilterProjectPlugin):
         except KeyError:
             package_lines = []
         for package_line in package_lines:
-            package_line = package_line.strip().casefold()
+            package_line = canonicalize_name(package_line.strip())
             if not package_line or package_line.startswith("#"):
                 continue
             package_requirement = Requirement(package_line)
@@ -84,7 +85,7 @@ class BlacklistProject(FilterProjectPlugin):
         if not name:
             return False
 
-        if name.casefold() in self.blacklist_package_names:
+        if canonicalize_name(name) in self.blacklist_package_names:
             logger.info(f"Package {name!r} is blacklisted")
             return True
         return False

--- a/src/bandersnatch_filter_plugins/whitelist_name.py
+++ b/src/bandersnatch_filter_plugins/whitelist_name.py
@@ -18,8 +18,8 @@ class WhitelistProject(FilterProjectPlugin):
         """
         Initialize the plugin
         """
-        # Generate a list of blacklisted packages from the configuration and
-        # store it into self.blacklist_package_names attribute so this
+        # Generate a list of whitelisted packages from the configuration and
+        # store it into self.whitelist_package_names attribute so this
         # operation doesn't end up in the fastpath.
         if not self.whitelist_package_names:
             self.whitelist_package_names = self._determine_unfiltered_package_names()
@@ -35,7 +35,7 @@ class WhitelistProject(FilterProjectPlugin):
         """
         # This plugin only processes packages, if the line in the packages
         # configuration contains a PEP440 specifier it will be processed by the
-        # blacklist release filter.  So we need to remove any packages that
+        # whitelist release filter.  So we need to remove any packages that
         # are not applicable for this plugin.
         unfiltered_packages: Set[str] = set()
         try:
@@ -44,7 +44,7 @@ class WhitelistProject(FilterProjectPlugin):
         except KeyError:
             package_lines = []
         for package_line in package_lines:
-            package_line = package_line.strip()
+            package_line = package_line.strip().casefold()
             if not package_line or package_line.startswith("#"):
                 continue
             unfiltered_packages.add(package_line)
@@ -55,14 +55,14 @@ class WhitelistProject(FilterProjectPlugin):
 
     def check_match(self, **kwargs: Any) -> bool:
         """
-        Check if the package name matches against a project that is blacklisted
+        Check if the package name matches against a project that is whitelisted
         in the configuration.
 
         Parameters
         ==========
         name: str
             The normalized package name of the package/project to check against
-            the blacklist.
+            the whitelist.
 
         Returns
         =======
@@ -76,7 +76,7 @@ class WhitelistProject(FilterProjectPlugin):
         if not name:
             return False
 
-        if name in self.whitelist_package_names:
+        if name.casefold() in self.whitelist_package_names:
             logger.info(f"Package {name!r} is whitelisted")
             return False
         return True

--- a/src/bandersnatch_filter_plugins/whitelist_name.py
+++ b/src/bandersnatch_filter_plugins/whitelist_name.py
@@ -2,6 +2,7 @@ import logging
 from typing import Any, Dict, List, Set
 
 from packaging.requirements import Requirement
+from packaging.utils import canonicalize_name
 from packaging.version import InvalidVersion, Version
 
 from bandersnatch.filter import FilterProjectPlugin, FilterReleasePlugin
@@ -44,7 +45,7 @@ class WhitelistProject(FilterProjectPlugin):
         except KeyError:
             package_lines = []
         for package_line in package_lines:
-            package_line = package_line.strip().casefold()
+            package_line = canonicalize_name(package_line.strip())
             if not package_line or package_line.startswith("#"):
                 continue
             unfiltered_packages.add(package_line)
@@ -76,7 +77,7 @@ class WhitelistProject(FilterProjectPlugin):
         if not name:
             return False
 
-        if name.casefold() in self.whitelist_package_names:
+        if canonicalize_name(name) in self.whitelist_package_names:
             logger.info(f"Package {name!r} is whitelisted")
             return False
         return True


### PR DESCRIPTION
This PR aims to fix #284 by casefolding package names listed in the bandersnatch configuration as well as those obtained from the XML-RPC when checking for a match.

Also fixes copy-pasta remnants in the whitelist plugin comments/docstrings.