### PR TITLE
Clean up isort config after upgrade to 5+

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,11 +17,6 @@ repos:
     hooks:
     -   id: pyupgrade
         args: [--py36-plus]
--   repo: https://github.com/asottile/seed-isort-config
-    rev: v2.2.0
-    hooks:
-    -   id: seed-isort-config
-        args: [--application-directories, '.:src']
 -   repo: https://github.com/PyCQA/isort
     rev: 5.6.4
     hooks:

--- a/setup.cfg
+++ b/setup.cfg
@@ -103,11 +103,6 @@ swift =
 
 [isort]
 atomic = true
-not_skip = __init__.py
-line_length = 88
-multi_line_output = 3
+profile = black
 known_third_party = _pytest,aiohttp,aiohttp_socks,aiohttp_xmlrpc,asynctest,filelock,freezegun,keystoneauth1,mock_config,packaging,pkg_resources,pytest,setuptools,swiftclient
 known_first_party = bandersnatch,bandersnatch_filter_plugins,bandersnatch_storage_plugins
-force_grid_wrap = 0
-use_parentheses=True
-include_trailing_comma = True


### PR DESCRIPTION
- Remove useless and deprecated 'not_skip' option
-> see https://pycqa.github.io/isort/docs/upgrade_guides/5.0.0/#not_skip

- Use isort 5+ profiles!
-> see https://pycqa.github.io/isort/docs/configuration/profiles/

- Remove unnecessary 'seed-isort-config' step in pre-commit config
-> https://pycqa.github.io/isort/docs/upgrade_guides/5.0.0/#seed-isort-config