### PR TITLE
make simple root page update optional

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@
 - Add PEP 629 header to Simple API HTML `PR #1122`
 - Added support to exclude specific Python minor versions `PR #1110` - Thanks **davidkim83**
 - Add S3 Docker Image building `PR #1092`
+- Add `--skip-root` option for `bandersnatch sync` command `PR #1145`
 
 ## Other
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,7 +5,7 @@
 - Add PEP 629 header to Simple API HTML `PR #1122`
 - Added support to exclude specific Python minor versions `PR #1110` - Thanks **davidkim83**
 - Add S3 Docker Image building `PR #1092`
-- Add `--skip-root` option for `bandersnatch sync` command `PR #1145`
+- Add `--skip-simple-root` option for `bandersnatch sync` command `PR #1145`
 
 ## Other
 

--- a/src/bandersnatch/main.py
+++ b/src/bandersnatch/main.py
@@ -163,7 +163,7 @@ async def async_main(args: argparse.Namespace, config: ConfigParser) -> int:
         return await bandersnatch.verify.metadata_verify(config, args)
     elif args.op.lower() == "sync":
         return await bandersnatch.mirror.mirror(
-            config, args.packages, not args.skip_root
+            config, args.packages, not args.skip_simple_root
         )
 
     if args.force_check:

--- a/src/bandersnatch/main.py
+++ b/src/bandersnatch/main.py
@@ -113,6 +113,12 @@ def _sync_parser(subparsers: argparse._SubParsersAction) -> None:
         help="The name of package to sync",
     )
     m.set_defaults(op="sync")
+    m.add_argument(
+        "--skip-root",
+        action="store_true",
+        default=False,
+        help="Skip updating simple page root",
+    )
 
 
 def _make_parser() -> argparse.ArgumentParser:
@@ -156,7 +162,9 @@ async def async_main(args: argparse.Namespace, config: ConfigParser) -> int:
     elif args.op.lower() == "verify":
         return await bandersnatch.verify.metadata_verify(config, args)
     elif args.op.lower() == "sync":
-        return await bandersnatch.mirror.mirror(config, args.packages)
+        return await bandersnatch.mirror.mirror(
+            config, args.packages, not args.skip_root
+        )
 
     if args.force_check:
         storage_plugin = next(iter(storage_backend_plugins()))

--- a/src/bandersnatch/main.py
+++ b/src/bandersnatch/main.py
@@ -114,10 +114,10 @@ def _sync_parser(subparsers: argparse._SubParsersAction) -> None:
     )
     m.set_defaults(op="sync")
     m.add_argument(
-        "--skip-root",
+        "--skip-simple-root",
         action="store_true",
         default=False,
-        help="Skip updating simple page root",
+        help="Skip updating simple index root page",
     )
 
 

--- a/src/bandersnatch/mirror.py
+++ b/src/bandersnatch/mirror.py
@@ -54,7 +54,9 @@ class Mirror:
         self.altered_packages: Dict[str, Set[str]] = {}
 
     async def synchronize(
-        self, specific_packages: Optional[List[str]] = None
+        self,
+        specific_packages: Optional[List[str]] = None,
+        sync_simple_index: bool = True,
     ) -> Dict[str, Set[str]]:
         logger.info(f"Syncing with {self.master.url}.")
         self.now = datetime.datetime.utcnow()
@@ -84,7 +86,8 @@ class Mirror:
             )
 
         await self.sync_packages()
-        self.finalize_sync()
+        if sync_simple_index:
+            self.finalize_sync()
         return self.altered_packages
 
     def _filter_packages(self) -> None:
@@ -979,7 +982,9 @@ class BandersnatchMirror(Mirror):
 
 
 async def mirror(
-    config: configparser.ConfigParser, specific_packages: Optional[List[str]] = None
+    config: configparser.ConfigParser,
+    specific_packages: Optional[List[str]] = None,
+    sync_simple_index: bool = True,
 ) -> int:
     config_values = validate_config_values(config)
 
@@ -1046,7 +1051,9 @@ async def mirror(
             download_mirror=config_values.download_mirror,
             download_mirror_no_fallback=config_values.download_mirror_no_fallback,
         )
-        changed_packages = await mirror.synchronize(specific_packages)
+        changed_packages = await mirror.synchronize(
+            specific_packages, sync_simple_index=sync_simple_index
+        )
 
     logger.info(f"{len(changed_packages)} packages had changes")
     for package_name, changes in changed_packages.items():

--- a/src/bandersnatch/mirror.py
+++ b/src/bandersnatch/mirror.py
@@ -86,8 +86,7 @@ class Mirror:
             )
 
         await self.sync_packages()
-        if sync_simple_index:
-            self.finalize_sync()
+        self.finalize_sync(sync_index_page=sync_simple_index)
         return self.altered_packages
 
     def _filter_packages(self) -> None:
@@ -167,7 +166,7 @@ class Mirror:
             # TODO Remove this check by following packages_to_sync's typing
             self.on_error(e)
 
-    def finalize_sync(self) -> None:
+    def finalize_sync(self, sync_index_page: bool = True) -> None:
         raise NotImplementedError()
 
     def on_error(self, exception: BaseException, **kwargs: Dict) -> None:
@@ -344,8 +343,9 @@ class BandersnatchMirror(Mirror):
         # Cleanup old legacy non PEP 503 Directories created for the Simple API
         await self.cleanup_non_pep_503_paths(package)
 
-    def finalize_sync(self) -> None:
-        self.sync_index_page()
+    def finalize_sync(self, sync_index_page: bool = True) -> None:
+        if sync_index_page:
+            self.sync_index_page()
         if self.need_wrapup:
             self.wrapup_successful_sync()
         return None

--- a/src/bandersnatch/tests/test_mirror.py
+++ b/src/bandersnatch/tests/test_mirror.py
@@ -298,6 +298,28 @@ web{0}simple{0}index.html""".format(
 
 
 @pytest.mark.asyncio
+async def test_mirror_sync_package_skip_index(mirror: BandersnatchMirror) -> None:
+    mirror.master.all_packages = mock.AsyncMock(return_value={"foo": 1})  # type: ignore
+    mirror.json_save = True
+    # Recall bootstrap so we have the json dirs
+    mirror._bootstrap()
+    await mirror.synchronize(sync_simple_index=False)
+
+    assert """\
+json{0}foo
+last-modified
+packages{0}2.7{0}f{0}foo{0}foo.whl
+packages{0}any{0}f{0}foo{0}foo.zip
+pypi{0}foo{0}json
+simple{0}foo{0}index.html""".format(
+        sep
+    ) == utils.find(
+        mirror.webdir, dirs=False
+    )
+    assert open("status", "rb").read() == b"1"
+
+
+@pytest.mark.asyncio
 async def test_mirror_sync_package(mirror: BandersnatchMirror) -> None:
     mirror.master.all_packages = mock.AsyncMock(return_value={"foo": 1})  # type: ignore
     mirror.json_save = True


### PR DESCRIPTION
Genrating simple root page is sometimes time-consuming , and it is not really used by pip( pip will use `https://pypi.org/simple/my-package/`  directly  ), thus not so important, this option could lead to an unsynced simple root page , but no critical damage is made.