### PR TITLE
Eliminate usages of deprecated APIs in unit tests

### DIFF
--- a/src/bandersnatch/tests/test_verify.py
+++ b/src/bandersnatch/tests/test_verify.py
@@ -258,7 +258,7 @@ async def test_get_latest_json_404(tmp_path: Path) -> None:
 
     master = Master(fc.get("mirror", "master"))
     url_fetch_404 = AsyncMock(
-        side_effect=ClientResponseError(code=404, history=(), request_info=None)
+        side_effect=ClientResponseError(status=404, history=(), request_info=None)
     )
     master.url_fetch = url_fetch_404  # type: ignore
 
@@ -286,7 +286,7 @@ async def test_verify_url_exception(tmp_path: Path) -> None:
 
     master = Master(fc.get("mirror", "master"))
     url_fetch_404 = AsyncMock(
-        side_effect=ClientResponseError(code=404, history=(), request_info=None)
+        side_effect=ClientResponseError(status=404, history=(), request_info=None)
     )
     master.url_fetch = url_fetch_404  # type: ignore
 

--- a/src/bandersnatch_filter_plugins/metadata_filter.py
+++ b/src/bandersnatch_filter_plugins/metadata_filter.py
@@ -200,7 +200,7 @@ class SizeProjectMetadataFilter(FilterMetadataPlugin, AllowListProject):
                     "max_package_size"
                 ]
             except KeyError:
-                logger.warn(
+                logger.warning(
                     f"Unable to initialise {self.name} plugin;"
                     f"must create max_package_size in configuration."
                 )
@@ -208,7 +208,7 @@ class SizeProjectMetadataFilter(FilterMetadataPlugin, AllowListProject):
             try:
                 self.max_package_size = parse_size(human_package_size, binary=True)
             except InvalidSize:
-                logger.warn(
+                logger.warning(
                     f"Unable to initialise {self.name} plugin;"
                     f'max_package_size of "{human_package_size}" is not valid.'
                 )


### PR DESCRIPTION
This aims to reduce the warnings emitted during a full unit test run.
Unfornately a few warnings are within third-party packages that probably
won't be too easy to replace so they will be dealt with later.

The following warnings are now gone:

```
src/bandersnatch/tests/test_mirror.py::test_limit_workers
src/bandersnatch/tests/test_mirror.py::test_mirror_loads_serial
src/bandersnatch/tests/test_mirror.py::test_mirror_recovers_from_inconsistent_serial
src/bandersnatch/tests/test_mirror.py::test_mirror_generation_3_resets_status_files
src/bandersnatch/tests/test_mirror.py::test_mirror_generation_4_resets_status_files
  /home/ichard26/programming/oss/bandersnatch/src/bandersnatch_filter_plugins/metadata_filter.py:203: DeprecationWarning: The 'warn' method is deprecated, use 'warning' instead
    logger.warn(

src/bandersnatch/tests/test_verify.py::test_get_latest_json_404
  /home/ichard26/programming/oss/bandersnatch/src/bandersnatch/tests/test_verify.py:261: DeprecationWarning: code argument is deprecated, use status instead
    side_effect=ClientResponseError(code=404, history=(), request_info=None)

src/bandersnatch/tests/test_verify.py::test_verify_url_exception
  /home/ichard26/programming/oss/bandersnatch/src/bandersnatch/tests/test_verify.py:289: DeprecationWarning: code argument is deprecated, use status instead
    side_effect=ClientResponseError(code=404, history=(), request_info=None)
```