### PR TITLE
Fix latest_release plugin

### DIFF
--- a/src/bandersnatch/tests/plugins/test_latest_release.py
+++ b/src/bandersnatch/tests/plugins/test_latest_release.py
@@ -100,6 +100,48 @@ keep = 2
 
         assert pkg.releases == {"2.0.1b2": {}, "2.0.0": {}}
 
+    def test_latest_releases_ensure_reusable(self) -> None:
+        """
+        Tests the filter multiple times to ensure no state is preserved and
+        thus is reusable between packages
+        """
+        mock_config(self.config_contents)
+
+        mirror = BandersnatchMirror(Path("."), Master(url="https://foo.bar.com"))
+        pkg1 = Package("foo", 1)
+        pkg1._metadata = {
+            "info": {"name": "foo", "version": "2.0.0"},
+            "releases": {
+                "0.1.1": {},
+                "0.1.2": {},
+                "0.1.3": {},
+                "1.0.0": {},
+                "1.1.0": {},
+                "1.2.0": {},
+                "2.0.0": {},
+            },
+        }
+        pkg2 = Package("bar", 1)
+        pkg2._metadata = {
+            "info": {"name": "bar", "version": "0.3.0"},
+            "releases": {
+                "0.1.0": {},
+                "0.1.1": {},
+                "0.1.2": {},
+                "0.1.3": {},
+                "0.1.4": {},
+                "0.1.5": {},
+                "0.2.0": {},
+                "0.3.0": {},
+            },
+        }
+
+        pkg1.filter_all_releases(mirror.filters.filter_release_plugins())
+        pkg2.filter_all_releases(mirror.filters.filter_release_plugins())
+
+        assert pkg1.releases == {"1.2.0": {}, "2.0.0": {}}
+        assert pkg2.releases == {"0.2.0": {}, "0.3.0": {}}
+
 
 class TestLatestReleaseFilterUninitialized(BasePluginTestCase):
 

--- a/src/bandersnatch_filter_plugins/latest_name.py
+++ b/src/bandersnatch_filter_plugins/latest_name.py
@@ -1,6 +1,6 @@
 import logging
 from operator import itemgetter
-from typing import Dict, Sequence, Tuple, Union
+from typing import Dict, Iterator, Tuple, Union
 
 from packaging.version import LegacyVersion, Version, parse
 
@@ -38,21 +38,23 @@ class LatestReleaseFilter(FilterReleasePlugin):
         Returns False if version fails the filter, i.e. is not a latest/current release
         """
 
-        info = metadata["info"]
-        releases = metadata["releases"]
-        version = metadata["version"]
+        info: Dict = metadata["info"]
+        releases: Dict = metadata["releases"]
+        version: str = metadata["version"]
 
         if self.keep == 0 or self.keep > len(releases):
             return True
 
-        versions_pair = map(lambda v: (parse(v), v), releases.keys())
+        versions_pair: Iterator[Tuple[Union[LegacyVersion, Version], str]] = map(
+            lambda v: (parse(v), v), releases.keys()
+        )
         # Sort all versions
         versions_sorted = sorted(versions_pair, reverse=True)
         # Select the first few (larger) items
-        versions_allowed = versions_sorted[:self.keep]
+        versions_allowed = versions_sorted[: self.keep]
         # Collect string versions back into a list
         version_names = list(map(itemgetter(1), versions_allowed))
-        
+
         # Add back latest version if necessary
         if info.get("version") not in version_names:
             version_names[-1] = info.get("version")

--- a/src/bandersnatch_filter_plugins/latest_name.py
+++ b/src/bandersnatch_filter_plugins/latest_name.py
@@ -52,5 +52,9 @@ class LatestReleaseFilter(FilterReleasePlugin):
         versions_allowed = versions_sorted[:self.keep]
         # Collect string versions back into a list
         version_names = list(map(itemgetter(1), versions_allowed))
+        
+        # Add back latest version if necessary
+        if info.get("version") not in version_names:
+            version_names[-1] = info.get("version")
 
         return version in version_names

--- a/src/bandersnatch_filter_plugins/latest_name.py
+++ b/src/bandersnatch_filter_plugins/latest_name.py
@@ -16,7 +16,6 @@ class LatestReleaseFilter(FilterReleasePlugin):
 
     name = "latest_release"
     keep = 0  # by default, keep 'em all
-    latest: Sequence[str] = []
 
     def initialize_plugin(self) -> None:
         """
@@ -38,31 +37,20 @@ class LatestReleaseFilter(FilterReleasePlugin):
         """
         Returns False if version fails the filter, i.e. is not a latest/current release
         """
-        if self.keep == 0:
+
+        info = metadata["info"]
+        releases = metadata["releases"]
+        version = metadata["version"]
+
+        if self.keep == 0 or self.keep > len(releases):
             return True
 
-        if not self.latest:
-            info = metadata["info"]
-            releases = metadata["releases"]
-            versions = list(releases.keys())
-            before = len(versions)
+        versions_pair = map(lambda v: (parse(v), v), releases.keys())
+        # Sort all versions
+        versions_sorted = sorted(versions_pair, reverse=True)
+        # Select the first few (larger) items
+        versions_allowed = versions_sorted[:self.keep]
+        # Collect string versions back into a list
+        version_names = list(map(itemgetter(1), versions_allowed))
 
-            if before <= self.keep:
-                # not enough releases: do nothing
-                return True
-
-            versions_pair = map(lambda v: (parse(v), v), versions)
-            latest_sorted: Sequence[Tuple[Union[LegacyVersion, Version], str]] = sorted(
-                versions_pair
-            )[
-                -self.keep :  # noqa: E203
-            ]
-            self.latest = list(map(itemgetter(1), latest_sorted))
-
-            current_version = info.get("version")
-            if current_version and (current_version not in self.latest):
-                # never remove the stable/official version
-                self.latest[0] = current_version
-
-        version = metadata["version"]
-        return version in self.latest
+        return version in version_names


### PR DESCRIPTION
Closes #659 

# Tasks Left

- [x] Run code
- [x] Look into writing tests to prevent such regressions from happening again
- [x] Fix additional and missing spaces

# Discussion

- Should we reintroduce the caching mechanism? Doing so only divides the time complexity by `self.keep`, which shouldn't be big anyway. 