### PR TITLE
packages allowlist can be defined from requirements like files

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+.tox
+.mypy_cache
+.git

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,9 +3,9 @@ FROM python:3.9 as base
 FROM base as builder
 RUN mkdir /install
 WORKDIR /install
+RUN pip install --target="/install" --upgrade pip setuptools wheel
 ADD requirements_swift.txt /install
 ADD requirements.txt /install
-RUN pip install --target="/install" --upgrade pip setuptools wheel
 RUN pip install --target="/install" \
     -r requirements.txt \
     -r requirements_swift.txt

--- a/docs/filtering_configuration.md
+++ b/docs/filtering_configuration.md
@@ -87,6 +87,21 @@ tag:tag:path.to.object =
     matchb
 ```
 
+### requirements files Filtering
+Packages and releases might be given as requirements.txt files
+
+if requirements_path is missing it is assumed to be root folder
+
+```ini
+[plugins]
+enabled =
+    allowlist_requirements
+[allowlist]
+requirements_path = /my_folder
+requirements =
+    requirements.txt
+```
+
 #### Project Regex Matching
 
 Filter projects to be synced based on regex matches against their raw metadata entries straight from parsed downloaded json.

--- a/docs/filtering_configuration.md
+++ b/docs/filtering_configuration.md
@@ -90,12 +90,13 @@ tag:tag:path.to.object =
 ### requirements files Filtering
 Packages and releases might be given as requirements.txt files
 
-if requirements_path is missing it is assumed to be root folder
+if requirements_path is missing it is assumed to be system root folder ('/')
 
 ```ini
 [plugins]
 enabled =
-    allowlist_requirements
+    project_requirements
+    project_requirements_pinned
 [allowlist]
 requirements_path = /my_folder
 requirements =

--- a/setup.cfg
+++ b/setup.cfg
@@ -61,6 +61,8 @@ bandersnatch_filter_plugins.v2.release =
     prerelease_release = bandersnatch_filter_plugins.prerelease_name:PreReleaseFilter
     regex_release = bandersnatch_filter_plugins.regex_name:RegexReleaseFilter
     latest_release = bandersnatch_filter_plugins.latest_name:LatestReleaseFilter
+    allowlist_release = bandersnatch_filter_plugins.allowlist_name:AllowListRelease
+    allowlist_requirements = bandersnatch_filter_plugins.allowlist_name:AllowListRequirements
 
 # This entrypoint group must match the value of bandersnatch.filter.RELEASE_FILE_PLUGIN_RESOURCE
 bandersnatch_filter_plugins.v2.release_file =

--- a/setup.cfg
+++ b/setup.cfg
@@ -62,7 +62,6 @@ bandersnatch_filter_plugins.v2.release =
     prerelease_release = bandersnatch_filter_plugins.prerelease_name:PreReleaseFilter
     regex_release = bandersnatch_filter_plugins.regex_name:RegexReleaseFilter
     latest_release = bandersnatch_filter_plugins.latest_name:LatestReleaseFilter
-    allowlist_release = bandersnatch_filter_plugins.allowlist_name:AllowListRelease
     project_requirements_pinned = bandersnatch_filter_plugins.allowlist_name:AllowListRequirementsPinned
 
 # This entrypoint group must match the value of bandersnatch.filter.RELEASE_FILE_PLUGIN_RESOURCE

--- a/setup.cfg
+++ b/setup.cfg
@@ -49,6 +49,7 @@ bandersnatch_filter_plugins.v2.project =
     blocklist_project = bandersnatch_filter_plugins.blocklist_name:BlockListProject
     allowlist_project = bandersnatch_filter_plugins.allowlist_name:AllowListProject
     regex_project = bandersnatch_filter_plugins.regex_name:RegexProjectFilter
+    project_requirements = bandersnatch_filter_plugins.allowlist_name:AllowListRequirements
 
 # This entrypoint group must match the value of bandersnatch.filter.METADATA_PLUGIN_RESOURCE
 bandersnatch_filter_plugins.v2.metadata =
