### PR TITLE
Add support to use uvloop

### DIFF
--- a/.github/workflows/uvloop_ci.yml
+++ b/.github/workflows/uvloop_ci.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         python-version: [3.8, 3.9]
-        os: [macOS-latest, ubuntu-latest, windows-latest]
+        os: [macOS-latest, ubuntu-latest]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/uvloop_ci.yml
+++ b/.github/workflows/uvloop_ci.yml
@@ -1,0 +1,41 @@
+name: bandersnatch_uvloop_ci
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    name: bandersnatch CI python ${{ matrix.python-version }} on ${{matrix.os}}
+    # We want to run on external PRs, but not on our own internal PRs (for the
+    # pull_request event) as they'll be run by the push to the branch. Without
+    # this if check, ci workflow checks are duplicated since internal PRs match
+    # both the push and pull_request events.
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
+
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        python-version: [3.8, 3.9]
+        os: [macOS-latest, ubuntu-latest, windows-latest]
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2.2.2
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Install latest pip, setuptools + tox
+      run: |
+        python -m pip install --upgrade pip setuptools tox
+
+    - name: Install base bandersnatch requirements
+      run: |
+        python -m pip install -r requirements.txt
+
+    - name: Run uvloop Integration Test
+      env:
+       TOXENV: INTEGRATION
+      run: |
+        python -m pip install .[uvloop]
+        python test_runner.py

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@
 - bandersnatch is now a >= 3.8 Python project
 - New size_project_metadata filter plugin, which can deny download of projects larger than defined threshold - `PR #806`
 - Add option to compare file size and upload time instead of sha256sum for downloading - `PR #822`
+- Add optional uvloop support - `PR #891` - Thanks **cooperlees**
 
 ## Bug Fixes
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -82,6 +82,9 @@ swift =
     openstackclient
     python-swiftclient
 
+uvloop =
+    uvloop
+
 [isort]
 atomic = true
 profile = black

--- a/src/bandersnatch/main.py
+++ b/src/bandersnatch/main.py
@@ -20,6 +20,7 @@ from bandersnatch.storage import storage_backend_plugins
 # See if we have uvloop and use if so
 try:
     import uvloop
+
     uvloop.install()
 except ImportError:
     pass

--- a/src/bandersnatch/main.py
+++ b/src/bandersnatch/main.py
@@ -17,6 +17,13 @@ import bandersnatch.mirror
 import bandersnatch.verify
 from bandersnatch.storage import storage_backend_plugins
 
+# See if we have uvloop and use if so
+try:
+    import uvloop
+    uvloop.install()
+except ImportError:
+    pass
+
 logger = logging.getLogger(__name__)  # pylint: disable=C0103
 
 


### PR DESCRIPTION
- If uvloop is imported, lets try and use it
- Also added extra install to facilitate it for users
  - i.e. `pip install bandersnatch[uvloop]` will now install it (one this is released to pypi)