### PR TITLE
s3: Fix typing + make functions same as Parent objects

### DIFF
--- a/src/bandersnatch_storage_plugins/s3.py
+++ b/src/bandersnatch_storage_plugins/s3.py
@@ -44,7 +44,7 @@ class S3Path(_S3Path):
         continuation_token = None
         while True:
             if continuation_token:
-                # mypy thinks we never get here die to response.get()
+                # mypy thinks we never get here due to response.get()
                 # not being typed I think
                 kwargs["ContinuationToken"] = continuation_token  # type: ignore
             response = bucket.meta.client.list_objects_v2(**kwargs)

--- a/src/bandersnatch_storage_plugins/s3.py
+++ b/src/bandersnatch_storage_plugins/s3.py
@@ -44,6 +44,8 @@ class S3Path(_S3Path):
         continuation_token = None
         while True:
             if continuation_token:
+                # mypy thinks we never get here die to response.get()
+                # not being typed I think
                 kwargs["ContinuationToken"] = continuation_token  # type: ignore
             response = bucket.meta.client.list_objects_v2(**kwargs)
             for file in response["Contents"]:
@@ -191,20 +193,16 @@ class S3Storage(StoragePlugin):
         results.sort()
         return "\n".join(str(result.relative_to(root)) for result in results)
 
-    # @contextlib.contextmanager
-    # TODO: Make a Generator
-    def rewrite(  # type: ignore
-        self,
-        filepath: PATH_TYPES,
-        mode: str = "w",
-        **kw: Any
-        # ) -> Generator[IO, None, None]:
-    ) -> IO:
+    @contextlib.contextmanager
+    def rewrite(
+        self, filepath: PATH_TYPES, mode: str = "w", **kw: Any
+    ) -> Generator[IO, None, None]:
         """Rewrite an existing file atomically to avoid programs running in
         parallel to have race conditions while reading."""
         if not isinstance(filepath, self.PATH_BACKEND):
             filepath = self.PATH_BACKEND(filepath)
-        return filepath.open(mode=mode, **kw)  # type: ignore
+        with filepath.open(mode=mode, **kw) as fh:
+            yield fh
 
     @contextlib.contextmanager
     def update_safe(self, filename: PATH_TYPES, **kw: Any) -> Generator[IO, None, None]:
@@ -218,8 +216,6 @@ class S3Storage(StoragePlugin):
             prefix=f"{os.path.basename(filename)}.",
             **kw,
         ) as tf:
-            # TODO: Workout if this is actually used / needed
-            tf.has_changed = False  # type: ignore
             yield tf
             if not os.path.exists(tf.name):
                 return
@@ -275,22 +271,18 @@ class S3Storage(StoragePlugin):
                 fp.write(contents)
         return
 
-    # @contextlib.contextmanager
-    # TODO: Make a Generator
-    def open_file(  # type: ignore
-        self,
-        path: PATH_TYPES,
-        text: bool = True,
-        encoding: str = "utf-8"
-        # ) -> Generator[IO, None, None]:
-    ) -> IO:
+    @contextlib.contextmanager
+    def open_file(
+        self, path: PATH_TYPES, text: bool = True, encoding: str = "utf-8"
+    ) -> Generator[IO, None, None]:
         if not isinstance(path, self.PATH_BACKEND):
             path = self.PATH_BACKEND(path)
         mode = "r" if text else "rb"
-        kwargs: dict[str, str] = {}
+        file_encoding = None
         if text:
-            kwargs["encoding"] = encoding
-        return path.open(mode=mode, **kwargs)  # type: ignore
+            file_encoding = encoding
+        with path.open(mode=mode, encoding=file_encoding) as fh:
+            yield fh
 
     def read_file(
         self,
@@ -301,9 +293,8 @@ class S3Storage(StoragePlugin):
     ) -> str | bytes:
         """Return the contents of the requested file, either a a bytestring or a unicode
         string depending on whether **text** is True"""
-
-        fh = self.open_file(path, text=text, encoding=encoding)
-        contents: str | bytes = fh.read()
+        with self.open_file(path, text=text, encoding=encoding) as fh:
+            contents: str | bytes = fh.read()
         return contents
 
     def delete_file(self, path: PATH_TYPES, dry_run: bool = False) -> int:


### PR DESCRIPTION
- Some functions were not made Generators that should be
- Also file filesystem `open_file` to not need a dict + copy to s3 child object
- Remove `tf.has_changed = False` from filesystem + s3 update_safe fucntion as it's not used

Ignoring swift plugin due to #1081

Fixes #1074