### PR TITLE
Fix links, improve docs CI, and improve external object linking

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -366,10 +366,14 @@ texinfo_documents = [
 # If true, do not generate a @detailmenu in the "Top" node's menu.
 # texinfo_no_detailmenu = False
 
-# Example configuration for intersphinx: refer to the Python standard library.
+# Configure intersphinx to generate links to the documentation of external objects.
+# For certain dependencies (e.g. aiohttp), intersphinx fails to generate links so that's
+# why this list doesn't and shouldn't contain all of our dependencies whose docs provide
+# an objects.inv
 intersphinx_mapping = {
-    "python": ("http://docs.python.org/3", None),
-    "urllib3": ("http://urllib3.readthedocs.org/en/latest", None),
+    "python": ("https://docs.python.org/3", None),
+    "filelock": ("https://filelock.readthedocs.io/en/stable", None),
+    "packaging": ("https://packaging.pypa.io/en/stable", None),
 }
 
 # Useful external link shortcuts

--- a/docs/filtering_configuration.md
+++ b/docs/filtering_configuration.md
@@ -198,7 +198,7 @@ Available platforms are: `windows` `macos` `freebsd` `linux`.
 
 ### Keep only latest releases
 
-You can also keep only the latest releases based on greatest [Version](https://packaging.pypa.io/en/latest/version/) numbers.
+You can also keep only the latest releases based on greatest [Version](https://packaging.pypa.io/en/latest/version.html) numbers.
 
 ```ini
 [plugins]

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -6,7 +6,7 @@ Bandersnatch documentation
 ==========================
 
 bandersnatch is a PyPI mirror client according to `PEP 381`
-http://www.python.org/dev/peps/pep-0381/.
+https://www.python.org/dev/peps/pep-0381/.
 
 Bandersnatch hits the XMLRPC API of pypi.org to get all packages with serial
 or packages since the last run's serial. bandersnatch then uses the JSON API

--- a/tox.ini
+++ b/tox.ini
@@ -14,7 +14,8 @@ extras = swift
 [testenv:doc_build]
 basepython=python3
 commands =
-    {envpython} {envbindir}/sphinx-build -a -W -b html docs docs/html
+    {envpython} {envbindir}/sphinx-build -a -W --keep-going -b html docs docs/html
+    {envpython} {envbindir}/sphinx-build -a -W --keep-going -b linkcheck docs docs/html
 changedir = {toxinidir}
 deps =
     -r requirements_docs.txt


### PR DESCRIPTION
* Fix broken or redirecting links

* More intersphinx linking
    
    Now references to packaging and filelock objects will be linked to their
    external documentation.
    
    Also removed urllib3 because no where does our code or docs reference it.

* Add linkcheck to tox config

    This commit exists because I didn't want to have to remember to run
    linkcheck routinely. Call me lazy if you will :P ... Well actually,
    running linkcheck on CI via tox is a good way to make sure links
    that go stale are noticed and fixed quickly.

    I added --keep-going because it's better to get all of the warnings
    in a single run then error out the build *than* only knowing that
    there's at least one warning somewhere. Very useful if you are
    looking at the CI logs as you can't just ask logs to tell what all the
    warnings were about ;)