### PR TITLE
Remove asynctest 1

### DIFF
--- a/src/bandersnatch/tests/test_master.py
+++ b/src/bandersnatch/tests/test_master.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 from tempfile import gettempdir
+from unittest.mock import AsyncMock, patch
 
-import asynctest
 import pytest
 
 import bandersnatch
@@ -20,21 +20,21 @@ def test_rpc_url(master: Master) -> None:
 @pytest.mark.asyncio
 async def test_all_packages(master: Master) -> None:
     expected = [["aiohttp", "", "", "", "69"]]
-    master.rpc = asynctest.CoroutineMock(return_value=expected)  # type: ignore
+    master.rpc = AsyncMock(return_value=expected)  # type: ignore
     pacakges = await master.all_packages()
     assert expected == pacakges
 
 
 @pytest.mark.asyncio
 async def test_all_packages_raises(master: Master) -> None:
-    master.rpc = asynctest.CoroutineMock(return_value=[])  # type: ignore
+    master.rpc = AsyncMock(return_value=[])  # type: ignore
     with pytest.raises(XmlRpcError):
         await master.all_packages()
 
 
 @pytest.mark.asyncio
 async def test_changed_packages_no_changes(master: Master) -> None:
-    master.rpc = asynctest.CoroutineMock(return_value=None)  # type: ignore
+    master.rpc = AsyncMock(return_value=None)  # type: ignore
     changes = await master.changed_packages(4)
     assert changes == {}
 
@@ -49,9 +49,7 @@ async def test_changed_packages_with_changes(master: Master) -> None:
         # changelog. This verifies that we don't fail even with garbage input.
         ("foobar", "1", 0, "changed", 19),
     ]
-    master.rpc = asynctest.CoroutineMock(  # type: ignore
-        return_value=list_of_package_changes
-    )
+    master.rpc = AsyncMock(return_value=list_of_package_changes)  # type: ignore
     changes = await master.changed_packages(4)
     assert changes == {"baz": 18, "foobar": 20}
 
@@ -85,8 +83,7 @@ async def test_xmlrpc_user_agent(master: Master) -> None:
 
 @pytest.mark.asyncio
 async def test_session_raise_for_status(master: Master) -> None:
-    patcher = asynctest.patch("aiohttp.ClientSession", autospec=True)
-    with patcher as create_session:
+    with patch("aiohttp.ClientSession", autospec=True) as create_session:
         async with master:
             pass
         assert len(create_session.call_args_list) == 1

--- a/src/bandersnatch/tests/test_mirror.py
+++ b/src/bandersnatch/tests/test_mirror.py
@@ -6,7 +6,6 @@ from pathlib import Path
 from tempfile import TemporaryDirectory, gettempdir
 from typing import Any, Dict, Iterator, List, NoReturn
 
-import asynctest
 import pytest
 from freezegun import freeze_time
 
