### PR TITLE
Update black from 20.8b1 to 21.4b0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
     -   id: check-added-large-files
         exclude: ^docs/conf.py$
 -   repo: https://github.com/psf/black
-    rev: 20.8b1
+    rev: 21.4b0
     hooks:
     -   id: black
         args: [--target-version, py36]

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,5 +1,5 @@
 async-timeout==3.0.1
-black==20.8b1
+black==21.4b0
 codecov==2.1.11
 coverage==5.5
 flake8==3.9.1

--- a/src/bandersnatch/master.py
+++ b/src/bandersnatch/master.py
@@ -46,7 +46,7 @@ class Master:
             raise ValueError(err)
 
     def _check_for_socks_proxy(self) -> Optional[ProxyConnector]:
-        """ Check env for a SOCKS proxy URL and return a connector if found """
+        """Check env for a SOCKS proxy URL and return a connector if found"""
         proxy_vars = (
             "https_proxy",
             "http_proxy",

--- a/src/bandersnatch/mirror.py
+++ b/src/bandersnatch/mirror.py
@@ -635,7 +635,7 @@ class BandersnatchMirror(Mirror):
         return True
 
     async def sync_release_files(self, package: Package) -> None:
-        """ Purge + download files returning files removed + added """
+        """Purge + download files returning files removed + added"""
         downloaded_files = set()
         deferred_exception = None
         for release_file in package.release_files:

--- a/src/bandersnatch/tests/test_main.py
+++ b/src/bandersnatch/tests/test_main.py
@@ -24,7 +24,7 @@ async def empty_dict(*args: Any, **kwargs: Any) -> Dict:
 
 
 def setup() -> None:
-    """ simple setup function to clear Singleton._instances before each test"""
+    """simple setup function to clear Singleton._instances before each test"""
     Singleton._instances = {}
 
 

--- a/src/bandersnatch/tests/test_mirror.py
+++ b/src/bandersnatch/tests/test_mirror.py
@@ -25,7 +25,7 @@ EXPECTED_REL_HREFS = (
 
 
 class JsonDict(dict):
-    """ Class to fake the object returned from requests lib in master.get() """
+    """Class to fake the object returned from requests lib in master.get()"""
 
     def json(self) -> "JsonDict":
         return self

--- a/src/bandersnatch/utils.py
+++ b/src/bandersnatch/utils.py
@@ -118,7 +118,7 @@ def recursive_find_files(files: Set[Path], base_dir: Path) -> None:
 
 
 def unlink_parent_dir(path: Path) -> None:
-    """ Remove a file and if the dir is empty remove it """
+    """Remove a file and if the dir is empty remove it"""
     logger.info(f"unlink {str(path)}")
     path.unlink()
 


### PR DESCRIPTION
Resolves #892 (i.e. supersedes)

I'm assuming this should get a skip news label