### PR TITLE
Add changelog GHA workflow

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,0 +1,19 @@
+name: bandersnatch_changelog
+
+on:
+  pull_request:
+    types: [opened, synchronize, labeled, unlabeled, reopened]
+
+jobs:
+  build:
+    name: Changelog Entry Check
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Grep CHANGES.md for PR number
+      if: contains(github.event.pull_request.labels.*.name, 'skip news') != true
+      run: |
+        grep -P "PR #${{ github.event.pull_request.number }}[^0-9]" CHANGES.md

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -138,6 +138,18 @@ Successfully installed apipkg-1.4 attrs-18.1.0 bandersnatch-2.1.3 coverage-4.5.1
 /path/to/venv/bin/pip install -e .
 ```
 
+## Creating a Pull Request
+
+### Changelog entry
+
+PRs must have an entry in CHANGES.md that references the PR number in the format of
+"PR #{number}". Yes, you'll either have to guess your PR number or do another push
+after the fact. **Some trival changes (eg. typo fixes) won't need an entry, but most
+of the time, your change will. If unsure, take a look at what's been logged before
+or just add one to be safe.**
+
+This is enforced by a GitHub Actions workflow.
+
 ## Running Bandersnatch
 
 You will need to customize `src/bandersnatch/default.conf` and run via the following:


### PR DESCRIPTION
Resolves #848.

I added a bonus feature that allows the check to be skipped if the pull request has a `skip news` label slapped on it. Look, I *had* to add something to overcomplicate it (might be useful for dependabot though). If you want me to get rid of it, please let me know!