### PR TITLE
docs: Fix a few typos

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -17,7 +17,7 @@ As of 4.0 bandersnatch:
 
 - Is fully asyncio based (mainly via aiohttp)
 - Only stores PEP503 nomalized packages names for the /simple API
-- Only stores JSON in normailzed package name path too
+- Only stores JSON in normalized package name path too
 
 
 .. sphinx_argparse_cli::

--- a/src/bandersnatch/storage.py
+++ b/src/bandersnatch/storage.py
@@ -140,7 +140,7 @@ class Storage:
         """
         Code to initialize the plugin
         """
-        # The intialize_plugin method is run once to initialize the plugin.  This should
+        # The initialize_plugin method is run once to initialize the plugin.  This should
         # contain all code to set up the plugin.
         # This method is not run in the fast path and should be used to do things like
         # indexing filter databases, etc that will speed the operation of the filter


### PR DESCRIPTION
There are small typos in:
- docs/index.rst
- src/bandersnatch/storage.py

Fixes:
- Should read `normalized` rather than `normailzed`.
- Should read `initialize` rather than `intialize`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md