### PR TITLE
Add PEP629 Version to Simple API HTML

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Other
 
+- Add PEP 620 header to Simple API HTML `PR #X`
 - Add S3 Docker Image building `PR #1092`
 - Move Docker containers to Python 3.10 `PR #1092`
 - Python 3.10 is now supported `PR #1073` -- Thanks **isidentical**

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,7 +2,7 @@
 
 ## Other
 
-- Add PEP 620 header to Simple API HTML `PR #X`
+- Add PEP 629 header to Simple API HTML `PR #1121`
 - Add S3 Docker Image building `PR #1092`
 - Move Docker containers to Python 3.10 `PR #1092`
 - Python 3.10 is now supported `PR #1073` -- Thanks **isidentical**

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,7 +2,7 @@
 
 ## Other
 
-- Add PEP 629 header to Simple API HTML `PR #1121`
+- Add PEP 629 header to Simple API HTML `PR #1122`
 - Add S3 Docker Image building `PR #1092`
 - Move Docker containers to Python 3.10 `PR #1092`
 - Python 3.10 is now supported `PR #1073` -- Thanks **isidentical**

--- a/src/bandersnatch/mirror.py
+++ b/src/bandersnatch/mirror.py
@@ -38,6 +38,9 @@ class Mirror:
     # of it when starting to sync.
     now = None
 
+    # PEP620 Simple API Version
+    pypi_repository_version = "1.0"
+
     def __init__(self, master: Master, workers: int = 3):
         self.master = master
         self.filters = LoadedFilters(load_all=True)
@@ -486,6 +489,10 @@ class BandersnatchMirror(Mirror):
             f.write("<!DOCTYPE html>\n")
             f.write("<html>\n")
             f.write("  <head>\n")
+            f.write(
+                '    <meta name="pypi:repository-version" content='
+                f'"{self.pypi_repository_version}">\n'
+            )
             f.write("    <title>Simple Index</title>\n")
             f.write("  </head>\n")
             f.write("  <body>\n")
@@ -754,11 +761,12 @@ class BandersnatchMirror(Mirror):
             "<!DOCTYPE html>\n"
             "<html>\n"
             "  <head>\n"
-            "    <title>Links for {0}</title>\n"
+            '    <meta name="pypi:repository-version" content="{0}">\n'
+            "    <title>Links for {1}</title>\n"
             "  </head>\n"
             "  <body>\n"
-            "    <h1>Links for {0}</h1>\n"
-        ).format(package.raw_name)
+            "    <h1>Links for {1}</h1>\n"
+        ).format(self.pypi_repository_version, package.raw_name)
 
         release_files = package.release_files
         logger.debug(f"There are {len(release_files)} releases for {package.name}")

