### PR TITLE
Fixes PYPI_SERIAL_HEADER

### DIFF
--- a/src/bandersnatch/master.py
+++ b/src/bandersnatch/master.py
@@ -18,7 +18,7 @@ from .utils import USER_AGENT
 
 logger = logging.getLogger(__name__)
 FIVE_HOURS_FLOAT = 5 * 60 * 60.0
-PYPI_SERIAL_HEADER = "X-PYPI-LAST-SERIAL"
+PYPI_SERIAL_HEADER = "X-PyPI-Last-Serial"
 
 
 class StalePage(Exception):


### PR DESCRIPTION
PYPI_SERIAL_HEADER should be 'X-PyPI-Last-Serial' instead of
'X-PYPI-LAST-SERIAL'. Example below:

curl -IL https://pypi.org/pypi/pip/json
...
X-PyPI-Last-Serial: 8436753
...