### PR TITLE
Move to using asyncio.run

### DIFF
--- a/src/bandersnatch/main.py
+++ b/src/bandersnatch/main.py
@@ -200,13 +200,9 @@ def main(loop: Optional[asyncio.AbstractEventLoop] = None) -> int:
     if config.has_option("mirror", "log-config"):
         logging.config.fileConfig(str(Path(config.get("mirror", "log-config"))))
 
-    # TODO: Go to asyncio.run() when >= 3.7
-    loop = loop or asyncio.get_event_loop()
-    loop.set_debug(args.debug)
-    try:
-        return loop.run_until_complete(async_main(args, config))
-    finally:
-        loop.close()
+    if loop:
+        loop.set_debug(args.debug)
+    return asyncio.run(async_main(args, config))
 
 
 if __name__ == "__main__":

--- a/src/bandersnatch/tests/test_master.py
+++ b/src/bandersnatch/tests/test_master.py
@@ -8,12 +8,14 @@ import bandersnatch
 from bandersnatch.master import Master, StalePage, XmlRpcError
 
 
-def test_disallow_http() -> None:
+@pytest.mark.asyncio
+async def test_disallow_http() -> None:
     with pytest.raises(ValueError):
         Master("http://pypi.example.com")
 
 
-def test_rpc_url(master: Master) -> None:
+@pytest.mark.asyncio
+async def test_rpc_url(master: Master) -> None:
     assert master.xmlrpc_url == "https://pypi.example.com/pypi"
 
 


### PR DESCRIPTION
- Now we're >= 3.8 we can just use asyncio's run() method to get into an async context

Tests:
- Make sure all tests pass
- Wrap some Master tests to ensure we have a running event loop for them to grab