### PR TITLE
Fixed name parsing issue for allow/blocklist project filters

### DIFF
--- a/src/bandersnatch_filter_plugins/allowlist_name.py
+++ b/src/bandersnatch_filter_plugins/allowlist_name.py
@@ -46,10 +46,10 @@ class AllowListProject(FilterProjectPlugin):
         except KeyError:
             package_lines = []
         for package_line in package_lines:
-            package_line = canonicalize_name(package_line.strip())
+            package_line = package_line.strip()
             if not package_line or package_line.startswith("#"):
                 continue
-            unfiltered_packages.add(Requirement(package_line).name)
+            unfiltered_packages.add(canonicalize_name(Requirement(package_line).name))
         return list(unfiltered_packages)
 
     def filter(self, metadata: Dict) -> bool:
@@ -126,6 +126,7 @@ class AllowListRelease(FilterReleasePlugin):
             if not package_line or package_line.startswith("#"):
                 continue
             requirement = Requirement(package_line)
+            requirement.name = canonicalize_name(requirement.name)
             requirement.specifier.prereleases = True
             filtered_requirements.add(requirement)
         return list(filtered_requirements)
@@ -137,7 +138,7 @@ class AllowListRelease(FilterReleasePlugin):
         """
         name = metadata["info"]["name"]
         version = metadata["version"]
-        return self._check_match(name, version)
+        return self._check_match(canonicalize_name(name), version)
 
     def _check_match(self, name: str, version_string: str) -> bool:
         """

--- a/src/bandersnatch_filter_plugins/blocklist_name.py
+++ b/src/bandersnatch_filter_plugins/blocklist_name.py
@@ -46,7 +46,7 @@ class BlockListProject(FilterProjectPlugin):
         except KeyError:
             package_lines = []
         for package_line in package_lines:
-            package_line = canonicalize_name(package_line.strip())
+            package_line = package_line.strip()
             if not package_line or package_line.startswith("#"):
                 continue
             package_requirement = Requirement(package_line)
@@ -59,7 +59,7 @@ class BlockListProject(FilterProjectPlugin):
                     package_requirement.name,
                 )
                 continue
-            filtered_packages.add(Requirement(package_line).name)
+            filtered_packages.add(canonicalize_name(package_requirement.name))
         logger.debug("Project blocklist is %r", list(filtered_packages))
         return list(filtered_packages)
 
@@ -134,6 +134,7 @@ class BlockListRelease(FilterReleasePlugin):
             if not package_line or package_line.startswith("#"):
                 continue
             requirement = Requirement(package_line)
+            requirement.name = canonicalize_name(requirement.name)
             requirement.specifier.prereleases = True
             filtered_requirements.add(requirement)
         return list(filtered_requirements)
@@ -145,7 +146,7 @@ class BlockListRelease(FilterReleasePlugin):
         """
         name = metadata["info"]["name"]
         version = metadata["version"]
-        return not self._check_match(name, version)
+        return not self._check_match(canonicalize_name(name), version)
 
     def _check_match(self, name: str, version_string: str) -> bool:
         """


### PR DESCRIPTION
Allowlist/blocklist project filters now create the Requirement object first before canonicalizing the package's name. This prevents canonicalize_name() from messing with the package's version specifier, if it was present, which could have caused a parse error inside the Requirement object if the package had the specifier "~=". Also, allowlist/blocklist release filters now how their package names canonicalized before checking to prevent casing mismatches.