### PR TITLE
Update aiohttp to 3.6.3; Downgrade multidict to 4.7.6, yarl to 1.5.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-aiohttp==3.6.2
+aiohttp==3.6.3
 aiohttp-socks==0.5.5
 aiohttp-xmlrpc==1.3.0
 async-timeout==3.0.1
@@ -8,9 +8,9 @@ filelock==3.0.12
 idna==2.10
 importlib_resources==3.0.0; python_version < '3.7'
 lxml==4.6.1
-multidict==5.0.0
+multidict==4.7.6
 packaging==20.4
 pyparsing==2.4.7
 setuptools==50.3.2
 six==1.15.0
-yarl==1.6.2
+yarl==1.5.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,9 +8,9 @@ filelock==3.0.12
 idna==2.10
 importlib_resources==3.0.0; python_version < '3.7'
 lxml==4.6.1
-multidict==4.7.6
+multidict==4.7.6  # pyup: ignore
 packaging==20.4
 pyparsing==2.4.7
 setuptools==50.3.2
 six==1.15.0
-yarl==1.5.1
+yarl==1.5.1  # pyup: ignore


### PR DESCRIPTION
This PR reverts 3a81bd28cb51d74f42a5a9ac20f106a623a6bd9d and 63926195169d79758f759c9e984a20e6a877bb5f in order to fix #707. Also closes #715.