### PR TITLE
 Use update_safe when updating some repo-level metadata

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,7 @@
 
 - Add bandersnatch command line help to the documentation main page `PR #920` - Thanks **ichard26**
 - Generate data-yanked tag in simple page `PR #931` - Thanks **happyaron**
+- Protect repository metadata from being trashed when disk is full `PR #961` - Thanks **happyaron**
 
 # 5.0.0 (2021-4-28)
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,7 +8,7 @@
 
 - Add bandersnatch command line help to the documentation main page `PR #920` - Thanks **ichard26**
 - Generate data-yanked tag in simple page `PR #931` - Thanks **happyaron**
-- Protect repository metadata from being trashed when disk is full `PR #961` - Thanks **happyaron**
+- Protect repository metadata from being trashed when disk is full `PR #962` - Thanks **happyaron**
 
 # 5.0.0 (2021-4-28)
 

--- a/src/bandersnatch/mirror.py
+++ b/src/bandersnatch/mirror.py
@@ -514,7 +514,9 @@ class BandersnatchMirror(Mirror):
             )
             return
 
-        with self.storage_backend.rewrite(str(last_modified)) as f:
+        with self.storage_backend.update_safe(
+            last_modified, mode="w", encoding="utf-8"
+        ) as f:
             f.write(self.now.strftime("%Y%m%dT%H:%M:%S\n"))
         self._save()
 
@@ -592,7 +594,10 @@ class BandersnatchMirror(Mirror):
             generation = 5
         if generation != CURRENT_GENERATION:
             raise RuntimeError(f"Unknown generation {generation} found")
-        self.generationfile.write_text(str(CURRENT_GENERATION), encoding="ascii")
+        with self.storage_backend.update_safe(
+            self.generationfile, mode="w", encoding="ascii"
+        ) as f:
+            f.write(str(CURRENT_GENERATION))
         # Now, actually proceed towards using the status files.
         if not self.statusfile.exists():
             logger.info(f"Status file {self.statusfile} missing. Starting over.")
@@ -602,7 +607,10 @@ class BandersnatchMirror(Mirror):
         )
 
     def _save(self) -> None:
-        self.statusfile.write_text(str(self.synced_serial), encoding="ascii")
+        with self.storage_backend.update_safe(
+            self.statusfile, mode="w+", encoding="ascii"
+        ) as f:
+            f.write(str(self.synced_serial))
 
     """
     BandersnatchMirror now includes all the original aspects of Mirror

--- a/src/bandersnatch/tests/plugins/test_storage_plugins.py
+++ b/src/bandersnatch/tests/plugins/test_storage_plugins.py
@@ -726,6 +726,12 @@ web{0}simple{0}index.html""".format(
 
     def test_find(self) -> None:
         base_path = self.mirror_base_path
+
+        # Clean up GitHub Actions environment on macOS tests
+        if sys.platform == "darwin":
+            env_garbage_path = os.path.join(self.mirror_base_path, "var")
+            shutil.rmtree(env_garbage_path, ignore_errors=True)
+
         self.assertEqual(self.base_find_contents, self.plugin.find(base_path))
 
     def test_open_file(self) -> None:

--- a/src/bandersnatch/tests/plugins/test_storage_plugins.py
+++ b/src/bandersnatch/tests/plugins/test_storage_plugins.py
@@ -726,8 +726,6 @@ web{0}simple{0}index.html""".format(
 
     def test_find(self) -> None:
         base_path = self.mirror_base_path
-        if self.backend == "swift":
-            base_path = base_path.lstrip("/")
         self.assertEqual(self.base_find_contents, self.plugin.find(base_path))
 
     def test_open_file(self) -> None:


### PR DESCRIPTION
In the current implementation, when disk is full while wrapping up the sync, bandersnatch will truncate last-modified, generation and status files (and maybe more). This lead to a situation that the last successful sync's serial is lost, forcing next sync to start from verifying everything even the disk space issue is resolved.

Repacing some of the Path.write_text() and rewrite() to mitigate this problem. This closes #961