### PR TITLE
Fix logging bug in metadata_filter for SizeProjectMetadataFilter

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,7 @@
 - Removed terrible isinstance check of unittest.Mock in mirror.py - `PR #859` - Thanks **ichard26**
 - Put potential time consuming IO operations into executor - `PR #877`
 - Migrated Markdown documentation from recommonmark to MyST-Parser + docs config clean up - `PR #879` - Thanks **ichard26**
+- Fixed logging bug in `SizeProjectMetadataFilter` to show it activated - `PR #889` - Thanks **cooperlees**
 
 # 4.4.0 (2020-12-31)
 

--- a/src/bandersnatch/filter.py
+++ b/src/bandersnatch/filter.py
@@ -47,7 +47,7 @@ class Filter:
         if (
             "all" not in split_plugins
             and self.name not in split_plugins
-            # NOTE: Remove after 5.0
+            # TODO: Remove after 5.0
             and not (self.deprecated_name and self.deprecated_name in split_plugins)
         ):
             return

--- a/src/bandersnatch/log.py
+++ b/src/bandersnatch/log.py
@@ -7,7 +7,9 @@ from typing import Any
 
 def setup_logging(args: Any) -> logging.StreamHandler:
     ch = logging.StreamHandler()
-    formatter = logging.Formatter("%(asctime)s %(levelname)s: %(message)s")
+    formatter = logging.Formatter(
+        "%(asctime)s %(levelname)s: %(message)s (%(filename)s:%(lineno)d)"
+    )
     ch.setFormatter(formatter)
     logger = logging.getLogger("bandersnatch")
     logger.setLevel(logging.DEBUG if args.debug else logging.INFO)

--- a/src/bandersnatch_filter_plugins/metadata_filter.py
+++ b/src/bandersnatch_filter_plugins/metadata_filter.py
@@ -219,12 +219,17 @@ class SizeProjectMetadataFilter(FilterMetadataPlugin, AllowListProject):
                         self._determine_unfiltered_package_names()
                     )
 
-                logger.info(
-                    f"Initialized metadata plugin {self.name} to block projects >{self.max_package_size}b"  # noqa: E501
-                    f"; except {self.allowlist_package_names}"
-                    if self.allowlist_package_names
-                    else ""
+                log_msg = (
+                    f"Initialized metadata plugin {self.name} to block projects "
+                    + f"> {self.max_package_size} bytes"
                 )
+                if self.allowlist_package_names:
+                    log_msg += (
+                        "; except packages in the allowlist: "
+                        + f"{self.allowlist_package_names}"
+                    )
+                logger.info(log_msg)
+
             self.initialized = True
 
     def filter(self, metadata: Dict) -> bool:


### PR DESCRIPTION
- Bad if logic caused empty log line to be output
- Add file + line of log messages into bandersnatch logging format to help find bugs easier

Fixes #885