### PR TITLE
Remove legacy support for non PC configuration names

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,11 @@
 - Add optional uvloop support - `PR #891` - Thanks **cooperlees**
 - Move to official docker upload action w/arm64 images uploaded - `PR #896` - Thanks **cooperlees**
 
+## Deprecations
+
+- blacklist/whitelist will no longer work in bandersnatch configuration - `PR #897` - Thanks **cooperlees**
+  - Please use allowlist/denylist respectively
+
 ## Bug Fixes
 
 - Unused storage plugins are loaded and cause non-fatal errors if dependencies are missing - `PR #799` - Thanks **electricworry**

--- a/src/bandersnatch/configuration.py
+++ b/src/bandersnatch/configuration.py
@@ -4,7 +4,6 @@ Module containing classes to access the bandersnatch configuration file
 import configparser
 import importlib.resources
 import logging
-import warnings
 from pathlib import Path
 from typing import Any, Dict, List, NamedTuple, Optional, Type
 

--- a/src/bandersnatch/configuration.py
+++ b/src/bandersnatch/configuration.py
@@ -53,19 +53,12 @@ class BandersnatchConfig(metaclass=Singleton):
             self.default_config_file = str(config_path)
         self.config_file = config_file
         self.load_configuration()
-        self.check_for_deprecations()
+        # Keeping for future deprecations ... Commenting to save function call etc.
+        # self.check_for_deprecations()
 
     def check_for_deprecations(self) -> None:
         if self.SHOWN_DEPRECATIONS:
             return
-        if self.config.has_section("whitelist") or self.config.has_section("blacklist"):
-            err_msg = (
-                "whitelist/blacklist filter plugins will be renamed to "
-                "allowlist_*/blocklist_* in version 5.0 "
-                " - Documentation @ https://bandersnatch.readthedocs.io/"
-            )
-            warnings.warn(err_msg, DeprecationWarning, stacklevel=2)
-            logger.warning(err_msg)
         self.SHOWN_DEPRECATIONS = True
 
     def load_configuration(self) -> None:

--- a/src/bandersnatch/filter.py
+++ b/src/bandersnatch/filter.py
@@ -87,22 +87,13 @@ class Filter:
         """
         return False
 
-    # NOTE: These two can be removed in 5.0
     @property
     def allowlist(self) -> "SectionProxy":
-        return (
-            self.configuration["whitelist"]
-            if self.configuration.has_section("whitelist")
-            else self.configuration["allowlist"]
-        )
+        return self.configuration["allowlist"]
 
     @property
     def blocklist(self) -> "SectionProxy":
-        return (
-            self.configuration["blacklist"]
-            if self.configuration.has_section("blacklist")
-            else self.configuration["blocklist"]
-        )
+        return self.configuration["blocklist"]
 
 
 class FilterProjectPlugin(Filter):

--- a/src/bandersnatch/tests/test_configuration.py
+++ b/src/bandersnatch/tests/test_configuration.py
@@ -155,31 +155,6 @@ class TestBandersnatchConf(TestCase):
             default_values, validate_config_values(release_files_false_configparser)
         )
 
-    def test_deprecation_warning_raised(self) -> None:
-        # Remove in 5.0 once we deprecate whitelist/blacklist
-
-        config_file = "test.conf"
-        instance = BandersnatchConfig()
-        instance.config_file = config_file
-        # Test no warning if new plugins used
-        with open(config_file, "w") as f:
-            f.write("[allowlist]\npackages=foo\n")
-        instance.load_configuration()
-        with warnings.catch_warnings(record=True) as w:
-            instance.check_for_deprecations()
-            self.assertEqual(len(w), 0)
-
-        # Test warning if old plugins used
-        instance.SHOWN_DEPRECATIONS = False
-        with open(config_file, "w") as f:
-            f.write("[whitelist]\npackages=foo\n")
-        instance.load_configuration()
-        with warnings.catch_warnings(record=True) as w:
-            instance.check_for_deprecations()
-            instance.check_for_deprecations()
-            # Assert we only throw 1 warning
-            self.assertEqual(len(w), 1)
-
 
 if __name__ == "__main__":
     unittest.main()

--- a/src/bandersnatch/tests/test_configuration.py
+++ b/src/bandersnatch/tests/test_configuration.py
@@ -2,7 +2,6 @@ import configparser
 import importlib.resources
 import os
 import unittest
-import warnings
 from tempfile import TemporaryDirectory
 from unittest import TestCase
 

--- a/src/bandersnatch_filter_plugins/allowlist_name.py
+++ b/src/bandersnatch_filter_plugins/allowlist_name.py
@@ -16,7 +16,6 @@ logger = logging.getLogger("bandersnatch")
 
 class AllowListProject(FilterProjectPlugin):
     name = "allowlist_project"
-    deprecated_name = "whitelist_project"
     # Requires iterable default
     allowlist_package_names: List[str] = []
 
@@ -154,7 +153,6 @@ class AllowListRequirements(AllowListProject):
 
 class AllowListRelease(FilterReleasePlugin):
     name = "allowlist_release"
-    deprecated_name = "whitelist_release"
     # Requires iterable default
     allowlist_package_names: List[Requirement] = []
 

--- a/src/bandersnatch_filter_plugins/blocklist_name.py
+++ b/src/bandersnatch_filter_plugins/blocklist_name.py
@@ -12,7 +12,6 @@ logger = logging.getLogger("bandersnatch")
 
 class BlockListProject(FilterProjectPlugin):
     name = "blocklist_project"
-    deprecated_name = "blacklist_project"
     # Requires iterable default
     blocklist_package_names: List[str] = []
 
@@ -94,7 +93,6 @@ class BlockListProject(FilterProjectPlugin):
 
 class BlockListRelease(FilterReleasePlugin):
     name = "blocklist_release"
-    deprecated_name = "blacklist_release"
     # Requires iterable default
     blocklist_package_names: List[Requirement] = []
 


### PR DESCRIPTION
- Remove the old allow/deny list naming
- Make it loud and proud in the CHANGES.md

Fixes #888

** This will require config updates from users using the legacy names!! **