### PR TITLE
Add plugins to documentation (and a few other documentation changes too)

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,23 @@
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+version: 2
+
+sphinx:
+  builder: html
+  configuration: docs/conf.py
+  # It's probably better if we have slightly outdated but known good documentation
+  # up than having (possibly very) broken documentation.
+  fail_on_warning: true
+
+formats:
+  - pdf
+  - htmlzip
+  - epub
+
+python:
+  version: 3.7
+  install:
+    - method: pip
+      path: .
+    - requirements: requirements_docs.txt  # By extension, this installs requirements_swift.txt too

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -42,6 +42,10 @@ python3 -m venv /path/to/venv
 
 - To verify any changes in the documentation:
 
+**NOTICE:** This effectively installs `requirements_swift` *and* `requirements_docs.txt`
+since the dependencies are needed by autodoc which imports all of bandersnatch during
+documention building. So pip will install **a lot** of dependencies.
+
 ```
 /path/to/venv/bin/pip install -r requirements_docs.txt
 ```

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -26,7 +26,7 @@ Lets now cd to where we want the code and clone the repo:
 
 One way to develop and install all the dependencies of bandersnatch is to use a venv.
 
-- Lets create one and upgrade `pip`
+- Lets create one and upgrade `pip` and `setuptools`.
 
 ```
 python3 -m venv /path/to/venv
@@ -50,7 +50,7 @@ documention building. So pip will install **a lot** of dependencies.
 /path/to/venv/bin/pip install -r requirements_docs.txt
 ```
 
