### PR TITLE
Remove debugging line that loads entire files into memory.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,7 @@
 
 - Unused storage plugins are loaded and cause non-fatal errors if dependencies are missing - `PR #799` - Thanks **electricworry**
 - Replaced usages of `asynctest` with `unittest.mock` in tests - `PR #807` and `PR #856` - Thanks **ichard26**
+- Remove debugging line that loads entire files into memory. - `PR #858` - Thanks **asrp**
 
 # 4.4.0 (2020-12-31)
 

--- a/src/bandersnatch_storage_plugins/filesystem.py
+++ b/src/bandersnatch_storage_plugins/filesystem.py
@@ -255,7 +255,6 @@ class FilesystemStorage(StoragePlugin):
         logger.debug(
             f"Opening {path.as_posix()} in binary mode for hash calculation..."
         )
-        logger.debug(f"Contents: {path.read_bytes()!s}")
         with open(path.absolute().as_posix(), "rb") as f:
             for chunk in iter(lambda: f.read(128 * 1024), b""):
                 logger.debug(f"Read chunk: {chunk!s}")


### PR DESCRIPTION
Hi,

I saw RAM usage spike when bandersnatch starts up and found this line. It was effectively loading the entire file into memory as a string. Removing it seems to fix the memory issue.

Note: memory is used up even if log level is set above debug