@@ -215,9 +214,7 @@ def test_mirror_with_same_homedir_needs_lock(
 
 @pytest.mark.asyncio
 async def test_mirror_empty_master_gets_index(mirror: BandersnatchMirror) -> None:
-    mirror.master.all_packages = asynctest.asynctest.CoroutineMock(  # type: ignore
-        return_value={}
-    )
+    mirror.master.all_packages = mock.AsyncMock(return_value={})  # type: ignore
     await mirror.synchronize()
 
     assert """\
@@ -298,9 +295,7 @@ web{0}simple{0}index.html""".format(
 
 @pytest.mark.asyncio
 async def test_mirror_sync_package(mirror: BandersnatchMirror) -> None:
-    mirror.master.all_packages = asynctest.CoroutineMock(  # type: ignore
-        return_value={"foo": 1}
-    )
+    mirror.master.all_packages = mock.AsyncMock(return_value={"foo": 1})  # type: ignore
     mirror.json_save = True
     # Recall bootstrap so we have the json dirs
     mirror._bootstrap()
@@ -338,9 +333,7 @@ simple{0}index.html""".format(
 async def test_mirror_sync_package_error_no_early_exit(
     mirror: BandersnatchMirror,
 ) -> None:
-    mirror.master.all_packages = asynctest.CoroutineMock(  # type: ignore
-        return_value={"foo": 1}
-    )
+    mirror.master.all_packages = mock.AsyncMock(return_value={"foo": 1})  # type: ignore
     mirror.errors = True
     changed_packages = await mirror.synchronize()
 
@@ -386,9 +379,7 @@ web{0}simple{0}index.html""".format(
 # TODO: Fix - Raises SystemExit but pytest does not like asyncio tasks
 @pytest.mark.asyncio
 async def mirror_sync_package_error_early_exit(mirror: BandersnatchMirror) -> None:
-    mirror.master.all_packages = asynctest.CoroutineMock(  # type: ignore
-        return_value={"foo": 1}
-    )
+    mirror.master.all_packages = mock.AsyncMock(return_value={"foo": 1})  # type: ignore
 
     with Path("web/simple/index.html").open("wb") as index:
         index.write(b"old index")
@@ -416,7 +407,7 @@ web{0}simple{0}index.html""".format(
 async def test_mirror_sync_package_with_hash(
     mirror_hash_index: BandersnatchMirror,
 ) -> None:
-    mirror_hash_index.master.all_packages = asynctest.CoroutineMock(  # type: ignore
+    mirror_hash_index.master.all_packages = mock.AsyncMock(  # type: ignore
         return_value={"foo": 1}
     )
     await mirror_hash_index.synchronize()
@@ -451,9 +442,7 @@ simple{0}index.html""".format(
 async def test_mirror_serial_current_no_sync_of_packages_and_index_page(
     mirror: BandersnatchMirror,
 ) -> None:
-    mirror.master.changed_packages = asynctest.CoroutineMock(  # type: ignore
-        return_value={}
-    )
+    mirror.master.changed_packages = mock.AsyncMock(return_value={})  # type: ignore
     mirror.synced_serial = 1
     await mirror.synchronize()
 

--- a/src/bandersnatch/tests/test_package.py
+++ b/src/bandersnatch/tests/test_package.py
@@ -1,6 +1,6 @@
 from asyncio import TimeoutError
+from unittest.mock import AsyncMock
 
-import asynctest
 import pytest
 from _pytest.capture import CaptureFixture
 
@@ -23,9 +23,7 @@ def test_package_accessors(package: Package) -> None:
 async def test_package_update_metadata_gives_up_after_3_stale_responses(
     caplog: CaptureFixture, master: Master
 ) -> None:
-    master.get_package_metadata = asynctest.CoroutineMock(  # type: ignore
-        side_effect=StalePage
-    )
+    master.get_package_metadata = AsyncMock(side_effect=StalePage)  # type: ignore
     package = Package("foo", serial=11)
 
     with pytest.raises(StaleMetadata):
@@ -37,7 +35,7 @@ async def test_package_update_metadata_gives_up_after_3_stale_responses(
 @pytest.mark.asyncio
 async def test_package_not_found(caplog: CaptureFixture, master: Master) -> None:
     pkg_name = "foo"
-    master.get_package_metadata = asynctest.CoroutineMock(  # type: ignore
+    master.get_package_metadata = AsyncMock(  # type: ignore
         side_effect=PackageNotFound(pkg_name)
     )
     package = Package(pkg_name, serial=11)
@@ -51,9 +49,7 @@ async def test_package_not_found(caplog: CaptureFixture, master: Master) -> None
 async def test_package_update_metadata_gives_up_after_3_timeouts(
     caplog: CaptureFixture, master: Master
 ) -> None:
-    master.get_package_metadata = asynctest.CoroutineMock(  # type: ignore
-        side_effect=TimeoutError
-    )
+    master.get_package_metadata = AsyncMock(side_effect=TimeoutError)  # type: ignore
     package = Package("foo", serial=11)
 
     with pytest.raises(ConnectionTimeout) as timeout:

--- a/src/bandersnatch/tests/test_sync.py
+++ b/src/bandersnatch/tests/test_sync.py
@@ -1,6 +1,6 @@
 from os import sep
+from unittest.mock import AsyncMock
 
-import asynctest
 import pytest
 
 from bandersnatch import utils
@@ -14,9 +14,7 @@ async def test_sync_specific_packages(mirror: BandersnatchMirror) -> None:
         f.write(FAKE_SERIAL)
     # Package names should be normalized by synchronize()
     specific_packages = ["Foo"]
-    mirror.master.all_packages = asynctest.CoroutineMock(  # type: ignore
-        return_value={"foo": 1}
-    )
+    mirror.master.all_packages = AsyncMock(return_value={"foo": 1})  # type: ignore
     mirror.json_save = True
     # Recall bootstrap so we have the json dirs
     mirror._bootstrap()

--- a/src/bandersnatch/tests/test_verify.py
+++ b/src/bandersnatch/tests/test_verify.py
@@ -7,8 +7,8 @@ from pathlib import Path
 from shutil import rmtree
 from tempfile import gettempdir
 from typing import Any, List
+from unittest.mock import AsyncMock
 
-import asynctest
 import pytest
 from _pytest.monkeypatch import MonkeyPatch
 from aiohttp.client_exceptions import ClientResponseError, ServerTimeoutError
@@ -231,9 +231,7 @@ async def test_get_latest_json_timeout(tmp_path: Path) -> None:
     fc = FakeConfig()
 
     master = Master(fc.get("mirror", "master"))
-    url_fetch_timeout = asynctest.asynctest.CoroutineMock(
-        side_effect=ServerTimeoutError
-    )
+    url_fetch_timeout = AsyncMock(side_effect=ServerTimeoutError)
     master.url_fetch = url_fetch_timeout  # type: ignore
 
     jsonpath = tmp_path / "web" / "json"
@@ -259,7 +257,7 @@ async def test_get_latest_json_404(tmp_path: Path) -> None:
     fc = FakeConfig()
 
     master = Master(fc.get("mirror", "master"))
-    url_fetch_404 = asynctest.asynctest.CoroutineMock(
+    url_fetch_404 = AsyncMock(
         side_effect=ClientResponseError(code=404, history=(), request_info=None)
     )
     master.url_fetch = url_fetch_404  # type: ignore
@@ -287,7 +285,7 @@ async def test_verify_url_exception(tmp_path: Path) -> None:
     fc = FakeConfig()
 
     master = Master(fc.get("mirror", "master"))
-    url_fetch_404 = asynctest.CoroutineMock(
+    url_fetch_404 = AsyncMock(
         side_effect=ClientResponseError(code=404, history=(), request_info=None)
     )
     master.url_fetch = url_fetch_404  # type: ignore


### PR DESCRIPTION
Will remove all of asynctest but will do in 2 stages.
1: All files but src/bandersnatch/tests/conftest.py
2: Remove to funky uses in src/bandersnatch/tests/conftest.py

- Remove coroutine magic mock
- Replace asynctest.patch with unittest.mock.patch() now it's smart enough to be async aware

Addresses most of #787