### PR TITLE
Use "skip news" label for Actions upgrades by dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,8 +2,14 @@ version: 2
 updates:
   # Enable version updates for Actions used in GitHub Actions workflows
   - package-ecosystem: "github-actions"
+
     # Workflow files in .github/workflows will be checked
     directory: "/"
+
     # Check for updates every day
     schedule:
       interval: "daily"
+
+    # Add "skip news" label since Actions upgrades are definitely not news worthy
+    labels:
+      - "skip news"


### PR DESCRIPTION
Had to do this after the workflow PR since dependabot needs the label to exist first :)