### PR TITLE
Fix passing package info to filters in verify action.

### DIFF
--- a/src/bandersnatch/verify.py
+++ b/src/bandersnatch/verify.py
@@ -116,7 +116,7 @@ async def verify(
 
     # apply releases filter plugins like class Package
     for plugin in LoadedFilters().filter_release_plugins() or []:
-        plugin.filter(pkg["info"])
+        plugin.filter(pkg)
 
     for release_version in pkg[releases_key]:
         for jpkg in pkg[releases_key][release_version]:


### PR DESCRIPTION
Plugin filters appear to now require the full pkg dict rather than just the "info" section.