### PR TITLE
Fixed allow/blocklist_release filtering prereleases

### DIFF
--- a/src/bandersnatch/tests/plugins/test_allowlist_name.py
+++ b/src/bandersnatch/tests/plugins/test_allowlist_name.py
@@ -199,3 +199,33 @@ packages =
         pkg._filter_all_releases(mirror.filters.filter_release_plugins())
 
         self.assertEqual(pkg.releases, {"1.2.0": {}})
+
+    def test__dont__filter__prereleases(self) -> None:
+        mock_config(
+            """\
+[plugins]
+enabled =
+    allowlist_release
+[allowlist]
+packages =
+    foo<=1.2.0
+"""
+        )
+
+        mirror = Mirror(Path("."), Master(url="https://foo.bar.com"))
+        pkg = Package("foo", 1, mirror)
+        pkg._metadata = {
+            "info": {"name": "foo"},
+            "releases": {
+                "1.1.0a2": {},
+                "1.1.1beta1": {},
+                "1.2.0": {},
+                "1.2.1": {},
+                "1.2.2alpha3": {},
+                "1.2.3rc1": {},
+            },
+        }
+
+        pkg._filter_all_releases(mirror.filters.filter_release_plugins())
+
+        self.assertEqual(pkg.releases, {"1.1.0a2": {}, "1.1.1beta1": {}, "1.2.0": {}})

--- a/src/bandersnatch/tests/plugins/test_blocklist_name.py
+++ b/src/bandersnatch/tests/plugins/test_blocklist_name.py
@@ -196,3 +196,33 @@ packages =
         pkg._filter_all_releases(mirror.filters.filter_release_plugins())
 
         self.assertEqual(pkg.releases, {"1.2.1": {}})
+
+    def test__dont__filter__prereleases(self) -> None:
+        mock_config(
+            """\
+[plugins]
+enabled =
+    blocklist_release
+[blocklist]
+packages =
+    foo<=1.2.0
+"""
+        )
+
+        mirror = Mirror(Path("."), Master(url="https://foo.bar.com"))
+        pkg = Package("foo", 1, mirror)
+        pkg._metadata = {
+            "info": {"name": "foo"},
+            "releases": {
+                "1.1.0a2": {},
+                "1.1.1beta1": {},
+                "1.2.0": {},
+                "1.2.1": {},
+                "1.2.2alpha3": {},
+                "1.2.3rc1": {},
+            },
+        }
+
+        pkg._filter_all_releases(mirror.filters.filter_release_plugins())
+
+        self.assertEqual(pkg.releases, {"1.2.1": {}, "1.2.2alpha3": {}, "1.2.3rc1": {}})

--- a/src/bandersnatch_filter_plugins/allowlist_name.py
+++ b/src/bandersnatch_filter_plugins/allowlist_name.py
@@ -125,7 +125,9 @@ class AllowListRelease(FilterReleasePlugin):
             package_line = package_line.strip()
             if not package_line or package_line.startswith("#"):
                 continue
-            filtered_requirements.add(Requirement(package_line))
+            requirement = Requirement(package_line)
+            requirement.specifier.prereleases = True
+            filtered_requirements.add(requirement)
         return list(filtered_requirements)
 
     def filter(self, metadata: Dict) -> bool:

--- a/src/bandersnatch_filter_plugins/blocklist_name.py
+++ b/src/bandersnatch_filter_plugins/blocklist_name.py
@@ -133,7 +133,9 @@ class BlockListRelease(FilterReleasePlugin):
             package_line = package_line.strip()
             if not package_line or package_line.startswith("#"):
                 continue
-            filtered_requirements.add(Requirement(package_line))
+            requirement = Requirement(package_line)
+            requirement.specifier.prereleases = True
+            filtered_requirements.add(requirement)
         return list(filtered_requirements)
 
     def filter(self, metadata: Dict) -> bool:


### PR DESCRIPTION
allowlist_release and blocklist_release were using the default construction of the Requirements object which creates a SpecifierSet in order to check requirements.  This SpecifierSet has a field 'prereleases' that gets set to false by default [0] and thus makes any comparisons against prerelease version specifiers return false even if the version would normally fall within the SpecifierSet.  Because of this behaviour allowlist_release and blocklist_release were filtering prereleases even if the prerelease filter wasn't set.

[0] https://packaging.pypa.io/en/latest/specifiers/#packaging.specifiers.SpecifierSet