### PR TITLE
Clean up stuff and migrate docs to MyST-Parser

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,7 @@
 - Remove debugging line that loads entire files into memory. - `PR #858` - Thanks **asrp**
 - Removed terrible isinstance check of unittest.Mock in mirror.py - `PR #859` - Thanks **ichard26**
 - Put potential time consuming IO operations into executor - `PR #877`
+- Migrated Markdown documentation from recommonmark to MyST-Parser + docs config clean up - `PR #879` - Thanks **ichard26**
 
 # 4.4.0 (2020-12-31)
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,6 +1,3 @@
-import os
-
-
 class DocStub:
     __version__ = "0.0.0"
     __name__ = "Unknown"
@@ -11,15 +8,6 @@ try:
 except ImportError:
     doc_module = DocStub()
 
-try:
-    from recommonmark.parser import CommonMarkParser  # noqa: F401
-    from recommonmark.transform import AutoStructify
-
-    github_doc_root = "https://partner.git.corp.yahoo.com/pages/yahoo.platform_init"
-    USE_MARKDOWN = True
-except ImportError:
-    USE_MARKDOWN = False
-
 # If your documentation needs a minimal Sphinx version, state it here.
 needs_sphinx = "3.0"
 
@@ -27,9 +15,9 @@ needs_sphinx = "3.0"
 # so just ignore the warning since we can't do anything a-boat it :D
 suppress_warnings = ["epub.unknown_project_files"]
 
-# Just a protection against an incompatible version of recommonmark.
+# Just a protection against an incompatible version of MyST-Parser
 # The listed version is the minimal version required for that extension.
-needs_extensions = {"recommonmark": "0.5"}
+needs_extensions = {"myst_parser": "0.13.0"}
 
 extensions = [
     "sphinx.ext.autodoc",
@@ -42,16 +30,14 @@ extensions = [
     "sphinx.ext.graphviz",
     "sphinx.ext.inheritance_diagram",
     "sphinx.ext.githubpages",
-    "recommonmark",
+    "myst_parser",
 ]
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]
 
 # The suffix of source filenames.
-source_suffix = [".rst"]
-if USE_MARKDOWN:
-    source_suffix.append(".md")
+source_suffix = [".rst", ".md"]
 
 # The encoding of source files.
 # source_encoding = 'utf-8-sig'
@@ -115,6 +101,9 @@ pygments_style = "sphinx"
 # If true, keep warnings as "system message" paragraphs in the built documents.
 # keep_warnings = False
 
+# Enable certain MyST-Parser extensions
+# see also: https://myst-parser.readthedocs.io/en/latest/using/syntax-optional.html
+myst_enable_extensions = ["colon_fence"]
 
 # -- Options for HTML output ----------------------------------------------
 
@@ -202,83 +191,13 @@ htmlhelp_basename = doc_module.__name__
 html_theme = "default"
 
 # Determine available themes and settings
-available_themes = ["default"]
-available_theme_settings = {}
-try:
-    import cloud_sptheme as csp
-
-    available_themes.insert(0, "cloudsp")
-    available_theme_settings["cloudsp"] = {}
-    available_theme_settings["cloudsp"]["theme"] = "cloud"
-    available_theme_settings["cloudsp"]["path"] = [csp.get_theme_dir()]
-    available_theme_settings["cloudsp"]["options"] = {"roottarget": "index"}
-except ImportError:
-    pass
-
-try:
-    import sphinx_bootstrap_theme
-
-    available_themes.insert(0, "bootstrap")
-    available_theme_settings["bootstrap"] = {}
-    available_theme_settings["bootstrap"]["theme"] = "bootstrap"
-    available_theme_settings["bootstrap"][
-        "path"
-    ] = sphinx_bootstrap_theme.get_html_theme_path()
-    available_theme_settings["bootstrap"]["options"] = {
-        # lumen, journal
-        "bootswatch_theme": os.environ.get("SPHINX_BOOTSWATCH_THEME", "journal")
-    }
-except ImportError:
-    pass
-
-try:
-    import guzzle_sphinx_theme
-
-    available_themes.insert(0, "guzzle")
-    available_theme_settings["guzzle"] = {}
-    available_theme_settings["guzzle"]["theme"] = "guzzle_sphinx_theme"
-    available_theme_settings["guzzle"]["path"] = guzzle_sphinx_theme.html_theme_path()
-    available_theme_settings["guzzle"]["options"] = {}
-except ImportError:
-    pass
-
-try:
-    import sphinx_rtd_theme
-
-    available_themes.insert(0, "read_the_docs")
-    available_theme_settings["read_the_docs"] = {}
-    available_theme_settings["read_the_docs"]["theme"] = "sphinx_rtd_theme"
-    available_theme_settings["read_the_docs"]["path"] = [
-        sphinx_rtd_theme.get_html_theme_path()
-    ]
-    available_theme_settings["read_the_docs"]["options"] = {
-        "collapse_navigation": os.environ.get("SPHINX_COLLAPSE_NAVIGATION", True),
-        "display_version": os.environ.get("SPHINX_DISPLAY_VERSION", version != "0.0.0"),
-        "navigation_depth": os.environ.get("SPHINX_NAVIGATION_DEPTH", 3),
-    }
-except ImportError:
-    pass
-
 try:
     import pypa_theme  # noqa: F401
 
