### PR TITLE
Add autogenerated CLI help to docs index page.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,7 +62,8 @@ instance/
 .scrapy
 
 # Sphinx documentation
-doc/html/
+docs/html/
+docs/_build/
 
 # PyBuilder
 target/

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+# 5.1.0 (2021-XX-XX)
+
+## Bug fixes
+
+- Add bandersnatch command line help to the documentation main page `PR #920` - Thanks **ichard26**
+
 # 5.0.0 (2021-4-28)
 
 ## New Features

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -31,6 +31,7 @@ extensions = [
     "sphinx.ext.inheritance_diagram",
     "sphinx.ext.githubpages",
     "myst_parser",
+    "sphinx_argparse_cli",
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -18,7 +18,14 @@ As of 4.0 bandersnatch:
 - Only stores PEP503 nomalized packages names for the /simple API
 - Only stores JSON in normailzed package name path too
 
-Contents:
+
+.. sphinx_argparse_cli::
+  :module: bandersnatch.main
+  :func: _make_parser
+  :title: Command line usage
+
+Contents
+--------
 
 .. toctree::
     :maxdepth: 3

--- a/requirements_docs.txt
+++ b/requirements_docs.txt
@@ -8,6 +8,7 @@ six==1.16.0
 sphinx==3.5.4
 MyST-Parser==0.13.7
 xmlrpc2==0.3.1
+sphinx-argparse-cli==1.6.0
 
 git+https://github.com/pypa/pypa-docs-theme.git#egg=pypa-docs-theme
 git+https://github.com/python/python-docs-theme.git#egg=python-docs-theme

--- a/src/bandersnatch/main.py
+++ b/src/bandersnatch/main.py
@@ -115,6 +115,36 @@ def _sync_parser(subparsers: argparse._SubParsersAction) -> None:
     m.set_defaults(op="sync")
 
 
+def _make_parser() -> argparse.ArgumentParser:
+    # Seperated so sphinx-argparse-cli can do its auto documentation magic.
+    parser = argparse.ArgumentParser(
+        description="PyPI PEP 381 mirroring client.", prog="bandersnatch"
+    )
+    parser.add_argument(
+        "--version", action="version", version=f"%(prog)s {bandersnatch.__version__}"
+    )
+    parser.add_argument(
+        "-c",
+        "--config",
+        default="/etc/bandersnatch.conf",
+        help="use configuration file (default: %(default)s)",
+    )
+    parser.add_argument(
+        "--debug",
+        action="store_true",
+        default=False,
+        help="Turn on extra logging (DEBUG level)",
+    )
+
+    subparsers = parser.add_subparsers()
+    _delete_parser(subparsers)
+    _mirror_parser(subparsers)
+    _verify_parser(subparsers)
+    _sync_parser(subparsers)
+
+    return parser
+
+
 async def async_main(args: argparse.Namespace, config: ConfigParser) -> int:
     if args.op.lower() == "delete":
         async with bandersnatch.master.Master(
@@ -155,31 +185,7 @@ async def async_main(args: argparse.Namespace, config: ConfigParser) -> int:
 
 
 def main(loop: Optional[asyncio.AbstractEventLoop] = None) -> int:
-    parser = argparse.ArgumentParser(
-        description="PyPI PEP 381 mirroring client.", prog="bandersnatch"
-    )
-    parser.add_argument(
-        "--version", action="version", version=f"%(prog)s {bandersnatch.__version__}"
-    )
-    parser.add_argument(
-        "-c",
-        "--config",
-        default="/etc/bandersnatch.conf",
-        help="use configuration file (default: %(default)s)",
-    )
-    parser.add_argument(
-        "--debug",
-        action="store_true",
-        default=False,
-        help="Turn on extra logging (DEBUG level)",
-    )
-
-    subparsers = parser.add_subparsers()
-    _delete_parser(subparsers)
-    _mirror_parser(subparsers)
-    _verify_parser(subparsers)
-    _sync_parser(subparsers)
-
+    parser = _make_parser()
     if len(sys.argv) < 2:
         parser.print_help()
         parser.exit()


### PR DESCRIPTION
Using sphinx-argparse-cli instead of sphinxcontrib-programoutput because
I got convinced by gaborjbernat via Discord.

Unfortanately this requires to move parser configuration to its own
function because that's what sphinx-argparse-cli uses as input. This
isn't that painful tho.

---

Preview: https://bandersnatch.readthedocs.io/en/add-cli-help/

Resolves #907. 