### PR TITLE
data-yanked: fix exception when yanked-reason is present but empty

### DIFF
--- a/src/bandersnatch/mirror.py
+++ b/src/bandersnatch/mirror.py
@@ -735,8 +735,10 @@ class BandersnatchMirror(Mirror):
 
         # data-yanked: yanked_reason
         if "yanked" in release and release["yanked"]:
-            if "yanked_reason" in release:
+            if "yanked_reason" in release and release["yanked_reason"]:
                 file_tags += f' data-yanked="{html.escape(release["yanked_reason"])}"'
+            else:
+                file_tags += ' data-yanked=""'
 
         return file_tags
 


### PR DESCRIPTION
This PR fixes an exception when yanked-reason is present but empty, which is discovered when syncing the package borisml-0.0

Because it's a trivial fix to an exisiting commit, I don't think there should be a dedicated changelog entry...