### PR TITLE
Add a default ThreadPoolExecutor to storage plugin to wrap all IO

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,6 +17,7 @@
 - Migrated Markdown documentation from recommonmark to MyST-Parser + docs config clean up - `PR #879` - Thanks **ichard26**
 - Use `shutil.move()` for temp file management - `PR #883` - Thanks **happyaron**
 - Fixed logging bug in `SizeProjectMetadataFilter` to show it activated - `PR #889` - Thanks **cooperlees**
+- Attempt to wrap all potentially block calls in a ThreadPoolExecutor - `PR #894` - Thanks **cooperlees**`
 
 # 4.4.0 (2020-12-31)
 

--- a/src/bandersnatch/storage.py
+++ b/src/bandersnatch/storage.py
@@ -1,6 +1,7 @@
 """
 Storage management
 """
+import asyncio
 import configparser
 import contextlib
 import datetime
@@ -8,6 +9,7 @@ import hashlib
 import logging
 import pathlib
 from collections import defaultdict
+from concurrent.futures import ThreadPoolExecutor
 from typing import (
     IO,
     Any,
@@ -80,6 +82,10 @@ class Storage:
         self.json_base_path = self.web_base_path / "json"
         self.pypi_base_path = self.web_base_path / "pypi"
         self.simple_base_path = self.web_base_path / "simple"
+        self.executor = ThreadPoolExecutor(
+            max_workers=self.configuration.getint("mirror", "workers")
+        )
+        self.loop = asyncio.get_event_loop()
 
     def __str__(self) -> str:
         return (

--- a/src/bandersnatch/tests/plugins/test_allowlist_name.py
+++ b/src/bandersnatch/tests/plugins/test_allowlist_name.py
@@ -33,6 +33,10 @@ class TestAllowListProject(TestCase):
     def test__plugin__loads__explicitly_enabled(self) -> None:
         mock_config(
             contents="""\
+[mirror]
+storage-backend = filesystem
+workers = 2
+
 [plugins]
 enabled =
     allowlist_project
@@ -49,6 +53,7 @@ enabled =
             """\
 [mirror]
 storage-backend = filesystem
+workers = 2
 
 [plugins]
 """
@@ -63,6 +68,7 @@ storage-backend = filesystem
             """\
 [mirror]
 storage-backend = filesystem
+workers = 2
 
 [plugins]
 enabled =
@@ -85,6 +91,7 @@ packages =
             """\
 [mirror]
 storage-backend = filesystem
+workers = 2
 
 [plugins]
 enabled =
@@ -108,6 +115,7 @@ packages =
             """\
 [mirror]
 storage-backend = filesystem
+workers = 2
 
 [plugins]
 enabled =
@@ -131,6 +139,7 @@ packages =
             """\
 [mirror]
 storage-backend = filesystem
+workers = 2
 
 [plugins]
 enabled =
@@ -157,6 +166,7 @@ packages =
             """\
 [mirror]
 storage-backend = filesystem
+workers = 2
 
 [plugins]
 enabled =
@@ -212,6 +222,10 @@ enabled =
     def test__plugin__doesnt_load__explicitly__disabled(self) -> None:
         mock_config(
             """\
+[mirror]
+storage-backend = filesystem
+workers = 2
+
 [plugins]
 enabled =
     allowlist_package
@@ -225,6 +239,10 @@ enabled =
     def test__filter__matches__release(self) -> None:
         mock_config(
             """\
+[mirror]
+storage-backend = filesystem
+workers = 2
+
 [plugins]
 enabled =
     allowlist_release
@@ -248,6 +266,10 @@ packages =
     def test__filter__matches__release__commented__inline(self) -> None:
         mock_config(
             """\
+[mirror]
+storage-backend = filesystem
+workers = 2
+
 [plugins]
 enabled =
     allowlist_release
@@ -271,6 +293,10 @@ packages =
     def test__dont__filter__prereleases(self) -> None:
         mock_config(
             """\
+[mirror]
+storage-backend = filesystem
+workers = 2
+
 [plugins]
 enabled =
     allowlist_release
@@ -301,6 +327,10 @@ packages =
     def test__casing__no__affect(self) -> None:
         mock_config(
             """\
+[mirror]
+storage-backend = filesystem
+workers = 2
+
 [plugins]
 enabled =
     allowlist_release
@@ -341,6 +371,10 @@ class TestAllowlistRequirements(TestCase):
     def test__plugin__loads__explicitly_enabled(self) -> None:
         mock_config(
             """\
+[mirror]
+storage-backend = filesystem
+workers = 2
+
 [plugins]
 enabled =
     project_requirements_pinned
@@ -355,6 +389,10 @@ enabled =
     def test__plugin__doesnt_load__explicitly__disabled(self) -> None:
         mock_config(
             """\
+[mirror]
+storage-backend = filesystem
+workers = 2
+
 [plugins]
 enabled =
     allowlist_package
@@ -378,6 +416,10 @@ foo==1.2.0             # via -r requirements.in
 
         mock_config(
             f"""\
+[mirror]
+storage-backend = filesystem
+workers = 2
+
 [plugins]
 enabled =
     project_requirements
@@ -413,6 +455,10 @@ foo==1.2.0             # via -r requirements.in
 
         mock_config(
             f"""\
+[mirror]
+storage-backend = filesystem
+workers = 2
+
 [plugins]
 enabled =
     project_requirements

--- a/src/bandersnatch/tests/test_delete.py
+++ b/src/bandersnatch/tests/test_delete.py
@@ -71,24 +71,25 @@ def _fake_config() -> ConfigParser:
     return cp
 
 
-def test_delete_path() -> None:
+@pytest.mark.asyncio
+async def test_delete_path() -> None:
     with TemporaryDirectory() as td:
         td_path = Path(td)
         fake_path = td_path / "unittest-file.tgz"
         with patch("bandersnatch.delete.logger.info") as mock_log:
-            assert delete_path(fake_path, True) == 0
+            assert await delete_path(fake_path, True) == 0
             assert mock_log.call_count == 1
 
         with patch("bandersnatch.delete.logger.debug") as mock_log:
-            assert delete_path(fake_path, False) == 0
+            assert await delete_path(fake_path, False) == 0
             assert mock_log.call_count == 1
 
         fake_path.touch()
         # Remove file
-        assert delete_path(fake_path, False) == 0
+        assert await delete_path(fake_path, False) == 0
         # File should be gone - We should log that via debug
         with patch("bandersnatch.delete.logger.debug") as mock_log:
-            assert delete_path(fake_path, False) == 0
+            assert await delete_path(fake_path, False) == 0
             assert mock_log.call_count == 1
 
 


### PR DESCRIPTION
- Have asyncio call all potential blocking IO in said ThreadPoolExectuor in heavy main workload - e.g. downloading many packages @ once
- Grepped popular blocking calls to find
- This should help stop starving the loop from CPU time
- Modified all modules that call storage block calls to wrap them in the sotrage class executor with max thread == workers

Testing:
- Fix unittests to pass
  - A lot just needed workers config
  - Some just needed to have a loop / become coroutines

Fixes #584