### PR TITLE
Ban idna 3.x series due to compatibility issues

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,16 @@ async-timeout==3.0.1
 attrs==20.3.0
 chardet==3.0.4  # pyup: ignore
 filelock==3.0.12
-idna==3.1
+idna==2.10  # pyup: ignore
+            # idna 3 and above causes some extreme backtracking because
+            # requests doesn't support the 3.x series. Requests is
+            # heavily used by dependencies needed for bandersnatch
+            # swift support so when requests must downgrade to a
+            # version that vendors idna, dependency tree turns into a
+            # variant that pip's new dependency resolver doesn't like
+            # resolving. Although not installing the swift dependencies
+            # or using the unpinned dependencies info in setup.cfg
+            # works properly.
 lxml==4.6.2
 multidict==5.1.0
 packaging==20.8


### PR DESCRIPTION
Fixes https://github.com/pypa/bandersnatch/issues/802

idna 3 and above causes some extreme backtracking because
requests doesn't support the 3.x series. Requests is
heavily used by dependencies needed for bandersnatch
swift support so when requests must downgrade to a
version that vendors idna, dependency tree turns into a
variant that pip's new dependency resolver doesn't like
resolving. Although not installing the swift dependencies
or using the unpinned dependencies info in setup.cfg
works properly.

This also fixes the long pip install process which caused certain GHA
jobs to timeout.