-    available_themes.insert(0, "pypa")
-    available_theme_settings["pypa"] = {}
-    available_theme_settings["pypa"]["theme"] = "pypa_theme"
-    available_theme_settings["pypa"]["path"] = []
-    available_theme_settings["pypa"]["options"] = {}
+    html_theme = "pypa_theme"
 except ImportError:
-    pass
-
-selected_theme = os.environ.get("SPHINX_THEME", available_themes[0])
-if selected_theme not in available_themes:
-    selected_theme = available_themes[0]
-    print(f"SPHINX_THEME is not installed, using {selected_theme!r} theme")
-
-html_theme = available_theme_settings[selected_theme]["theme"]
-html_theme_path = available_theme_settings[selected_theme]["path"]
-if available_theme_settings[selected_theme].get("options", None):
-    html_theme_options = available_theme_settings[selected_theme]["options"]
+    print("WARNING: 'pypa_theme' isn't available, falling back to 'default' HTML theme")
+    html_theme = "default"
 
 # -- Options for LaTeX output ---------------------------------------------
 
@@ -378,18 +297,3 @@ intersphinx_mapping = {
 
 # Useful external link shortcuts
 extlinks = {"issue": ("https://github.com/sphinx-doc/sphinx/issues/%s", "issue ")}
-
-
-def setup(app):
-    if USE_MARKDOWN:
-        print("Adding recommonmark settings")
-        app.add_config_value(
-            "recommonmark_config",
-            {
-                "url_resolver": lambda url: github_doc_root + url,
-                "auto_toc_tree_section": "Contents",
-                "enable_eval_rst": True,
-            },
-            True,
-        )
-        app.add_transform(AutoStructify)

--- a/docs/filtering_configuration.md
+++ b/docs/filtering_configuration.md
@@ -1,4 +1,4 @@
-## Mirror filtering
+# Mirror filtering
 
 _NOTE: All references to whitelist/blacklist are deprecated, and will be replaced with allowlist/blocklist in 5.0_
 
@@ -13,7 +13,7 @@ converted.
 E.g. to Blocklist [discord.py](https://pypi.org/project/discord.py/) the string 'discord-py'
 is correct, but 'discord.PY' will also work.
 
-### Plugins Enabling
+## Plugins Enabling
 
 The plugins setting is a list of plugins to enable.
 
@@ -39,7 +39,7 @@ enabled =
     ...
 ```
 
-### allowlist / blocklist filtering settings
+## allowlist / blocklist filtering settings
 
 The blocklist / allowlist settings are in configuration sections named **\[blocklist\]** and **\[allowlist\]**
 these section provides settings to indicate packages, projects and releases that should /
@@ -47,7 +47,7 @@ should not be mirrored from PyPI.
 
 This is useful to avoid syncing broken or malicious packages.
 
-### packages
+## packages
 
 The packages setting is a list of python [pep440 version specifier](https://www.python.org/dev/peps/pep-0440/#id51) of packages to not be mirrored. Enable version specifier filtering for blocklist and allowlist packages through enabling the 'blocklist_release' and 'allowlist_release' plugins, respectively.
 
@@ -74,7 +74,7 @@ packages =
     ptr
 ```
 
-### Metadata Filtering
+## Metadata Filtering
 Packages and release files may be selected by filtering on specific metadata value.
 
 General form of configuration entries is:
@@ -86,7 +86,7 @@ tag:tag:path.to.object =
     matchb
 ```
 
-### requirements files Filtering
+## requirements files Filtering
 Packages and releases might be given as requirements.txt files
 
 if requirements_path is missing it is assumed to be system root folder ('/')
@@ -102,7 +102,7 @@ requirements =
     requirements.txt
 ```
 
-#### Project Regex Matching
+### Project Regex Matching
 
 Filter projects to be synced based on regex matches against their raw metadata entries straight from parsed downloaded json.
 
@@ -119,7 +119,7 @@ Valid tags are `all`,`any`,`none`,`match-null`,`not-null`, with default of `any:
 All metadata provided by json is available, including `info`, `last_serial`, `releases`, etc. headings.
 
 
-#### Release File Regex Matching
+### Release File Regex Matching
 
 Filter release files to be downloaded for projects based on regex matches against the stored metadata entries for each release file.
 
@@ -139,7 +139,7 @@ containing the package-wide inthe fo, `release` containing the version of the re
 for an individual file for that release.
 
 
-### Prerelease filtering
+## Prerelease filtering
 
 Bandersnatch includes a plugin to filter our pre-releases of packages. To enable this plugin simply add `prerelease_release` to the enabled plugins list.
 
@@ -149,7 +149,7 @@ enabled =
     prerelease_release
 ```
 
-### Regex filtering
+## Regex filtering
 
 Advanced users who would like finer control over which packages and releases to filter can use the regex Bandersnatch plugin.
 
@@ -178,7 +178,7 @@ releases =
 Note the same `filter_regex` section may include a `packages` and a `releases` entry with any number of regular expressions.
 
 
-### Platform-specific binaries filtering
+## Platform-specific binaries filtering
 
 This filter allows advanced users not interesting in Windows/macOS/Linux specific binaries to not mirror the corresponding files.
 
@@ -195,7 +195,7 @@ platforms =
 Available platforms are: `windows` `macos` `freebsd` `linux`.
 
 
-### Keep only latest releases
+## Keep only latest releases
 
 You can also keep only the latest releases based on greatest [Version](https://packaging.pypa.io/en/latest/version.html) numbers.
 
@@ -213,7 +213,7 @@ By default, the plugin does not filter out any release. You have to add the `kee
 You should be aware that it can break requirements. Prereleases are also kept.
 
 
-### Block projects above a specified size threshold
+## Block projects above a specified size threshold
 
 There is an increasing number of projects that consume a large amount of space.
 At the time of writing (Jan 2021) the [stats](https://pypi.org/stats/) shows some

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,4 +1,4 @@
-## Installation
+# Installation
 
 The following instructions will place the bandersnatch executable in a
 virtualenv under `bandersnatch/bin/bandersnatch`.
@@ -6,7 +6,7 @@ virtualenv under `bandersnatch/bin/bandersnatch`.
 - bandersnatch **requires** `>= Python 3.8.0`
 
 
-### pip
+## pip
 
 This installs the latest stable, released version.
 

--- a/docs/mirror_configuration.md
+++ b/docs/mirror_configuration.md
@@ -1,11 +1,11 @@
-## Mirror configuration
+# Mirror configuration
 
 The mirror configuration settings are in a configuration section of the configuration file
 named **\[mirror\]**.
 
 This section contains settings to specify how the mirroring software should operate.
 
-### directory
+## directory
 
 The mirror directory setting is a string that specifies the directory to
 store the mirror files.
@@ -21,7 +21,7 @@ Example:
 directory = /srv/pypi
 ```
 
-### json
+## json
 
 The mirror json seting is a boolean (true/false) setting that indicates that
 the json packaging metadata should be mirrored in additon to the packages.
@@ -32,7 +32,7 @@ Example:
 json = false
 ```
 
-### release-files
+## release-files
 
 The mirror release-files setting is a boolean (true/false) setting that indicates that
 the package release files should be mirrored. Defaults to `true`. When this option is disabled (via setting to false), you
@@ -45,7 +45,7 @@ Example:
 release-files = true
 ```
 
-### master
+## master
 
 The master setting is a string containing a url of the server which will be mirrored.
 
@@ -59,7 +59,7 @@ Example:
 master = https://pypi.org
 ```
 
-### timeout
+## timeout
 
 The timeout value is an integer that indicates the maximum number of seconds for web requests.
 
@@ -71,7 +71,7 @@ Example:
 timeout = 10
 ```
 
-### global-timeout
+## global-timeout
 
 The global-timeout value is an integer that indicates the maximum runtime of individual aiohttp coroutines.
 
@@ -83,7 +83,7 @@ Example:
 global-timeout = 18000
 ```
 
-### workers
+## workers
 
 The workers value is an integer from from 1-10 that indicates the number of concurrent downloads.
 
@@ -94,17 +94,17 @@ Recommendations for the workers setting:
 - official servers located in data centers could run 10 workers
 - anything beyond 10 is probably unreasonable and is not allowed.
 
-### hash-index
+## hash-index
 
 The hash-index is a boolean (true/false) to determine if package hashing should be used.
 
 The Recommended setting: the default of false for full pip/pypi compatibility.
 
-```eval_rst
-.. warning:: Package index directory hashing is incompatible with pip, and so this should only be used in an environment where it is behind an application that can translate URIs to filesystem locations.
-```
+:::{warning}
+Package index directory hashing is incompatible with pip, and so this should only be used in an environment where it is behind an application that can translate URIs to filesystem locations.
+:::
 
-#### Apache rewrite rules when using hash-index
+### Apache rewrite rules when using hash-index
 
 When using this setting with an apache server.  The apache server will need the following rewrite rules:
 
@@ -113,7 +113,7 @@ RewriteRule ^([^/])([^/]*)/$ /mirror/pypi/web/simple/$1/$1$2/
 RewriteRule ^([^/])([^/]*)/([^/]+)$/ /mirror/pypi/web/simple/$1/$1$2/$3
 ```
 
-#### NGINX rewrite rules when using hash-index
+### NGINX rewrite rules when using hash-index
 
 When using this setting with an nginx server.  The nginx server will need the following rewrite rules:
 
@@ -122,7 +122,7 @@ rewrite ^/simple/([^/])([^/]*)/$ /simple/$1/$1$2/ last;
 rewrite ^/simple/([^/])([^/]*)/([^/]+)$/ /simple/$1/$1$2/$3 last;
 ```
 
-### stop-on-error
+## stop-on-error
 
 The stop-on-error setting is a boolean (true/false) setting that indicates if bandersnatch
 should stop immediately if it encounters an error.
@@ -135,7 +135,7 @@ mark the sync as successful when the sync is complete.
 stop-on-error = false
 ```
 
-### log-config
+## log-config
 
 The log-config setting is a string containing the filename of a python logging configuration
 file.
@@ -146,13 +146,13 @@ Example:
 log-config = /etc/bandersnatch-log.conf
 ```
 
-### root_uri
+## root_uri
 
 The root_uri is a string containing a uri which is the root added to relative links.
 
-``` eval_rst
-.. note:: This is generally not necessary, but was added for the official internal PyPI mirror, which requires serving packages from https://files.pythonhosted.org
-```
+:::{note}
+This is generally not necessary, but was added for the official internal PyPI mirror, which requires serving packages from https://files.pythonhosted.org
+:::
 
 Example:
 ```ini
@@ -161,7 +161,7 @@ root_uri = https://example.com
 ```
 
 
-### diff-file
+## diff-file
 
 The diff file is a string containing the filename to log the files that were downloaded during the mirror.
 This file can then be used to synchronize external disks or send the files through some other mechanism to offline systems.
@@ -183,7 +183,7 @@ diff-file = /srv/pypi/mirrored-files
 
 
 
-### diff-append-epoch
+## diff-append-epoch
 
 The diff append epoch is a boolean (true/false) setting that indicates if the diff-file should be appended with the current epoch time.
 This can be used to track diffs over time so the diff file doesn't get cobbered each run.  It is only used when diff-file is used.
@@ -194,7 +194,7 @@ Example:
 diff-append-epoch = true
 ```
 
-### compare-method
+## compare-method
 
 The compare method is used to set how to compare an existing file with upstream file to determine whether a download is required:
   - hash: this is the default which reads local file content and computes hashes (currently sha256sum), it is reliable but sometimes slower;

--- a/docs/serving.md
+++ b/docs/serving.md
@@ -1,10 +1,10 @@
-## Serving your Mirror
+# Serving your Mirror
 
 So if you've had a successful `bandersnatch mirror` run, you're now ready to server
 your mirror. Any webserver can do this, as long as it can serve the simple HTML and
 packages directory that the HTML links to.
 
-### BanderX
+## BanderX
 
 `banderx` is a very simple [NGINX](https://www.nginx.com/) docker image with a
 sample config included. The example only does HTTP and expects you to do your
@@ -15,18 +15,18 @@ own HTTPS/TLS elsewhere.
     uncommented
   - It also sets the correct JSON MIME type for `/json` + `/pypi`
 
-#### Docker Build
+### Docker Build
 
 - `cd src/banderx`
 - `docker build -t banderx .`
 
-#### Docker Run
+### Docker Run
 
 - `docker run --name bandersnatch_nginx --mount type=bind,source=/data/pypi/web,target=/data/pypi/web banderx`
 - For custom config add:
   - `--mount type=bind,source=$PWD/nginx.conf,target=/config/nginx.conf`
 
-#### Bind Mount Nginx Config
+### Bind Mount Nginx Config
 
 If you want a different nginx config bind mount to:
 

--- a/requirements_docs.txt
+++ b/requirements_docs.txt
@@ -6,7 +6,7 @@ packaging==20.9
 requests==2.25.1
 six==1.15.0
 sphinx==3.5.4
-recommonmark==0.7.1
+MyST-Parser==0.13.6
 xmlrpc2==0.3.1
 
 git+https://github.com/pypa/pypa-docs-theme.git#egg=pypa-docs-theme

--- a/setup.cfg
+++ b/setup.cfg
@@ -77,23 +77,6 @@ console_scripts =
 safety_db =
     bandersnatch_safety_db
 
-test =
-    coverage
-    freezegun
-    flake8
-    flake8-bugbear
-    pytest
-    pytest-timeout
-    pytest-cache
-
-doc_build =
-    docutils
-    sphinx
-    sphinx_bootstrap_theme
-    guzzle_sphinx_theme
-    sphinx_rtd_theme
-    recommonmark
-
 swift =
     keystoneauth1
     openstackclient

--- a/tox.ini
+++ b/tox.ini
@@ -17,9 +17,7 @@ commands =
     {envpython} {envbindir}/sphinx-build -a -W --keep-going -b html docs docs/html
     {envpython} {envbindir}/sphinx-build -a -W --keep-going -b linkcheck docs docs/html
 changedir = {toxinidir}
-deps =
-    -r requirements_docs.txt
-    sphinx-rtd-theme
+deps = -r requirements_docs.txt
 
 extras = doc_build
 passenv = SSH_AUTH_SOCK


### PR DESCRIPTION
- Migrate markdown documentation to use MyST-Parser since recommonmark
  is going away.
  - The "ReStructuredText syntax in Markdown" feature once provided by
    recommonmark.AutoStructify has been replaced with MyST-Parser's syntax
    extensions
  - Fix the heading depths (i.e. remove a single `#` from most headers)
    because MyST-Parser was emitting warnings
  - Redo the Sphinx configuration to use the new parser

- Remove the `test` and `doc_build` extra installs because they are
  developer-facing and duplicating them doesn't make sense.

- Remove `sphinx_rtd_theme` from the `doc_build` tox environment since
  it's unnecessary

- Remove support for the following HTML themes in the Sphinx configuration:
  cloud_sptheme,sphinx_bootstrap_theme, guzzle_sphinx_theme, sphinx_rtd_theme.
  Only pypa_theme was ever actually being used.

Resolves GH-878.