### PR TITLE
Limit CI running to help PyPA

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,14 @@
 name: bandersnatch_ci
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
 
 jobs:
   build:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,11 +13,6 @@ concurrency:
 jobs:
   build:
     name: bandersnatch CI python ${{ matrix.python-version }} on ${{matrix.os}}
-    # We want to run on external PRs, but not on our own internal PRs (for the
-    # pull_request event) as they'll be run by the push to the branch. Without
-    # this if check, ci workflow checks are duplicated since internal PRs match
-    # both the push and pull_request events.
-    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/ci_ubuntu.yml
+++ b/.github/workflows/ci_ubuntu.yml
@@ -13,11 +13,6 @@ concurrency:
 jobs:
   build:
     name: bandersnatch CI python ${{ matrix.python-version }} on ${{matrix.os}}
-    # We want to run on external PRs, but not on our own internal PRs (for the
-    # pull_request event) as they'll be run by the push to the branch. Without
-    # this if check, ci workflow checks are duplicated since internal PRs match
-    # both the push and pull_request events.
-    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/ci_ubuntu.yml
+++ b/.github/workflows/ci_ubuntu.yml
@@ -1,6 +1,14 @@
 name: bandersnatch_ci_ubuntu
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
 
 jobs:
   build:

--- a/.github/workflows/doc_build.yml
+++ b/.github/workflows/doc_build.yml
@@ -1,6 +1,10 @@
 name: doc_build
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
 
 jobs:
   lint:

--- a/.github/workflows/docker_upload.yml
+++ b/.github/workflows/docker_upload.yml
@@ -3,7 +3,7 @@ name: bandersnatch_docker_upload
 on:
   push:
     branches:
-      - "master"
+      - main
   release:
     types: created
 


### PR DESCRIPTION
- As request by di tune our jobs
  - To be fair our CI is pretty quick and we're not a busy project but I guess all helps
- Add only run on main branch push + pull requests to all on PR CI
- Also add the concurrency tweaks like `pip` to our main CI (`ci.yml` and `ci_ubuntu.yml`)
  - We test the S3 plugin in ubuntu and it has some extra deps to mimic the S3 API etc.
- Fix broken docker_upload branch name of "master" to "main"

Let me know if there are any more tweaks we can do to be a team plater.