### PR TITLE
Make webdir/pypi/json/PKG symlinks relative.

### DIFF
--- a/src/bandersnatch/package.py
+++ b/src/bandersnatch/package.py
@@ -2,6 +2,7 @@ import asyncio
 import hashlib
 import html
 import logging
+import os
 import sys
 from json import dump
 from pathlib import Path
@@ -103,7 +104,9 @@ class Package:
         # In 4.0 we move to normalized name only so want to overwrite older symlinks
         if self.json_pypi_symlink.exists():
             self.json_pypi_symlink.unlink()
-        self.json_pypi_symlink.symlink_to(self.json_file)
+        self.json_pypi_symlink.symlink_to(
+            os.path.relpath(self.json_file, self.json_pypi_symlink.parent)
+        )
 
         return True
 

--- a/src/bandersnatch/tests/test_package.py
+++ b/src/bandersnatch/tests/test_package.py
@@ -46,7 +46,7 @@ def test_save_json_metadata(mirror: Mirror, package_json: Dict[str, Any]) -> Non
     package.json_pypi_symlink.symlink_to(Path(gettempdir()))
     assert package.save_json_metadata(package_json)
     assert package.json_pypi_symlink.is_symlink()
-    assert Path("../../json/foo") == Path(os.readlink(package.json_pypi_symlink))
+    assert Path("../../json/foo") == Path(os.readlink(str(package.json_pypi_symlink)))
 
 
 @pytest.mark.asyncio

--- a/src/bandersnatch/tests/test_package.py
+++ b/src/bandersnatch/tests/test_package.py
@@ -45,6 +45,8 @@ def test_save_json_metadata(mirror: Mirror, package_json: Dict[str, Any]) -> Non
     package.json_pypi_symlink.parent.mkdir(parents=True)
     package.json_pypi_symlink.symlink_to(Path(gettempdir()))
     assert package.save_json_metadata(package_json)
+    assert package.json_pypi_symlink.is_symlink()
+    assert Path("../../json/foo") == Path(os.readlink(package.json_pypi_symlink))
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
In order to assist changing the mirror location or maintaining an
offline mirror at a different path symlinks to webdir/json/PKG should be
relative, addresses #636 