### PR TITLE
Add support for skipping mirroring release files

### DIFF
--- a/docs/mirror_configuration.md
+++ b/docs/mirror_configuration.md
@@ -35,9 +35,9 @@ json = false
 ### release-files
 
 The mirror release-files setting is a boolean (true/false) setting that indicates that
-the package release files should be mirrored. Defaults to `true`. When specified, you
-must also specify the `root_uri` configuration. If the uri is empty, it will be set
-to https://files.pythonhosted.org.
+the package release files should be mirrored. Defaults to `true`. When this option is disabled (via setting to false), you
+should also specify the `root_uri` configuration. If the uri is empty, it will be set
+to https://files.pythonhosted.org/.
 
 Example:
 ``` ini

--- a/docs/mirror_configuration.md
+++ b/docs/mirror_configuration.md
@@ -32,6 +32,19 @@ Example:
 json = false
 ```
 
+### release-files
+
+The mirror release-files setting is a boolean (true/false) setting that indicates that
+the package release files should be mirrored. Defaults to `true`. When specified, you
+must also specify the `root_uri` configuration. If the uri is empty, it will be set
+to https://files.pythonhosted.org.
+
+Example:
+``` ini
+[mirror]
+release-files = true
+```
+
 ### master
 
 The master setting is a string containing a url of the server which will be mirrored.

--- a/src/bandersnatch/configuration.py
+++ b/src/bandersnatch/configuration.py
@@ -28,6 +28,7 @@ class SetConfigValues(NamedTuple):
     digest_name: str
     storage_backend_name: str
     cleanup: bool
+    release_files_save: bool
 
 
 class Singleton(type):  # pragma: no cover
@@ -160,6 +161,15 @@ def validate_config_values(config: configparser.ConfigParser) -> SetConfigValues
         )
         cleanup = False
 
+    release_files_save = config.getboolean("mirror", "release-files", fallback=True)
+    if not release_files_save and not root_uri:
+        root_uri = "https://files.pythonhosted.org"
+        logger.error(
+            "Please update your config to include a root_uri in the [mirror] "
+            + "section when disabling release file sync. Setting to "
+            + root_uri
+        )
+
     return SetConfigValues(
         json_save,
         root_uri,
@@ -168,4 +178,5 @@ def validate_config_values(config: configparser.ConfigParser) -> SetConfigValues
         digest_name,
         storage_backend_name,
         cleanup,
+        release_files_save,
     )

--- a/src/bandersnatch/default.conf
+++ b/src/bandersnatch/default.conf
@@ -5,6 +5,9 @@ directory = /srv/pypi
 ; URL/pypi/PKG_NAME/json (Symlink) -> URL/json/PKG_NAME
 json = false
 
+; Save package release files
+release-files = true
+
 ; Cleanup legacy non PEP 503 normalized named simple directories
 cleanup = false
 

--- a/src/bandersnatch/mirror.py
+++ b/src/bandersnatch/mirror.py
@@ -190,6 +190,7 @@ class BandersnatchMirror(Mirror):
         diff_file_list: Optional[List] = None,
         *,
         cleanup: bool = False,
+        release_files_save: bool = True,
     ) -> None:
         super().__init__(master=master, workers=workers)
         self.cleanup = cleanup
@@ -209,6 +210,9 @@ class BandersnatchMirror(Mirror):
         self.stop_on_error = stop_on_error
         self.json_save = (
             json_save  # Whether or not to mirror PyPI JSON metadata to disk
+        )
+        self.release_files_save = (
+            release_files_save  # Whether or not to mirror PyPI release files to disk
         )
         self.hash_index = hash_index
         # Allow configuring a root_uri to make generated index pages absolute.
@@ -301,7 +305,9 @@ class BandersnatchMirror(Mirror):
         package.filter_all_releases_files(self.filters.filter_release_file_plugins())
         package.filter_all_releases(self.filters.filter_release_plugins())
 
-        await self.sync_release_files(package)
+        if self.release_files_save:
+            await self.sync_release_files(package)
+
         self.sync_simple_page(package)
         # XMLRPC PyPI Endpoint stores raw_name so we need to provide it
         self.record_finished_package(package.raw_name)
@@ -864,6 +870,7 @@ async def mirror(
             diff_append_epoch=config_values.diff_append_epoch,
             diff_full_path=diff_full_path if diff_full_path else None,
             cleanup=config_values.cleanup,
+            release_files_save=config_values.release_files_save,
         )
 
         # TODO: Remove this terrible hack and async mock the code correctly

--- a/src/bandersnatch/tests/test_configuration.py
+++ b/src/bandersnatch/tests/test_configuration.py
@@ -71,6 +71,7 @@ class TestBandersnatchConf(TestCase):
                 "hash-index",
                 "json",
                 "master",
+                "release-files",
                 "stop-on-error",
                 "storage-backend",
                 "timeout",
@@ -135,12 +136,29 @@ class TestBandersnatchConf(TestCase):
 
     def test_validate_config_values(self) -> None:
         default_values = SetConfigValues(
-            False, "", "", False, "sha256", "filesystem", False
+            False, "", "", False, "sha256", "filesystem", False, True
         )
         no_options_configparser = configparser.ConfigParser()
         no_options_configparser["mirror"] = {}
         self.assertEqual(
             default_values, validate_config_values(no_options_configparser)
+        )
+
+    def test_validate_config_values_release_files_false_sets_root_uri(self) -> None:
+        default_values = SetConfigValues(
+            False,
+            "https://files.pythonhosted.org",
+            "",
+            False,
+            "sha256",
+            "filesystem",
+            False,
+            False,
+        )
+        release_files_false_configparser = configparser.ConfigParser()
+        release_files_false_configparser["mirror"] = {"release-files": "false"}
+        self.assertEqual(
+            default_values, validate_config_values(release_files_false_configparser)
         )
 
     def test_deprecation_warning_raised(self) -> None:

--- a/src/bandersnatch/tests/test_main.py
+++ b/src/bandersnatch/tests/test_main.py
@@ -85,6 +85,7 @@ def test_main_reads_config_values(mirror_mock: mock.MagicMock, tmpdir: Path) -> 
         "json_save": False,
         "digest_name": "sha256",
         "keep_index_versions": 0,
+        "release_files_save": True,
         "storage_backend": "filesystem",
         "diff_file": diff_file,
         "diff_append_epoch": False,

--- a/src/bandersnatch/tests/test_mirror.py
+++ b/src/bandersnatch/tests/test_mirror.py
@@ -820,6 +820,16 @@ async def test_package_sync_downloads_release_file(mirror: BandersnatchMirror) -
 
 
 @pytest.mark.asyncio
+async def test_package_sync_skips_release_file(mirror: BandersnatchMirror) -> None:
+    mirror.release_files_save = False
+    mirror.packages_to_sync = {"foo": 0}
+    await mirror.sync_packages()
+    assert not mirror.errors
+
+    assert not os.path.exists("web/packages/any/f/foo/foo.zip")
+
+
+@pytest.mark.asyncio
 async def test_package_download_rejects_non_package_directory_links(
     mirror: BandersnatchMirror,
 ) -> None:


### PR DESCRIPTION
This changes adds a new configuration `release-files`, defaulting to
`true` (preserving existing behaviour), that allows a bandersnatch
mirror to skip syncing package release files. If set, this will also
check for `root_uri` being set, if not set will set it to
https://files.pythonhosted.org to ensure file links are still usable.

Resolves: #665