-- Finally install the bandersnatch in editable mode:
+- Finally install bandersnatch in editable mode:
 
 ```
 /path/to/venv/bin/pip install -e .

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -6,11 +6,11 @@ maintainers hold and can conduct.
 ## Summary of being a Maintainer of `bandersnatch`
 
 - **Issue Triage**
-  - Asses if the Issue is accurate + reproducible
-  - If feature, asses if this fits the *bandersnatch mission*
+  - Assesses if the Issue is accurate + reproducible
+  - If the issue is a feature request, assesses if it fits the *bandersnatch mission*
 - **PR Merging**
-  - Access Pull Requests for suitability and adherence to the *bandersnatch mission*
-- If is preferred that big changes be pulling in from *branches* via *Pull Requests*
+  - Accesses Pull Requests for suitability and adherence to the *bandersnatch mission*
+- It is preferred that big changes be pulling in from *branches* via *Pull Requests*
   - Peer reviewed by another maintainer
 - **Releases**
 - You will have **"the commit bit"** access
@@ -27,7 +27,7 @@ maintainers hold and can conduct.
 ### Evaluating Issues and Pull Requests
 
 Please always think of the mission of bandersnatch. We should just mirror in a
-compatible way a PEP381 mirror. Simple is always better than complex and all *bug*
+compatible way like a PEP381 mirror. Simple is always better than complex and all *bug*
 issues need to be reproducable for our developers.
 
 #### pyup.io

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ this project.
 
 - If interested contact @cooperlees
 
-`bandersnatch` has it's dependencies kept up to date by **[pyup.io](https://pyup.io/)**!
+`bandersnatch` has its dependencies kept up to date by **[pyup.io](https://pyup.io/)**!
 
 - If you'd like to have your dependencies kept up to date in your `requirements.txt` or `setup.cfg`,
   this is the service for you!

--- a/docs/bandersnatch.rst
+++ b/docs/bandersnatch.rst
@@ -1,6 +1,14 @@
 bandersnatch package
 ====================
 
+Package contents
+----------------
+
+.. automodule:: bandersnatch
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 Submodules
 ----------
 
@@ -88,15 +96,6 @@ bandersnatch.verify module
 --------------------------
 
 .. automodule:: bandersnatch.verify
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
-
-Module contents
----------------
-
-.. automodule:: bandersnatch
    :members:
    :undoc-members:
    :show-inheritance:

--- a/docs/bandersnatch_filter_plugins.rst
+++ b/docs/bandersnatch_filter_plugins.rst
@@ -28,8 +28,8 @@ bandersnatch_filter_plugins.filename_name module
    :undoc-members:
    :show-inheritance:
 
-bandersnatch.latest_name module
--------------------------------
+bandersnatch_filter_plugins.latest_name module
+----------------------------------------------
 
 .. automodule:: bandersnatch_filter_plugins.latest_name
    :members:

--- a/docs/bandersnatch_filter_plugins.rst
+++ b/docs/bandersnatch_filter_plugins.rst
@@ -1,0 +1,69 @@
+bandersnatch_filter_plugins package
+===================================
+
+Package contents
+----------------
+
+.. automodule:: bandersnatch_filter_plugins
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Submodules
+----------
+
+bandersnatch_filter_plugins.blacklist_name module
+-------------------------------------------------
+
+.. automodule:: bandersnatch_filter_plugins.blacklist_name
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+bandersnatch_filter_plugins.filename_name module
+------------------------------------------------
+
+.. automodule:: bandersnatch_filter_plugins.filename_name
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+bandersnatch.latest_name module
+-------------------------------
+
+.. automodule:: bandersnatch_filter_plugins.latest_name
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+bandersnatch_filter_plugins.metadata_filter module
+--------------------------------------------------
+
+.. automodule:: bandersnatch_filter_plugins.metadata_filter
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+bandersnatch_filter_plugins.prerelease_name module
+--------------------------------------------------
+
+.. automodule:: bandersnatch_filter_plugins.prerelease_name
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+bandersnatch_filter_plugins.regex_name module
+---------------------------------------------
+
+.. automodule:: bandersnatch_filter_plugins.regex_name
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+bandersnatch_filter_plugins.whitelist_name module
+-------------------------------------------------
+
+.. automodule:: bandersnatch_filter_plugins.whitelist_name
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/bandersnatch_storage_plugins.rst
+++ b/docs/bandersnatch_storage_plugins.rst
@@ -1,0 +1,29 @@
+bandersnatch_storage_plugins package
+====================================
+
+Package contents
+----------------
+
+.. automodule:: bandersnatch_storage_plugins
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Submodules
+----------
+
+bandersnatch_storage_plugins.filesystem module
+----------------------------------------------
+
+.. automodule:: bandersnatch_storage_plugins.filesystem
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+bandersnatch_storage_plugins.swift module
+-----------------------------------------
+
+.. automodule:: bandersnatch_storage_plugins.swift
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -23,6 +23,10 @@ except ImportError:
 # If your documentation needs a minimal Sphinx version, state it here.
 needs_sphinx = "3.0"
 
+# epub build warns about .nojekyll of which Sphinx creates on build,
+# so just ignore the warning since we can't do anything a-boat it :D
+suppress_warnings = ["epub.unknown_project_files"]
+
 # Just a protection against an incompatible version of recommonmark.
 # The listed version is the minimal version required for that extension.
 needs_extensions = {"recommonmark": "0.5"}
@@ -69,6 +73,7 @@ if hasattr(doc_module, "__copyright__"):
 version = "0.0.0"
 if hasattr(doc_module, "__version__"):
     version = doc_module.__version__
+
 # The full version, including alpha/beta/rc tags.
 release = version
 

--- a/docs/filtering_configuration.md
+++ b/docs/filtering_configuration.md
@@ -4,11 +4,11 @@ The mirror filter configuration settings are in the same configuration file as t
 There are different configuration sections for the different plugin types.
 
 Filtering Plugin pacakage lists need to use the **Raw PyPI Name**
-(non [PEP503](https://www.python.org/dev/peps/pep-0503/#normalized-names) normailized)
+(non [PEP503](https://www.python.org/dev/peps/pep-0503/#normalized-names) normalized)
 in order to get filtered.
 
 E.g. to Blacklist [ACMPlus](https://pypi.org/project/ACMPlus/) you'd need to
-use that *exact* case in `bandersnatch.conf`
+use that *exact* casing in `bandersnatch.conf`
 
 - A PR would be welcome fixing the normalization but it's an invasive PR
 
@@ -40,9 +40,9 @@ enabled =
 
 ### blacklist / whitelist filtering settings
 
-The blacklist settings are in a configuration sections named **\[blacklist\]** and **\[whitelist\]**
-this section provides settings to indicate packages, projects and releases that should
-not be mirrored from PyPI.
+The blacklist / whitelist settings are in configuration sections named **\[blacklist\]** and **\[whitelist\]**
+these section provides settings to indicate packages, projects and releases that should /
+should not be mirrored from PyPI.
 
 This is useful to avoid syncing broken or malicious packages.
 

--- a/docs/mirror_configuration.md
+++ b/docs/mirror_configuration.md
@@ -83,7 +83,7 @@ Recommendations for the workers setting:
 
 ### hash-index
 
-The hash-index is a boolean (true/false) ot determine if package hashing should be used.
+The hash-index is a boolean (true/false) to determine if package hashing should be used.
 
 The Recommended setting: the default of false for full pip/pypi compatibility.
 
@@ -112,7 +112,7 @@ rewrite ^/simple/([^/])([^/]*)/([^/]+)$/ /simple/$1/$1$2/$3 last;
 ### stop-on-error
 
 The stop-on-error setting is a boolean (true/false) setting that indicates if bandersnatch
-should execute immediately if it encounters an error.
+should stop immediately if it encounters an error.
 
 If this setting is false it will not stop when an error is encountered but it will not
 mark the sync as successful when the sync is complete.
@@ -124,7 +124,7 @@ stop-on-error = false
 
 ### log-config
 
-The log-config setting is as string containing the filename of a python logging configuration
+The log-config setting is a string containing the filename of a python logging configuration
 file.
 
 Example:

--- a/docs/modules.rst
+++ b/docs/modules.rst
@@ -5,3 +5,5 @@ bandersnatch
    :maxdepth: 4
 
    bandersnatch
+   bandersnatch_filter_plugins
+   bandersnatch_storage_plugins

--- a/requirements_docs.txt
+++ b/requirements_docs.txt
@@ -10,3 +10,8 @@ xmlrpc2==0.3.1
 
 git+https://github.com/pypa/pypa-docs-theme.git#egg=pypa-docs-theme
 git+https://github.com/python/python-docs-theme.git#egg=python-docs-theme
+
+# This is needed since autodoc imports all bandersnatch packages and modules
+# so imports must not fail or its containing module will NOT be documented.
+# Also, it will cause the doc build to fail since it raises a warning.
+-r requirements_swift.txt

--- a/requirements_docs.txt
+++ b/requirements_docs.txt
@@ -13,5 +13,6 @@ git+https://github.com/python/python-docs-theme.git#egg=python-docs-theme
 
 # This is needed since autodoc imports all bandersnatch packages and modules
 # so imports must not fail or its containing module will NOT be documented.
-# Also, it will cause the doc build to fail since it raises a warning.
+# Also, the missing swift dependencies will cause the doc build to fail since
+# autodoc will raise a warning due to the import failure.
 -r requirements_swift.txt

--- a/src/bandersnatch/__init__.py
+++ b/src/bandersnatch/__init__.py
@@ -1,4 +1,7 @@
 #!/usr/bin/env python3
+
+__copyright__ = "2010-2020, PyPA"
+
 from typing import NamedTuple
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -14,7 +14,6 @@ extras = swift
 [testenv:doc_build]
 basepython=python3
 commands =
-    {envpython} {envbindir}/sphinx-apidoc -f -o docs src/bandersnatch
     {envpython} {envbindir}/sphinx-build -a -W -b html docs docs/html
 changedir = {toxinidir}
 deps =


### PR DESCRIPTION
Updated version here ~(currently a bit broken, see to-do list below)~:
https://ichard26-testbandersnatchdocs.readthedocs.io/en/add_plugins_to_docs/index.html

To-do list:
- [x] Add entries so bandersnatch plugins are picked up by autodoc
- [x] Fix installation and import failures
- [x] Fix epub build
  - [x] Ignore `unknown mimetype for '.nojekyll'` warning ~(unpushed yet)~
  - [x] Fill in the copyright field in `docs/conf.py`  - waiting for what to put here from cooperlees :) 
- [x] Look into and fix Travis CI failure ...
- [x] Final checks and maybe a merge from master