@@ -62,7 +63,7 @@ bandersnatch_filter_plugins.v2.release =
     regex_release = bandersnatch_filter_plugins.regex_name:RegexReleaseFilter
     latest_release = bandersnatch_filter_plugins.latest_name:LatestReleaseFilter
     allowlist_release = bandersnatch_filter_plugins.allowlist_name:AllowListRelease
-    allowlist_requirements = bandersnatch_filter_plugins.allowlist_name:AllowListRequirements
+    project_requirements_pinned = bandersnatch_filter_plugins.allowlist_name:AllowListRequirementsPinned
 
 # This entrypoint group must match the value of bandersnatch.filter.RELEASE_FILE_PLUGIN_RESOURCE
 bandersnatch_filter_plugins.v2.release_file =

--- a/src/bandersnatch/tests/plugins/test_allowlist_name.py
+++ b/src/bandersnatch/tests/plugins/test_allowlist_name.py
@@ -18,9 +18,6 @@ class TestAllowListProject(TestCase):
     Tests for the bandersnatch filtering classes
     """
 
-    tempdir = None
-    cwd = None
-
     def setUp(self) -> None:
         self.cwd = os.getcwd()
         self.tempdir = TemporaryDirectory()
@@ -32,7 +29,6 @@ class TestAllowListProject(TestCase):
             assert self.cwd
             os.chdir(self.cwd)
             self.tempdir.cleanup()
-            self.tempdir = None
 
     def test__plugin__loads__explicitly_enabled(self) -> None:
         mock_config(
@@ -188,9 +184,6 @@ class TestAllowlistRelease(TestCase):
     Tests for the bandersnatch filtering classes
     """
 
-    tempdir = None
-    cwd = None
-
     def setUp(self) -> None:
         self.cwd = os.getcwd()
         self.tempdir = TemporaryDirectory()
@@ -201,7 +194,6 @@ class TestAllowlistRelease(TestCase):
             assert self.cwd
             os.chdir(self.cwd)
             self.tempdir.cleanup()
