### PR TITLE
Move to PEP517 `build` package/frontend for packaging releases

### DIFF
--- a/.github/workflows/pypi_upload.yml
+++ b/.github/workflows/pypi_upload.yml
@@ -15,13 +15,17 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v2.3.1
 
-    - name: Install latest pip, setuptools, twine, wheel
+    - name: Install latest build, twine
       run: |
-        python -m pip install --upgrade build pip setuptools twine wheel
+        python -m pip install --upgrade build twine
 
     - name: Build sdist & wheel
       run: |
         python -m build
+
+    - name: Run a twine check
+      run: |
+        twine --check dist/*
 
     - name: Upload to PyPI via Twine
       env:

--- a/.github/workflows/pypi_upload.yml
+++ b/.github/workflows/pypi_upload.yml
@@ -17,12 +17,11 @@ jobs:
 
     - name: Install latest pip, setuptools, twine, wheel
       run: |
-        python -m pip install --upgrade pip setuptools twine wheel
+        python -m pip install --upgrade build pip setuptools twine wheel
 
     - name: Build sdist & wheel
       run: |
-        python setup.py bdist_wheel
-        python setup.py sdist
+        python -m build
 
     - name: Upload to PyPI via Twine
       env:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[build-system]
+requires = ["setuptools", "wheel"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
-requires = ["setuptools>=42.0.0"]
+requires = ["setuptools>=43.0.0"]
 build-backend = "setuptools.build_meta"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,3 @@
 [build-system]
-requires = ["setuptools", "wheel"]
+requires = ["setuptools>=42.0.0"]
+build-backend = "setuptools.build_meta"


### PR DESCRIPTION
- `setup.py` direct invocations is deprecated
  - https://blog.ganssle.io/articles/2021/10/setup-py-deprecated.html
- Lets be a good **PyPA** package and move to build PEP517 buld frontend that should do the right things

Test

- Show Python version used for test:
```
crl-m1:ptr cooper$ python3 -V
Python 3.9.10
```
- `/tmp/test_build/bin/pip install --upgrade pip setuptools`
- `/tmp/test_build/bin/pip install --upgrade build pip setuptools twine`
- `/tmp/test_build/bin/python -m build`
  - Output: https://pastebin.com/rcmCp0cb