### PR TITLE
Remove deprecated --use-feature=in-tree-build in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,7 @@ jobs:
       env:
        TOXENV: INTEGRATION
       run: |
-        python -m pip install . --use-feature=in-tree-build
+        python -m pip install .
         python test_runner.py
 
     - name: Run Integration Test (uvloop)
@@ -67,5 +67,5 @@ jobs:
       env:
        TOXENV: INTEGRATION
       run: |
-        python -m pip install .[uvloop] --use-feature=in-tree-build
+        python -m pip install .[uvloop]
         python test_runner.py

--- a/.github/workflows/ci_ubuntu.yml
+++ b/.github/workflows/ci_ubuntu.yml
@@ -71,12 +71,12 @@ jobs:
       env:
        TOXENV: INTEGRATION
       run: |
-        python -m pip install . --use-feature=in-tree-build
+        python -m pip install .
         python test_runner.py
 
     - name: Run Integration Test (uvloop)
       env:
        TOXENV: INTEGRATION
       run: |
-        python -m pip install .[uvloop] --use-feature=in-tree-build
+        python -m pip install .[uvloop]
         python test_runner.py


### PR DESCRIPTION
pip now always does in-tree builds, see also https://github.com/pypa/pip/pull/11001