### PR TITLE
storage: add move_file() and use in rewrite() and update_safe()

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,7 @@
 - Removed terrible isinstance check of unittest.Mock in mirror.py - `PR #859` - Thanks **ichard26**
 - Put potential time consuming IO operations into executor - `PR #877`
 - Migrated Markdown documentation from recommonmark to MyST-Parser + docs config clean up - `PR #879` - Thanks **ichard26**
+- Use `shutil.move()` for temp file management - `PR #883`
 
 # 4.4.0 (2020-12-31)
 

--- a/src/bandersnatch/storage.py
+++ b/src/bandersnatch/storage.py
@@ -238,6 +238,10 @@ class Storage:
         """Copy a file from **source** to **dest**"""
         raise NotImplementedError
 
+    def move_file(self, source: PATH_TYPES, dest: PATH_TYPES) -> None:
+        """Move a file from **source** to **dest**"""
+        raise NotImplementedError
+
     def mkdir(
         self, path: PATH_TYPES, exist_ok: bool = False, parents: bool = False
     ) -> None:

--- a/src/bandersnatch_storage_plugins/filesystem.py
+++ b/src/bandersnatch_storage_plugins/filesystem.py
@@ -93,9 +93,7 @@ class FilesystemStorage(StoragePlugin):
         logger.debug(
             f"Writing temporary file {filepath_tmp} to target destination: {filepath!s}"
         )
-        self.copy_file(filepath_tmp, filepath)
-        logger.debug(f"Deleting temporary file: {filepath_tmp}")
-        self.delete_file(filepath_tmp)
+        self.move_file(filepath_tmp, filepath)
 
     @contextlib.contextmanager
     def update_safe(self, filename: PATH_TYPES, **kw: Any) -> Generator[IO, None, None]:
@@ -123,9 +121,7 @@ class FilesystemStorage(StoragePlugin):
             os.unlink(filename_tmp)
         else:
             logger.debug(f"Modifying destination: {filename!s} with: {filename_tmp}")
-            self.copy_file(filename_tmp, filename)
-            logger.debug(f"Deleting temporary file: {filename_tmp}")
-            self.delete_file(filename_tmp)
+            self.move_file(filename_tmp, filename)
 
     def compare_files(self, file1: PATH_TYPES, file2: PATH_TYPES) -> bool:
         """Compare two files, returning true if they are the same and False if not."""
@@ -136,6 +132,13 @@ class FilesystemStorage(StoragePlugin):
         if not self.exists(source):
             raise FileNotFoundError(source)
         shutil.copy(source, dest)
+        return
+
+    def move_file(self, source: PATH_TYPES, dest: PATH_TYPES) -> None:
+        """Move a file from **source** to **dest**"""
+        if not self.exists(source):
+            raise FileNotFoundError(source)
+        shutil.move(str(source), dest)
         return
 
     def write_file(self, path: PATH_TYPES, contents: Union[str, bytes]) -> None:


### PR DESCRIPTION
This commit avoids copying the file over on (local) filesystem in most circumstances which reduces disk IOs.

When `source` and `dest` are on the same filesystem `shutil.move()` makes use of `os.rename()` which is desired to be atomic, otherwise it will copy and delete like in our previous implementation.