### PR TITLE
Fix duplication of checks on internal PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,12 @@ on: [push, pull_request]
 jobs:
   build:
     name: bandersnatch CI python ${{ matrix.python-version }} on ${{matrix.os}}
+    # We want to run on external PRs, but not on our own internal PRs (for the
+    # pull_request event) as they'll be run by the push to the branch. Without
+    # this if check, ci workflow checks are duplicated since internal PRs match
+    # both the push and pull_request events.
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
+
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:


### PR DESCRIPTION
Internal PRs (that come from branches of pypa/bandersnatch) match both
the push and pull_request events. This leads to a duplication of ci
checks on such PRs. Not only is it a waste of resources, it makes the
Status Checks UI more frustrating to go through.

Patch taken from:
https://github.community/t/duplicate-checks-on-push-and-pull-request-simultaneous-event/18012

--- 
see also: https://github.com/psf/black/pull/1986