### PR TITLE
Setup dependabot so Actions are automatically updated

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+version: 2
+updates:
+  # Enable version updates for Actions used in GitHub Actions workflows
+  - package-ecosystem: "github-actions"
+    # Workflow files in .github/workflows will be checked
+    directory: "/"
+    # Check for updates every day
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
One thing less to remember to update :D

Implemented according to https://docs.github.com/en/free-pro-team@latest/github/administering-a-repository/keeping-your-actions-up-to-date-with-dependabot

FYI a `dependencies` label [will be created automatically for use by Dependabot](https://docs.github.com/en/free-pro-team@latest/github/administering-a-repository/configuration-options-for-dependency-updates#labels). Unfortunately it appears there is no way to disable this behaviour. I guess configure PyUP to add that label too now?