### PR TITLE
Add linux platform types based on PEP 599

### DIFF
--- a/src/bandersnatch_filter_plugins/filename_name.py
+++ b/src/bandersnatch_filter_plugins/filename_name.py
@@ -27,6 +27,13 @@ class ExcludePlatformFilter(FilterReleaseFilePlugin):
         "manylinux1_x86_64",  # PEP 513
         "manylinux2010_i686",  # PEP 571
         "manylinux2010_x86_64",  # PEP 571
+        "manylinux2014_x86_64",  # PEP 599
+        "manylinux2014_i686",  # PEP 599
+        "manylinux2014_aarch64",  # PEP 599
+        "manylinux2014_armv7l",  # PEP 599
+        "manylinux2014_ppc64",  # PEP 599
+        "manylinux2014_ppc64le",  # PEP 599
+        "manylinux2014_s390x"  # PEP 599
     ]
 
     def initialize_plugin(self) -> None:

--- a/src/bandersnatch_filter_plugins/filename_name.py
+++ b/src/bandersnatch_filter_plugins/filename_name.py
@@ -33,7 +33,7 @@ class ExcludePlatformFilter(FilterReleaseFilePlugin):
         "manylinux2014_armv7l",  # PEP 599
         "manylinux2014_ppc64",  # PEP 599
         "manylinux2014_ppc64le",  # PEP 599
-        "manylinux2014_s390x"  # PEP 599
+        "manylinux2014_s390x",  # PEP 599
     ]
 
     def initialize_plugin(self) -> None:


### PR DESCRIPTION
Will add platform tags specified in PEP 599 to `exclude_platform` filter:

- `manylinux2014_x86_64`
- `manylinux2014_i686`
- `manylinux2014_aarch64`
- `manylinux2014_armv7l`
- `manylinux2014_ppc64`
- `manylinux2014_ppc64le`
- `manylinux2014_s390x`

Addresses the PEP 599 portion of #830 