### PR TITLE
add __main__ and program name override to ArgumentParser

### DIFF
--- a/src/bandersnatch/__main__.py
+++ b/src/bandersnatch/__main__.py
@@ -1,0 +1,3 @@
+from . import main
+
+exit(main.main())

--- a/src/bandersnatch/main.py
+++ b/src/bandersnatch/main.py
@@ -143,7 +143,9 @@ async def async_main(args: argparse.Namespace, config: ConfigParser) -> int:
 
 
 def main(loop: Optional[asyncio.AbstractEventLoop] = None) -> int:
-    parser = argparse.ArgumentParser(description="PyPI PEP 381 mirroring client.")
+    parser = argparse.ArgumentParser(
+        description="PyPI PEP 381 mirroring client.", prog="bandersnatch"
+    )
     parser.add_argument(
         "--version", action="version", version=f"%(prog)s {bandersnatch.__version__}"
     )


### PR DESCRIPTION
Fixes #383.

This should allow bandersnatch to be called with `python -m bandersnatch` for use with e.g. PyOxidizer.