-            self.tempdir = None
 
     def test__plugin__loads__explicitly_enabled(self) -> None:
         mock_config(
@@ -335,9 +327,6 @@ class TestAllowlistRequirements(TestCase):
     Tests for the bandersnatch filtering by requirements
     """
 
-    tempdir = None
-    cwd = None
-
     def setUp(self) -> None:
         self.cwd = os.getcwd()
         self.tempdir = TemporaryDirectory()
@@ -348,7 +337,6 @@ class TestAllowlistRequirements(TestCase):
             assert self.cwd
             os.chdir(self.cwd)
             self.tempdir.cleanup()
-            self.tempdir = None
 
     def test__plugin__loads__explicitly_enabled(self) -> None:
         mock_config(
@@ -384,7 +372,7 @@ enabled =
                 """\
 #    This is needed for workshop 1
 #
-foo==1.2.0             # via -r requirements.in            
+foo==1.2.0             # via -r requirements.in
 """
             )
 
@@ -419,7 +407,7 @@ requirements =
                 """\
 #    This is needed for workshop 1
 #
-foo==1.2.0             # via -r requirements.in            
+foo==1.2.0             # via -r requirements.in
 """
             )
 

--- a/src/bandersnatch_filter_plugins/allowlist_name.py
+++ b/src/bandersnatch_filter_plugins/allowlist_name.py
@@ -141,8 +141,12 @@ class AllowListRequirements(AllowListProject):
         file.
         """
         filtered_requirements: Set[Requirement] = set()
+        try:
+            filepaths = get_requirement_files(self.allowlist)
+        except KeyError:
+            return []
 
-        for filepath in get_requirement_files(self.allowlist):
+        for filepath in filepaths:
             with open(filepath) as req_fh:
                 filtered_requirements |= _parse_package_lines(req_fh.readlines())
         return list(req.name for req in filtered_requirements)
@@ -254,7 +258,11 @@ class AllowListRequirementsPinned(AllowListRelease):
         """
         filtered_requirements: Set[Requirement] = set()
 
-        for filepath in get_requirement_files(self.allowlist):
+        try:
+            filepaths = get_requirement_files(self.allowlist)
+        except KeyError:
+            return []
+        for filepath in filepaths:
             with open(filepath) as req_fh:
                 filtered_requirements |= _parse_package_lines(req_fh.readlines())
         return list(filtered_requirements)

--- a/src/bandersnatch_filter_plugins/allowlist_name.py
+++ b/src/bandersnatch_filter_plugins/allowlist_name.py
@@ -1,6 +1,6 @@
 import logging
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Dict, Generator, List, Set
+from typing import TYPE_CHECKING, Any, Dict, Iterator, List, Set
 
 if TYPE_CHECKING:
     from configparser import SectionProxy
@@ -91,7 +91,7 @@ class AllowListProject(FilterProjectPlugin):
         return True
 
 
-def get_requirement_files(allowlist: "SectionProxy") -> Generator[Path, None, None]:
+def get_requirement_files(allowlist: "SectionProxy") -> Iterator[Path]:
     try:
         requirements_path = Path(allowlist["requirements_path"])
     except KeyError:

--- a/src/bandersnatch_filter_plugins/allowlist_name.py
+++ b/src/bandersnatch_filter_plugins/allowlist_name.py
@@ -50,7 +50,7 @@ class AllowListProject(FilterProjectPlugin):
             if not package_line or package_line.startswith("#"):
                 continue
             package_line, *_ = package_line.split('#')
-            unfiltered_packages.add(canonicalize_name(Requirement(package_line).name))
+            unfiltered_packages.add(canonicalize_name(Requirement(package_line.strip()).name))
         return list(unfiltered_packages)
 
     def filter(self, metadata: Dict) -> bool:

--- a/src/bandersnatch_filter_plugins/allowlist_name.py
+++ b/src/bandersnatch_filter_plugins/allowlist_name.py
@@ -49,6 +49,7 @@ class AllowListProject(FilterProjectPlugin):
             package_line = package_line.strip()
             if not package_line or package_line.startswith("#"):
                 continue
+            package_line, *_ = package_line.split('#')
             unfiltered_packages.add(canonicalize_name(Requirement(package_line).name))
         return list(unfiltered_packages)
 
@@ -125,7 +126,8 @@ class AllowListRelease(FilterReleasePlugin):
             package_line = package_line.strip()
             if not package_line or package_line.startswith("#"):
                 continue
-            requirement = Requirement(package_line)
+            package_line, *_ = package_line.split('#')
+            requirement = Requirement(package_line.strip())
             requirement.name = canonicalize_name(requirement.name)
             requirement.specifier.prereleases = True
             filtered_requirements.add(requirement)

--- a/src/bandersnatch_filter_plugins/filename_name.py
+++ b/src/bandersnatch_filter_plugins/filename_name.py
@@ -8,7 +8,7 @@ logger = logging.getLogger("bandersnatch")
 
 class ExcludePlatformFilter(FilterReleaseFilePlugin):
     """
-    Filters releases based on regex patters defined by the user.
+    Filters releases based on regex patterns defined by the user.
     """
 
     name = "exclude_platform"

--- a/tox.ini
+++ b/tox.ini
@@ -30,7 +30,8 @@ basepython=python3
 skip_install=True
 deps = -r requirements_test.txt
 commands=
-    pre-commit run --all-files --show-diff-on-failure
+    pre-commit run --all-files
+;    pre-commit run --all-files --show-diff-on-failure
     flake8
 
 [isort]


### PR DESCRIPTION
because working with pip-compile generates requirements files with inline comments like
```
appdirs==1.4.4            # via black
black==20.8b1             # via -r requirements.in
certifi==2020.11.8        # via requests
```

and for now it's convenient to be able to paste it