--- a/src/bandersnatch/tests/test_mirror.py
+++ b/src/bandersnatch/tests/test_mirror.py
@@ -236,6 +236,7 @@ simple{0}index.html""".format(
 <!DOCTYPE html>
 <html>
   <head>
+    <meta name="pypi:repository-version" content="1.0">
     <title>Simple Index</title>
   </head>
   <body>
@@ -285,6 +286,7 @@ web{0}simple{0}index.html""".format(
 <!DOCTYPE html>
 <html>
   <head>
+    <meta name="pypi:repository-version" content="1.0">
     <title>Simple Index</title>
   </head>
   <body>
@@ -321,6 +323,7 @@ simple{0}index.html""".format(
 <!DOCTYPE html>
 <html>
   <head>
+    <meta name="pypi:repository-version" content="1.0">
     <title>Simple Index</title>
   </head>
   <body>
@@ -358,6 +361,7 @@ web{0}simple{0}index.html""".format(
 <!DOCTYPE html>
 <html>
   <head>
+    <meta name="pypi:repository-version" content="1.0">
     <title>Simple Index</title>
   </head>
   <body>
@@ -430,6 +434,7 @@ simple{0}index.html""".format(
 <!DOCTYPE html>
 <html>
   <head>
+    <meta name="pypi:repository-version" content="1.0">
     <title>Simple Index</title>
   </head>
   <body>
@@ -471,6 +476,7 @@ simple{0}index.html""".format(
 <!DOCTYPE html>
 <html>
   <head>
+    <meta name="pypi:repository-version" content="1.0">
     <title>Simple Index</title>
   </head>
   <body>
@@ -511,6 +517,7 @@ simple{0}index.html""".format(
 <!DOCTYPE html>
 <html>
   <head>
+    <meta name="pypi:repository-version" content="1.0">
     <title>Simple Index</title>
   </head>
   <body>
@@ -643,6 +650,7 @@ async def test_package_sync_with_release_no_files_syncs_simple_page(
 <!DOCTYPE html>
 <html>
   <head>
+    <meta name="pypi:repository-version" content="1.0">
     <title>Links for foo</title>
   </head>
   <body>
@@ -671,6 +679,7 @@ async def test_package_sync_with_release_no_files_syncs_simple_page_with_hash(
 <!DOCTYPE html>
 <html>
   <head>
+    <meta name="pypi:repository-version" content="1.0">
     <title>Links for foo</title>
   </head>
   <body>
@@ -700,6 +709,7 @@ async def test_package_sync_with_canonical_simple_page(
 <!DOCTYPE html>
 <html>
   <head>
+    <meta name="pypi:repository-version" content="1.0">
     <title>Links for Foo</title>
   </head>
   <body>
@@ -728,6 +738,7 @@ async def test_package_sync_with_canonical_simple_page_with_hash(
 <!DOCTYPE html>
 <html>
   <head>
+    <meta name="pypi:repository-version" content="1.0">
     <title>Links for Foo</title>
   </head>
   <body>
@@ -756,6 +767,7 @@ async def test_package_sync_with_normalized_simple_page(
 <!DOCTYPE html>
 <html>
   <head>
+    <meta name="pypi:repository-version" content="1.0">
     <title>Links for Foo.bar-thing_other</title>
   </head>
   <body>
@@ -791,6 +803,7 @@ async def test_package_sync_simple_page_root_uri(mirror: BandersnatchMirror) -> 
 <!DOCTYPE html>
 <html>
   <head>
+    <meta name="pypi:repository-version" content="1.0">
     <title>Links for foo</title>
   </head>
   <body>
@@ -817,6 +830,7 @@ async def test_package_sync_simple_page_with_files(mirror: BandersnatchMirror) -
 <!DOCTYPE html>
 <html>
   <head>
+    <meta name="pypi:repository-version" content="1.0">
     <title>Links for foo</title>
   </head>
   <body>
@@ -849,6 +863,7 @@ async def test_package_sync_simple_page_with_existing_dir(
 <!DOCTYPE html>
 <html>
   <head>
+    <meta name="pypi:repository-version" content="1.0">
     <title>Links for foo</title>
   </head>
   <body>
@@ -879,6 +894,7 @@ async def test_package_sync_simple_page_with_existing_dir_with_hash(
 <!DOCTYPE html>
 <html>
   <head>
+    <meta name="pypi:repository-version" content="1.0">
     <title>Links for foo</title>
   </head>
   <body>
@@ -1070,6 +1086,7 @@ async def test_survives_exceptions_from_record_finished_package(
 <!DOCTYPE html>
 <html>
   <head>
+    <meta name="pypi:repository-version" content="1.0">
     <title>Links for Foo</title>
   </head>
   <body>

--- a/src/bandersnatch/tests/test_sync.py
+++ b/src/bandersnatch/tests/test_sync.py
@@ -38,6 +38,7 @@ simple{0}index.html""".format(
 <!DOCTYPE html>
 <html>
   <head>
+    <meta name="pypi:repository-version" content="1.0">
     <title>Simple Index</title>
   </head>
   <body>


### PR DESCRIPTION
- Add 1.0 to our HTML to indicate we only support that
- Make a static class variable for version number so it will be easy to update in our two write locations
- Update test expectations to see it work how we want

Fixes #1121 