### PR TITLE
Remove terrible isinstance check in mirror.py

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,7 @@
 - Unused storage plugins are loaded and cause non-fatal errors if dependencies are missing - `PR #799` - Thanks **electricworry**
 - Replaced usages of `asynctest` with `unittest.mock` in tests - `PR #807` and `PR #856` - Thanks **ichard26**
 - Remove debugging line that loads entire files into memory. - `PR #858` - Thanks **asrp**
+- Removed terrible isinstance check of unittest.Mock in mirror.py - `PR #859` - Thanks **ichard26**
 
 # 4.4.0 (2020-12-31)
 

--- a/src/bandersnatch/mirror.py
+++ b/src/bandersnatch/mirror.py
@@ -12,7 +12,6 @@ from pathlib import Path
 from shutil import rmtree
 from threading import RLock
 from typing import Any, Awaitable, Dict, List, Optional, Set, Union
-from unittest.mock import Mock
 from urllib.parse import unquote, urlparse
 
 from filelock import Timeout
@@ -924,13 +923,7 @@ async def mirror(
             cleanup=config_values.cleanup,
             release_files_save=config_values.release_files_save,
         )
-
-        # TODO: Remove this terrible hack and async mock the code correctly
-        # This works around "TypeError: object
-        # MagicMock can't be used in 'await' expression"
-        changed_packages: Dict[str, Set[str]] = {}
-        if not isinstance(mirror, Mock):
-            changed_packages = await mirror.synchronize(specific_packages)
+        changed_packages = await mirror.synchronize(specific_packages)
 
     logger.info(f"{len(changed_packages)} packages had changes")
     for package_name, changes in changed_packages.items():

--- a/src/bandersnatch/tests/conftest.py
+++ b/src/bandersnatch/tests/conftest.py
@@ -141,6 +141,11 @@ def mirror_mock(request: FixtureRequest) -> mock.MagicMock:
     patcher = mock.patch("bandersnatch.mirror.BandersnatchMirror")
     mirror: mock.MagicMock = patcher.start()
 
+    # Mock the synchronize method too to avoid TypeError exceptions since methods are
+    # by default replaced by MagicMock instances when AsyncMock is necessary.
+    instance = mirror.return_value
+    instance.synchronize = mock.AsyncMock(return_value={})
+
     def tearDown() -> None:
         patcher.stop()
 


### PR DESCRIPTION
The way unittests were written caused us to mock the synchronize()
method to allow for testing we're setting up mirror object correctly.
Moving to asyncio has caused TypeErrors during the unittests so a very
dirty isinstace was added:

```python3
if not isinstance(mirror, Mock):  # type: ignore
    changed_packages = await mirror.synchronize()
```

This commit eliminates the isinstance check seen above by mocking the
synchronize() method directly with unittest.mock.AsyncMock while patching
the whole mirror class.

The reason why the isinstance check was needed in the first place is
that unittest.mock.patch replaces methods with unittest.mock.MagicMock
instances by default. Even when unittest.mock.AsyncMock is needed.

Resolves GH-464. 