### PR TITLE
Skip downloading based on file size and upload time instead of sha256sum

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@
 
 - bandersnatch is now a >= 3.8 Python project
 - New size_project_metadata filter plugin, which can deny download of projects larger than defined threshold - `PR #806`
+- Add option to compare file size and upload time instead of sha256sum for downloading - `PR #822`
 
 ## Bug Fixes
 

--- a/docs/mirror_configuration.md
+++ b/docs/mirror_configuration.md
@@ -193,3 +193,15 @@ Example:
 [mirror]
 diff-append-epoch = true
 ```
+
+### compare-method
+
+The compare method is used to set how to compare an existing file with upstream file to determine whether a download is required:
+  - hash: this is the default which reads local file content and computes hashes (currently sha256sum), it is reliable but sometimes slower;
+  - stat: use file size and change time to compare, which is named after the stat() syscall, this avoids retrieving the full file content thus reducing some io workloads.
+
+Example:
+```ini
+[mirror]
+compare-method = hash
+```

--- a/src/bandersnatch/configuration.py
+++ b/src/bandersnatch/configuration.py
@@ -81,7 +81,9 @@ class BandersnatchConfig(metaclass=Singleton):
 
 
 # 11-15, 84-89, 98-99, 117-118, 124-126, 144-149
-def validate_config_values(config: configparser.ConfigParser) -> SetConfigValues:
+def validate_config_values(  # noqa: C901
+    config: configparser.ConfigParser,
+) -> SetConfigValues:
     try:
         json_save = config.getboolean("mirror", "json")
     except configparser.NoOptionError:

--- a/src/bandersnatch/configuration.py
+++ b/src/bandersnatch/configuration.py
@@ -20,6 +20,7 @@ class SetConfigValues(NamedTuple):
     storage_backend_name: str
     cleanup: bool
     release_files_save: bool
+    compare_method: str
 
 
 class Singleton(type):  # pragma: no cover
@@ -159,6 +160,23 @@ def validate_config_values(config: configparser.ConfigParser) -> SetConfigValues
             + root_uri
         )
 
+    try:
+        logger.debug("Checking config for compare method...")
+        compare_method = config.get("mirror", "compare-method")
+        logger.debug("Found compare method in config!")
+    except configparser.NoOptionError:
+        compare_method = "hash"
+        logger.debug(
+            "Failed to find compare method in config, falling back to default!"
+        )
+    if compare_method not in ("hash", "stat"):
+        raise ValueError(
+            f"Supplied compare_method {compare_method} is not supported! Please "
+            + "update compare_method to one of ('hash', 'stat') in the [mirror] "
+            + "section."
+        )
+    logger.info(f"Selected compare method: {compare_method}")
+
     return SetConfigValues(
         json_save,
         root_uri,
@@ -168,4 +186,5 @@ def validate_config_values(config: configparser.ConfigParser) -> SetConfigValues
         storage_backend_name,
         cleanup,
         release_files_save,
+        compare_method,
     )

--- a/src/bandersnatch/default.conf
+++ b/src/bandersnatch/default.conf
@@ -79,6 +79,14 @@ verifiers = 3
 ; If unset defaults to 0.
 ; keep_index_versions = 0
 
+; Configure an option to compare whether a file is identical. By default the
+; "hash" method is used which reads local file content and computes hashes,
+; which is slow but more reliable; when "stat" method is used, file size and
+; change time are used to compare, which is useful to reduce IO workload when
+; verifying a lot of files frequently.
+; Possible values are: hash (default), stat
+compare-method = hash
+
 ; vim: set ft=cfg:
 
 ; Configure a file to write out the list of files downloaded during the mirror.

--- a/src/bandersnatch/mirror.py
+++ b/src/bandersnatch/mirror.py
@@ -778,7 +778,7 @@ class BandersnatchMirror(Mirror):
 
         # Avoid downloading again if we have the file and it matches the hash.
         if path.exists():
-            if self.compare_method is "stat":
+            if self.compare_method == "stat":
                 existing_size = self.storage_backend.get_size(str(path))
                 if existing_size == size:
                     return None

--- a/src/bandersnatch/mirror.py
+++ b/src/bandersnatch/mirror.py
@@ -644,7 +644,9 @@ class BandersnatchMirror(Mirror):
                 downloaded_file = await self.download_file(
                     release_file["url"],
                     release_file["size"],
-                    datetime.datetime.fromisoformat(release_file["upload_time_iso_8601"].replace("Z", "+00:00")),
+                    datetime.datetime.fromisoformat(
+                        release_file["upload_time_iso_8601"].replace("Z", "+00:00")
+                    ),
                     release_file["digests"]["sha256"],
                 )
                 if downloaded_file:
@@ -779,7 +781,7 @@ class BandersnatchMirror(Mirror):
         file_size: str,
         upload_time: datetime.datetime,
         sha256sum: str,
-        chunk_size: int = 64 * 1024
+        chunk_size: int = 64 * 1024,
     ) -> Optional[Path]:
         path = self._file_url_to_local_path(url)
 
@@ -800,15 +802,13 @@ class BandersnatchMirror(Mirror):
                     existing_hash = self.storage_backend.get_hash(str(path))
                     if existing_hash != sha256sum:
                         logger.info(
-                            f"File upload time and checksum mismatch with local "
+                            "File upload time and checksum mismatch with local "
                             + f"file {path}: expected "
                             + f"{sha256sum} got {existing_hash}, will re-download."
                         )
                         path.unlink()
                     else:
-                        logger.info(
-                            f"Updating file upload time of local file {path}."
-                        )
+                        logger.info(f"Updating file upload time of local file {path}.")
                         self.storage_backend.set_upload_time(path, upload_time)
                         return None
             else:

--- a/src/bandersnatch/storage.py
+++ b/src/bandersnatch/storage.py
@@ -3,6 +3,7 @@ Storage management
 """
 import configparser
 import contextlib
+import datetime
 import hashlib
 import logging
 import pathlib
@@ -276,6 +277,18 @@ class Storage:
 
     def get_hash(self, path: PATH_TYPES, function: str = "sha256") -> str:
         """Get the sha256sum of a given **path**"""
+        raise NotImplementedError
+
+    def get_file_size(self, path: PATH_TYPES) -> int:
+        """Get the size of a given **path** in bytes"""
+        raise NotImplementedError
+
+    def get_upload_time(self, path: PATH_TYPES) -> datetime.datetime:
+        """Get the upload time of a given **path**"""
+        raise NotImplementedError
+
+    def set_upload_time(self, path: PATH_TYPES, time: datetime.datetime) -> None:
+        """Set the upload time of a given **path**"""
         raise NotImplementedError
 
 

--- a/src/bandersnatch/tests/ci-swift.conf
+++ b/src/bandersnatch/tests/ci-swift.conf
@@ -12,6 +12,7 @@ stop-on-error = true
 storage-backend = swift
 verifiers = 3
 keep_index_versions = 2
+compare-method = hash
 
 [swift]
 default_container = bandersnatch

--- a/src/bandersnatch/tests/ci.conf
+++ b/src/bandersnatch/tests/ci.conf
@@ -13,6 +13,7 @@ stop-on-error = true
 storage-backend = filesystem
 verifiers = 3
 keep_index_versions = 2
+compare-method = hash
 
 [plugins]
 enabled =

--- a/src/bandersnatch/tests/conftest.py
+++ b/src/bandersnatch/tests/conftest.py
@@ -66,6 +66,8 @@ def package_json() -> Dict[str, Any]:
                         "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
                     },
                     "md5_digest": "b6bcb391b040c4468262706faf9d3cce",
+                    "size": 0,
+                    "upload_time_iso_8601": "2000-02-02T01:23:45.123456Z",
                 },
                 {
                     "url": "https://pypi.example.com/packages/2.7/f/foo/foo.whl",
@@ -75,6 +77,8 @@ def package_json() -> Dict[str, Any]:
                         "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
                     },
                     "md5_digest": "6bd3ddc295176f4dca196b5eb2c4d858",
+                    "size": 12345,
+                    "upload_time_iso_8601": "2000-03-03T01:23:45.123456Z",
                 },
             ]
         },

--- a/src/bandersnatch/tests/test_configuration.py
+++ b/src/bandersnatch/tests/test_configuration.py
@@ -57,6 +57,7 @@ class TestBandersnatchConf(TestCase):
             options,
             [
                 "cleanup",
+                "compare-method",
                 "directory",
                 "global-timeout",
                 "hash-index",
@@ -86,6 +87,7 @@ class TestBandersnatchConf(TestCase):
             ("timeout", int),
             ("global-timeout", int),
             ("workers", int),
+            ("compare-method", str),
         ]:
             self.assertIsInstance(
                 option_type(instance.config["mirror"].get(option)), option_type
@@ -127,7 +129,7 @@ class TestBandersnatchConf(TestCase):
 
     def test_validate_config_values(self) -> None:
         default_values = SetConfigValues(
-            False, "", "", False, "sha256", "filesystem", False, True
+            False, "", "", False, "sha256", "filesystem", False, True, "hash"
         )
         no_options_configparser = configparser.ConfigParser()
         no_options_configparser["mirror"] = {}
@@ -145,6 +147,7 @@ class TestBandersnatchConf(TestCase):
             "filesystem",
             False,
             False,
+            "hash",
         )
         release_files_false_configparser = configparser.ConfigParser()
         release_files_false_configparser["mirror"] = {"release-files": "false"}

--- a/src/bandersnatch/tests/test_main.py
+++ b/src/bandersnatch/tests/test_main.py
@@ -91,6 +91,7 @@ def test_main_reads_config_values(mirror_mock: mock.MagicMock, tmpdir: Path) -> 
         "diff_append_epoch": False,
         "diff_full_path": diff_file,
         "cleanup": False,
+        "compare_method": "hash",
     } == kwargs
 
 

--- a/src/bandersnatch/tests/test_mirror.py
+++ b/src/bandersnatch/tests/test_mirror.py
@@ -53,6 +53,8 @@ FAKE_RELEASE_DATA = JsonDict(
                     },
                     "md5_digest": "ebdad75ed9a852bbfd9be4c18bf76d00",
                     "packagetype": "sdist",
+                    "size": 1234,
+                    "upload_time_iso_8601": "2000-01-01T01:23:45.123456Z",
                 }
             ]
         },
@@ -880,6 +882,10 @@ async def test_package_sync_does_not_touch_existing_local_file(
     touch_files([pkg_file_path])
     with pkg_file_path.open("w") as f:
         f.write("")
+    # Here mtime is used to store upload time
+    # 949454625.123456 => 2000-02-02T01:23:45.123456Z in conftest.py
+    mtime = 949454625.123456
+    os.utime(pkg_file_path, (mtime, mtime))
     old_stat = pkg_file_path.stat()
 
     mirror.packages_to_sync = {"foo": 1}

--- a/src/bandersnatch/unittest.conf
+++ b/src/bandersnatch/unittest.conf
@@ -80,6 +80,14 @@ verifiers = 3
 diff-file = {{mirror_directory}}/mirrored-files
 diff-append-epoch = false
 
+; Configure an option to compare whether a file is identical. By default the
+; "hash" method is used which reads local file content and computes hashes,
+; which is slow but more reliable; when "stat" method is used, file size and
+; change time are used to compare, which is useful to reduce IO workload when
+; verifying a lot of files frequently.
+; Possible values are: hash (default), stat
+compare-method = hash
+
 ; Enable filtering plugins
 [plugins]
 ; Enable all or specific plugins - e.g. allowlist_project

--- a/src/bandersnatch_storage_plugins/filesystem.py
+++ b/src/bandersnatch_storage_plugins/filesystem.py
@@ -1,4 +1,5 @@
 import contextlib
+import datetime
 import filecmp
 import hashlib
 import logging
@@ -263,8 +264,22 @@ class FilesystemStorage(StoragePlugin):
         logger.debug(f"Calculated digest: {digest!s}")
         return str(h.hexdigest())
 
-    def get_size(self, path: PATH_TYPES) -> str:
+    def get_file_size(self, path: PATH_TYPES) -> str:
         """Return the file size of provided path."""
         if not isinstance(path, pathlib.Path):
             path = pathlib.Path(path)
         return str(path.stat().st_size)
+
+    def get_upload_time(self, path: PATH_TYPES) -> datetime.datetime:
+        if not isinstance(path, pathlib.Path):
+            path = pathlib.Path(path)
+        return datetime.datetime.fromtimestamp(
+            path.stat().st_mtime, datetime.timezone.utc
+        )
+
+    def set_upload_time(self, path: PATH_TYPES, time: datetime.datetime) -> None:
+        """Set the upload time of a given **path**"""
+        if not isinstance(path, pathlib.Path):
+            path = pathlib.Path(path)
+        ts = time.timestamp()
+        os.utime(path, (ts, ts))

--- a/src/bandersnatch_storage_plugins/filesystem.py
+++ b/src/bandersnatch_storage_plugins/filesystem.py
@@ -262,3 +262,9 @@ class FilesystemStorage(StoragePlugin):
         digest = h.hexdigest()
         logger.debug(f"Calculated digest: {digest!s}")
         return str(h.hexdigest())
+
+    def get_size(self, path: PATH_TYPES) -> str:
+        """Return the file size of provided path."""
+        if not isinstance(path, pathlib.Path):
+            path = pathlib.Path(path)
+        return str(path.stat().st_size)

--- a/src/bandersnatch_storage_plugins/filesystem.py
+++ b/src/bandersnatch_storage_plugins/filesystem.py
@@ -264,11 +264,11 @@ class FilesystemStorage(StoragePlugin):
         logger.debug(f"Calculated digest: {digest!s}")
         return str(h.hexdigest())
 
-    def get_file_size(self, path: PATH_TYPES) -> str:
+    def get_file_size(self, path: PATH_TYPES) -> int:
         """Return the file size of provided path."""
         if not isinstance(path, pathlib.Path):
             path = pathlib.Path(path)
-        return str(path.stat().st_size)
+        return path.stat().st_size
 
     def get_upload_time(self, path: PATH_TYPES) -> datetime.datetime:
         if not isinstance(path, pathlib.Path):

--- a/src/bandersnatch_storage_plugins/swift.py
+++ b/src/bandersnatch_storage_plugins/swift.py
@@ -933,3 +933,29 @@ class SwiftStorage(StoragePlugin):
                 content_type="application/symlink",
                 headers=headers,
             )
+
+    def get_file_size(self, path: PATH_TYPES) -> int:
+        with self.connection() as conn:
+            headers = conn.head_object(
+                self.default_container,
+                str(path),
+            )
+            return int(headers.get("content-length", "0"))
+
+    def get_upload_time(self, path: PATH_TYPES) -> datetime.datetime:
+        with self.connection() as conn:
+            headers = conn.head_object(
+                self.default_container,
+                str(path),
+            )
+            ts = int(headers.get("x-object-meta-upload", "0"))
+            return datetime.datetime.fromtimestamp(ts, datetime.timezone.utc)
+
+    def set_upload_time(self, path: PATH_TYPES, time: datetime.datetime) -> None:
+        """Set the upload time of a given **path**"""
+        with self.connection() as conn:
+            conn.post_object(
+                self.default_container,
+                str(path),
+                {"x-object-meta-upload": str(time.timestamp())},
+            )


### PR DESCRIPTION
See issue #821. This pr implements:

1. check file size and modification time(upload time)

It currently does not allow user to force sha256sum check. And this pr is tested only on local filesystems, but not OpenStack.