### PR TITLE
Add S3 Docker Image support + uploading

### DIFF
--- a/.github/workflows/docker_upload.yml
+++ b/.github/workflows/docker_upload.yml
@@ -34,21 +34,38 @@ jobs:
       - name: Build and push filesystem image
         uses: docker/build-push-action@v2
         env:
-          PY_VERSION: 3.9
+          PY_VERSION: '3.10'
         with:
           build-args: PY_VERSION
           context: .
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: pypa/bandersnatch:latest,pypa/bandersnatch:${{ env.GIT_TAG }},pypa/bandersnatch:3,pypa/bandersnatch:3.9
+          tags: pypa/bandersnatch:latest,pypa/bandersnatch:${{ env.GIT_TAG }},pypa/bandersnatch:3,pypa/bandersnatch:3.10
 
       - name: Filesystem Image digest
+        run: echo ${{ steps.docker_build.outputs.digest }}
+
+      - name: Build and push s3 image
+        uses: docker/build-push-action@v2
+        env:
+          PY_VERSION: '3.10'
+          WITH_S3: yes
+        with:
+          build-args: |
+            PY_VERSION
+            WITH_S3
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: pypa/bandersnatch:s3-latest,pypa/bandersnatch:s3-${{ env.GIT_TAG }},pypa/bandersnatch:s3-3,pypa/bandersnatch:s3-3.10
+
+      - name: S3 Image digest
         run: echo ${{ steps.docker_build.outputs.digest }}
 
       - name: Build and push swift image
         uses: docker/build-push-action@v2
         env:
-          PY_VERSION: 3.9
+          PY_VERSION: '3.10'
           WITH_SWIFT: yes
         with:
           build-args: |
@@ -57,7 +74,7 @@ jobs:
           context: .
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: pypa/bandersnatch:swift-latest,pypa/bandersnatch:swift-${{ env.GIT_TAG }},pypa/bandersnatch:swift-3,pypa/bandersnatch:swift-3.9
+          tags: pypa/bandersnatch:swift-latest,pypa/bandersnatch:swift-${{ env.GIT_TAG }},pypa/bandersnatch:swift-3,pypa/bandersnatch:swift-3.10
 
       - name: Swift Image digest
         run: echo ${{ steps.docker_build.outputs.digest }}

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## Other
 
+- Add S3 Docker Image building `PR #1092`
+- Move Docker containers to Python 3.10 `PR #1092`
 - Python 3.10 is now supported `PR #1073` -- Thanks **isidentical**
 
 # 5.1.1 (2021-12-14)

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,24 @@
-ARG PY_VERSION=3.9
+ARG PY_VERSION=3.10
 
 FROM python:${PY_VERSION} as base
 
 FROM base as builder
 ARG PY_VERSION
+ARG WITH_S3
 ARG WITH_SWIFT
 
 RUN mkdir /install
 WORKDIR /install
 RUN pip install --target="/install" --upgrade pip setuptools wheel
+ADD requirements_s3.txt /install
 ADD requirements_swift.txt /install
 ADD requirements.txt /install
-RUN if [ ! -z "$WITH_SWIFT" ] \
+RUN if [ ! -z "$WITH_S3" ] \
+     ; then \
+     pip install --target="/install" \
+        -r requirements.txt \
+        -r requirements_s3.txt \
+     ; elif [ ! -z "$WITH_SWIFT" ] \
      ; then \
      pip install --target="/install" \
         -r requirements.txt \
@@ -28,6 +35,7 @@ ENV LANG C.UTF-8
 ENV LC_ALL C.UTF-8
 
 ARG PY_VERSION
+ARG WITH_S3
 ARG WITH_SWIFT
 
 COPY --from=builder /install /usr/local/lib/python${PY_VERSION}/site-packages
@@ -38,7 +46,10 @@ COPY setup.py /bandersnatch
 COPY README.md /bandersnatch
 COPY LICENSE /bandersnatch
 COPY src /bandersnatch/src
-RUN if [ ! -z "$WITH_SWIFT" ] \
+RUN if [ ! -z "$WITH_S3" ] \
+     ; then \
+     pip --no-cache-dir install /bandersnatch/[s3] \
+     ; elif [ ! -z "$WITH_SWIFT" ] \
      ; then \
      pip --no-cache-dir install /bandersnatch/[swift] \
      ; else \


### PR DESCRIPTION
- Move all docker containers to Python 3.10
- Add `requirements_s3.txt` into container + install if it's the S3 build enabled via a docker build arg
- Update GitHub `docker_upload` action to also build + upload a s3 container

Test:
- `docker build -t bander_test --build-arg PY_VERSION=3.10 --build-arg WITH_S3=yes .`
- Will have to test docker_upload on the PR merge

Fixes #1055