### PR TITLE
Generate data-yanked tag in simple page

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@
 ## Bug fixes
 
 - Add bandersnatch command line help to the documentation main page `PR #920` - Thanks **ichard26**
+- Generate data-yanked tag in simple page `PR #931` - Thanks **happyaron**
 
 # 5.0.0 (2021-4-28)
 

--- a/src/bandersnatch/mirror.py
+++ b/src/bandersnatch/mirror.py
@@ -671,10 +671,21 @@ class BandersnatchMirror(Mirror):
 
         self.altered_packages[package.name] = downloaded_files
 
-    def gen_data_requires_python(self, release: Dict) -> str:
+    def gen_html_file_tags(self, release: Dict) -> str:
+        file_tags = ""
+
+        # data-requires-python: requires_python
         if "requires_python" in release and release["requires_python"] is not None:
-            return f' data-requires-python="{html.escape(release["requires_python"])}"'
-        return ""
+            file_tags += (
+                f' data-requires-python="{html.escape(release["requires_python"])}"'
+            )
+
+        # data-yanked: yanked_reason
+        if "yanked" in release and release["yanked"]:
+            if "yanked_reason" in release:
+                file_tags += f' data-yanked="{html.escape(release["yanked_reason"])}"'
+
+        return file_tags
 
     def generate_simple_page(self, package: Package) -> str:
         # Generate the header of our simple page.
@@ -702,7 +713,7 @@ class BandersnatchMirror(Mirror):
                     self._file_url_to_local_url(r["url"]),
                     digest_name,
                     r["digests"][digest_name],
-                    self.gen_data_requires_python(r),
+                    self.gen_html_file_tags(r),
                     r["filename"],
                 )
                 for r in release_files

--- a/src/bandersnatch/tests/test_mirror.py
+++ b/src/bandersnatch/tests/test_mirror.py
@@ -898,14 +898,30 @@ async def test_package_sync_does_not_touch_existing_local_file(
     assert old_stat.st_ctime == Path(pkg_file_path_str).stat().st_ctime
 
 
-def test_gen_data_requires_python(mirror: BandersnatchMirror) -> None:
+def test_gen_html_file_tags(mirror: BandersnatchMirror) -> None:
     fake_no_release: Dict[str, str] = {}
-    fake_release = {"requires_python": ">=3.6"}
 
-    assert mirror.gen_data_requires_python(fake_no_release) == ""
+    # only requires_python
+    fake_release_1 = {"requires_python": ">=3.6"}
+
+    # only data_yanked
+    fake_release_2 = {"yanked": True, "yanked_reason": "Broken release"}
+
+    # requires_python and data_yanked
+    fake_release_3 = {
+        "requires_python": ">=3.6",
+        "yanked": True,
+        "yanked_reason": "Broken release",
+    }
+
+    assert mirror.gen_html_file_tags(fake_no_release) == ""
     assert (
-        mirror.gen_data_requires_python(fake_release)
-        == ' data-requires-python="&gt;=3.6"'
+        mirror.gen_html_file_tags(fake_release_1) == ' data-requires-python="&gt;=3.6"'
+    )
+    assert mirror.gen_html_file_tags(fake_release_2) == ' data-yanked="Broken release"'
+    assert (
+        mirror.gen_html_file_tags(fake_release_3)
+        == ' data-requires-python="&gt;=3.6" data-yanked="Broken release"'
     )
 
 


### PR DESCRIPTION
data-yanked is not generated in bandersnatch's simple page, this may confuse pip client because it will not install yanked release if not explictedly requested by user.