### PR TITLE
Add PEP691 Format support

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+# 6.0.0
+
+## New Features
+
+- Add PEP691 simple index support `PR #1154`
+
 # 5.3.0 (2022-07-29)
 
 ## New Features

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,7 +16,7 @@ project_urls =
     Source Code = https://github.com/pypa/bandersnatch
     Change Log = https://github.com/pypa/bandersnatch/blob/master/CHANGES.md
 url = https://github.com/pypa/bandersnatch/
-version = 5.3.0
+version = 6.0.0.dev0
 
 [options]
 install_requires =

--- a/src/bandersnatch/__init__.py
+++ b/src/bandersnatch/__init__.py
@@ -19,10 +19,10 @@ class _VersionInfo(NamedTuple):
 
 
 __version_info__ = _VersionInfo(
-    major=5,
-    minor=3,
+    major=6,
+    minor=0,
     micro=0,
-    releaselevel="",
+    releaselevel="dev0",
     serial=0,  # Not currently in use with Bandersnatch versioning
 )
 __version__ = __version_info__.version_str

--- a/src/bandersnatch/configuration.py
+++ b/src/bandersnatch/configuration.py
@@ -7,6 +7,8 @@ import logging
 from pathlib import Path
 from typing import Any, Dict, List, NamedTuple, Optional, Type
 
+from .simple import SimpleFormat, get_format_value
+
 logger = logging.getLogger("bandersnatch")
 
 
@@ -22,6 +24,7 @@ class SetConfigValues(NamedTuple):
     compare_method: str
     download_mirror: str
     download_mirror_no_fallback: bool
+    simple_format: SimpleFormat
 
 
 class Singleton(type):  # pragma: no cover
@@ -75,7 +78,6 @@ class BandersnatchConfig(metaclass=Singleton):
         self.config.read(config_file)
 
 
-# 11-15, 84-89, 98-99, 117-118, 124-126, 144-149
 def validate_config_values(  # noqa: C901
     config: configparser.ConfigParser,
 ) -> SetConfigValues:
@@ -205,6 +207,12 @@ def validate_config_values(  # noqa: C901
             + "is not set in config."
         )
 
+    try:
+        simple_format = get_format_value(config.get("mirror", "simple-format"))
+    except configparser.NoOptionError:
+        logger.debug("Storing all Simple Formats by default ...")
+        simple_format = SimpleFormat.ALL
+
     return SetConfigValues(
         json_save,
         root_uri,
@@ -217,4 +225,5 @@ def validate_config_values(  # noqa: C901
         compare_method,
         download_mirror,
         download_mirror_no_fallback,
+        simple_format,
     )

--- a/src/bandersnatch/default.conf
+++ b/src/bandersnatch/default.conf
@@ -49,6 +49,10 @@ workers = 3
 ; Recommended setting: the default of false for full pip/pypi compatibility.
 hash-index = false
 
+; Format for simple API to be stored in
+; Since PEP691 we have HTML and JSON
+simple-format = ALL
+
 ; Whether to stop a sync quickly after an error is found or whether to continue
 ; syncing but not marking the sync as successful. Value should be "true" or
 ; "false".

--- a/src/bandersnatch/simple.py
+++ b/src/bandersnatch/simple.py
@@ -1,0 +1,272 @@
+import html
+import json
+import logging
+from enum import Enum, auto
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Dict, List, NamedTuple, Optional, Union
+from urllib.parse import urlparse
+
+from packaging.utils import canonicalize_name
+
+from .package import Package
+
+if TYPE_CHECKING:
+    from .storage import Storage
+
+
+class SimpleFormats(NamedTuple):
+    html: str
+    json: str
+
+
+class SimpleFormat(Enum):
+    ALL = auto()
+    HTML = auto()
+    JSON = auto()
+
+
+logger = logging.getLogger(__name__)
+
+
+class InvalidSimpleFormat(KeyError):
+    """We don't have a valid format choice from configuration"""
+
+    pass
+
+
+def get_format_value(format: str) -> SimpleFormat:
+    try:
+        return SimpleFormat[format.upper()]
+    except KeyError:
+        valid_formats = [v.name for v in SimpleFormat].sort()
+        raise InvalidSimpleFormat(
+            f"{format.upper()} is not a valid Simple API format. "
+            + f"Valid Options: {valid_formats}"
+        )
+
+
+class SimpleAPI:
+    """Handle all Simple API file generation"""
+
+    # PEP620 Simple API Version
+    pypi_repository_version = "1.0"
+    # PEP691 Simple API Version
+    pypi_simple_api_version = "1.0"
+
+    def __init__(
+        self,
+        storage_backend: "Storage",
+        format: Union[SimpleFormat, str],
+        diff_file_list: List[Path],
+        digest_name: str,
+        hash_index: bool,
+        root_uri: Optional[str],
+    ) -> None:
+        self.diff_file_list = diff_file_list
+        self.digest_name = digest_name
+        self.format = get_format_value(format) if isinstance(format, str) else format
+        self.hash_index = hash_index
+        self.root_uri = root_uri
+        self.storage_backend = storage_backend
+
+    def html_enabled(self) -> bool:
+        return self.format in {SimpleFormat.ALL, SimpleFormat.HTML}
+
+    def json_enabled(self) -> bool:
+        return self.format in {SimpleFormat.ALL, SimpleFormat.JSON}
+
+    def find_package_indexes_in_dir(self, simple_dir: Path) -> List[str]:
+        """Given a directory that contains simple packages indexes, return
+        a sorted list of normalized package names.  This presumes every
+        directory within is a simple package index directory."""
+        simple_path = self.storage_backend.PATH_BACKEND(str(simple_dir))
+        return sorted(
+            {
+                canonicalize_name(str(x.parent.relative_to(simple_path)))
+                for x in simple_path.glob("**/index.html")
+                if str(x.parent.relative_to(simple_path)) != "."
+            }
+        )
+
+    def gen_html_file_tags(self, release: Dict) -> str:
+        file_tags = ""
+
+        # data-requires-python: requires_python
+        if "requires_python" in release and release["requires_python"] is not None:
+            file_tags += (
+                f' data-requires-python="{html.escape(release["requires_python"])}"'
+            )
+
+        # data-yanked: yanked_reason
+        if "yanked" in release and release["yanked"]:
+            if "yanked_reason" in release and release["yanked_reason"]:
+                file_tags += f' data-yanked="{html.escape(release["yanked_reason"])}"'
+            else:
+                file_tags += ' data-yanked=""'
+
+        return file_tags
+
+    # TODO: This can return SwiftPath types now
+    def get_simple_dirs(self, simple_dir: Path) -> List[Path]:
+        """Return a list of simple index directories that should be searched
+        for package indexes when compiling the main index page."""
+        if self.hash_index:
+            # We are using index page directory hashing, so the directory
+            # format is /simple/f/foo/.  We want to return a list of dirs
+            # like "simple/f".
+            subdirs = [simple_dir / x for x in simple_dir.iterdir() if x.is_dir()]
+        else:
+            # This is the traditional layout of /simple/foo/.  We should
+            # return a single directory, "simple".
+            subdirs = [simple_dir]
+        return subdirs
+
+    def _file_url_to_local_url(self, url: str) -> str:
+        parsed = urlparse(url)
+        if not parsed.path.startswith("/packages"):
+            raise RuntimeError(f"Got invalid download URL: {url}")
+        prefix = self.root_uri if self.root_uri else "../.."
+        return prefix + parsed.path
+
+    def generate_html_simple_page(self, package: Package) -> str:
+        # Generate the header of our simple page.
+        simple_page_content = (
+            "<!DOCTYPE html>\n"
+            "<html>\n"
+            "  <head>\n"
+            '    <meta name="pypi:repository-version" content="{0}">\n'
+            "    <title>Links for {1}</title>\n"
+            "  </head>\n"
+            "  <body>\n"
+            "    <h1>Links for {1}</h1>\n"
+        ).format(self.pypi_repository_version, package.raw_name)
+
+        release_files = package.release_files
+        logger.debug(f"There are {len(release_files)} releases for {package.name}")
+        # Lets sort based on the filename rather than the whole URL
+        # Typing is hard here as we allow Any/Dict[Any, Any] for JSON
+        release_files.sort(key=lambda x: x["filename"])  # type: ignore
+
+        digest_name = self.digest_name
+
+        simple_page_content += "\n".join(
+            [
+                '    <a href="{}#{}={}"{}>{}</a><br/>'.format(
+                    self._file_url_to_local_url(r["url"]),
+                    digest_name,
+                    r["digests"][digest_name],
+                    self.gen_html_file_tags(r),
+                    r["filename"],
+                )
+                for r in release_files
+            ]
+        )
+
+        simple_page_content += (
+            f"\n  </body>\n</html>\n<!--SERIAL {package.last_serial}-->"
+        )
+
+        return simple_page_content
+
+    def generate_json_simple_page(
+        self, package: Package, *, pretty: bool = False
+    ) -> str:
+        package_json: Dict[str, Any] = {
+            "files": [],
+            "meta": {
+                "api-version": self.pypi_simple_api_version,
+                "_last-serial": str(package.last_serial),
+            },
+            "name": package.name,
+        }
+
+        release_files = package.release_files
+        release_files.sort(key=lambda x: x["filename"])  # type: ignore
+
+        # Add release files into the JSON dict
+        for r in release_files:
+            package_json["files"].append(
+                {
+                    "filename": r["filename"],
+                    "hashes": {
+                        digest_name: digest_hash
+                        for digest_name, digest_hash in r["digests"].items()
+                    },
+                    "requires-python": r.get("requires_python", ""),
+                    "url": self._file_url_to_local_url(r["url"]),
+                    "yanked": r.get("yanked", False),
+                }
+            )
+
+        if pretty:
+            return json.dumps(package_json, indent=4)
+        return json.dumps(package_json)
+
+    def generate_simple_pages(self, package: Package) -> SimpleFormats:
+        simple_html_content = ""
+        simple_json_content = ""
+        if self.format in {SimpleFormat.ALL, SimpleFormat.HTML}:
+            simple_html_content = self.generate_html_simple_page(package)
+            logger.debug(f"Generated simple HTML format for {package.name}")
+        if self.format in {SimpleFormat.ALL, SimpleFormat.JSON}:
+            simple_json_content = self.generate_json_simple_page(package)
+            logger.debug(f"Generated simple JSON format for {package.name}")
+        assert simple_html_content or simple_json_content
+        return SimpleFormats(simple_html_content, simple_json_content)
+
+    def sync_index_page(
+        self, need_index_sync: bool, webdir: Path, serial: int, *, pretty: bool = False
+    ) -> None:
+        if not need_index_sync:
+            return
+
+        logger.info("Generating global index page.")
+        simple_dir = webdir / "simple"
+        simple_html_path = simple_dir / "index.html"
+        simple_html_version_path = simple_dir / "index.v1_html"
+        simple_json_path = simple_dir / "index.v1_json"
+
+        simple_json: Dict[str, Any] = {
+            "meta": {"_last-serial": serial, "api-version": "1.0"},
+            "projects": [],
+        }
+
+        with self.storage_backend.rewrite(str(simple_html_path)) as f:
+            f.write("<!DOCTYPE html>\n")
+            f.write("<html>\n")
+            f.write("  <head>\n")
+            f.write(
+                '    <meta name="pypi:repository-version" content='
+                f'"{self.pypi_repository_version}">\n'
+            )
+            f.write("    <title>Simple Index</title>\n")
+            f.write("  </head>\n")
+            f.write("  <body>\n")
+            # This will either be the simple dir, or if we are using index
+            # directory hashing, a list of subdirs to process.
+            for subdir in self.get_simple_dirs(simple_dir):
+                for pkg in self.find_package_indexes_in_dir(subdir):
+                    # We're really trusty that this is all encoded in UTF-8. :/
+                    f.write(f'    <a href="{pkg}/">{pkg}</a><br/>\n')
+                    if self.json_enabled:
+                        simple_json["projects"].append({"name": pkg})
+            f.write("  </body>\n</html>")
+
+        if self.html_enabled():
+            self.diff_file_list.append(simple_html_path)
+            self.storage_backend.copy_file(simple_html_path, simple_html_version_path)
+            self.diff_file_list.append(simple_html_version_path)
+        else:
+            self.storage_backend.delete_file(simple_html_path)
+            logger.debug(
+                f"Deleting simple {simple_html_path} as HTML format is disabled"
+            )
+
+        # TODO: If memory usage gets to high we can write out json as we go like HTML
+        if self.json_enabled():
+            with self.storage_backend.rewrite(str(simple_json_path)) as f:
+                if pretty:
+                    json.dump(simple_json, f, indent=4)
+                else:
+                    json.dump(simple_json, f)
+            self.diff_file_list.append(simple_json_path)

--- a/src/bandersnatch/tests/conftest.py
+++ b/src/bandersnatch/tests/conftest.py
@@ -69,6 +69,8 @@ def package_json() -> Dict[str, Any]:
                     "md5_digest": "b6bcb391b040c4468262706faf9d3cce",
                     "size": 0,
                     "upload_time_iso_8601": "2000-02-02T01:23:45.123456Z",
+                    "python_requires": ">=3.6",
+                    "yanked": False,
                 },
                 {
                     "url": "https://pypi.example.com/packages/2.7/f/foo/foo.whl",
@@ -80,6 +82,7 @@ def package_json() -> Dict[str, Any]:
                     "md5_digest": "6bd3ddc295176f4dca196b5eb2c4d858",
                     "size": 12345,
                     "upload_time_iso_8601": "2000-03-03T01:23:45.123456Z",
+                    "yanked": False,
                 },
             ]
         },

--- a/src/bandersnatch/tests/plugins/test_allowlist_name.py
+++ b/src/bandersnatch/tests/plugins/test_allowlist_name.py
@@ -4,13 +4,12 @@ from pathlib import Path
 from tempfile import TemporaryDirectory
 from unittest import TestCase
 
-from mock_config import mock_config
-
 import bandersnatch.filter
 import bandersnatch.storage
 from bandersnatch.master import Master
 from bandersnatch.mirror import BandersnatchMirror
 from bandersnatch.package import Package
+from bandersnatch.tests.mock_config import mock_config
 
 
 class TestAllowListProject(TestCase):

--- a/src/bandersnatch/tests/plugins/test_blocklist_name.py
+++ b/src/bandersnatch/tests/plugins/test_blocklist_name.py
@@ -3,12 +3,11 @@ from pathlib import Path
 from tempfile import TemporaryDirectory
 from unittest import TestCase
 
-from mock_config import mock_config
-
 import bandersnatch.filter
 from bandersnatch.master import Master
 from bandersnatch.mirror import BandersnatchMirror
 from bandersnatch.package import Package
+from bandersnatch.tests.mock_config import mock_config
 
 
 class TestBlockListProject(TestCase):

--- a/src/bandersnatch/tests/plugins/test_filename.py
+++ b/src/bandersnatch/tests/plugins/test_filename.py
@@ -3,12 +3,11 @@ from pathlib import Path
 from tempfile import TemporaryDirectory
 from unittest import TestCase
 
-from mock_config import mock_config
-
 import bandersnatch.filter
 from bandersnatch.master import Master
 from bandersnatch.mirror import BandersnatchMirror
 from bandersnatch.package import Package
+from bandersnatch.tests.mock_config import mock_config
 from bandersnatch_filter_plugins import filename_name
 
 

--- a/src/bandersnatch/tests/plugins/test_latest_release.py
+++ b/src/bandersnatch/tests/plugins/test_latest_release.py
@@ -3,12 +3,11 @@ from pathlib import Path
 from tempfile import TemporaryDirectory
 from unittest import TestCase
 
-from mock_config import mock_config
-
 import bandersnatch.filter
 from bandersnatch.master import Master
 from bandersnatch.mirror import BandersnatchMirror
 from bandersnatch.package import Package
+from bandersnatch.tests.mock_config import mock_config
 from bandersnatch_filter_plugins import latest_name
 
 

--- a/src/bandersnatch/tests/plugins/test_metadata_plugins.py
+++ b/src/bandersnatch/tests/plugins/test_metadata_plugins.py
@@ -4,12 +4,11 @@ from tempfile import TemporaryDirectory
 from typing import cast
 from unittest import TestCase
 
-from mock_config import mock_config
-
 import bandersnatch.filter
 from bandersnatch.master import Master
 from bandersnatch.mirror import BandersnatchMirror
 from bandersnatch.package import Package
+from bandersnatch.tests.mock_config import mock_config
 from bandersnatch_filter_plugins.metadata_filter import SizeProjectMetadataFilter
 
 

--- a/src/bandersnatch/tests/plugins/test_prerelease_name.py
+++ b/src/bandersnatch/tests/plugins/test_prerelease_name.py
@@ -4,12 +4,11 @@ from pathlib import Path
 from tempfile import TemporaryDirectory
 from unittest import TestCase
 
-from mock_config import mock_config
-
 import bandersnatch.filter
 from bandersnatch.master import Master
 from bandersnatch.mirror import BandersnatchMirror
 from bandersnatch.package import Package
+from bandersnatch.tests.mock_config import mock_config
 from bandersnatch_filter_plugins import prerelease_name
 
 

--- a/src/bandersnatch/tests/plugins/test_regex_name.py
+++ b/src/bandersnatch/tests/plugins/test_regex_name.py
@@ -4,12 +4,11 @@ from pathlib import Path
 from tempfile import TemporaryDirectory
 from unittest import TestCase
 
-from mock_config import mock_config
-
 import bandersnatch.filter
 from bandersnatch.master import Master
 from bandersnatch.mirror import BandersnatchMirror
 from bandersnatch.package import Package
+from bandersnatch.tests.mock_config import mock_config
 from bandersnatch_filter_plugins import regex_name
 
 

--- a/src/bandersnatch/tests/plugins/test_storage_plugin_s3.py
+++ b/src/bandersnatch/tests/plugins/test_storage_plugin_s3.py
@@ -1,8 +1,8 @@
 from datetime import datetime
 
-from mock_config import mock_config
 from s3path import S3Path
 
+from bandersnatch.tests.mock_config import mock_config
 from bandersnatch_storage_plugins import s3
 
 

--- a/src/bandersnatch/tests/plugins/test_storage_plugins.py
+++ b/src/bandersnatch/tests/plugins/test_storage_plugins.py
@@ -14,13 +14,12 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, Dict, Iterator, List, Optional, Tuple, Union
 from unittest import TestCase, mock
 
-from mock_config import mock_config
-
 import bandersnatch.storage
 from bandersnatch.master import Master
 from bandersnatch.mirror import BandersnatchMirror
 from bandersnatch.package import Package
 from bandersnatch.storage import PATH_TYPES
+from bandersnatch.tests.mock_config import mock_config
 from bandersnatch_storage_plugins import filesystem, swift
 
 if TYPE_CHECKING:

--- a/src/bandersnatch/tests/test_configuration.py
+++ b/src/bandersnatch/tests/test_configuration.py
@@ -11,6 +11,7 @@ from bandersnatch.configuration import (
     Singleton,
     validate_config_values,
 )
+from bandersnatch.simple import SimpleFormat
 
 
 class TestBandersnatchConf(TestCase):
@@ -63,6 +64,7 @@ class TestBandersnatchConf(TestCase):
                 "json",
                 "master",
                 "release-files",
+                "simple-format",
                 "stop-on-error",
                 "storage-backend",
                 "timeout",
@@ -139,6 +141,7 @@ class TestBandersnatchConf(TestCase):
             "hash",
             "",
             False,
+            SimpleFormat.ALL,
         )
         no_options_configparser = configparser.ConfigParser()
         no_options_configparser["mirror"] = {}
@@ -159,6 +162,7 @@ class TestBandersnatchConf(TestCase):
             "hash",
             "",
             False,
+            SimpleFormat.ALL,
         )
         release_files_false_configparser = configparser.ConfigParser()
         release_files_false_configparser["mirror"] = {"release-files": "false"}
@@ -181,6 +185,7 @@ class TestBandersnatchConf(TestCase):
             "hash",
             "",
             False,
+            SimpleFormat.ALL,
         )
         release_files_false_configparser = configparser.ConfigParser()
         release_files_false_configparser["mirror"] = {

--- a/src/bandersnatch/tests/test_filter.py
+++ b/src/bandersnatch/tests/test_filter.py
@@ -4,9 +4,8 @@ import unittest
 from tempfile import TemporaryDirectory
 from unittest import TestCase
 
-from mock_config import mock_config
-
 from bandersnatch.configuration import BandersnatchConfig
+from bandersnatch.tests.mock_config import mock_config
 
 from bandersnatch.filter import (  # isort:skip
     Filter,

--- a/src/bandersnatch/tests/test_main.py
+++ b/src/bandersnatch/tests/test_main.py
@@ -14,6 +14,7 @@ import bandersnatch.mirror
 import bandersnatch.storage
 from bandersnatch.configuration import Singleton
 from bandersnatch.main import main
+from bandersnatch.simple import SimpleFormat
 
 if TYPE_CHECKING:
     from bandersnatch.mirror import BandersnatchMirror
@@ -94,6 +95,7 @@ def test_main_reads_config_values(mirror_mock: mock.MagicMock, tmpdir: Path) -> 
         "compare_method": "hash",
         "download_mirror": "",
         "download_mirror_no_fallback": False,
+        "simple_format": SimpleFormat.ALL,
     } == kwargs
 
 

--- a/src/bandersnatch/tests/test_simple.py
+++ b/src/bandersnatch/tests/test_simple.py
@@ -1,0 +1,81 @@
+from configparser import ConfigParser
+from os import sep
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+import pytest
+
+from bandersnatch import utils
+from bandersnatch.package import Package
+from bandersnatch.simple import InvalidSimpleFormat, SimpleAPI, SimpleFormat
+from bandersnatch.storage import Storage
+from bandersnatch.tests.test_simple_fixtures import (
+    EXPECTED_SIMPLE_GLOBAL_JSON_PRETTY,
+    EXPECTED_SIMPLE_SIXTYNINE_JSON,
+    EXPECTED_SIMPLE_SIXTYNINE_JSON_PRETTY,
+    SIXTYNINE_METADATA,
+)
+from bandersnatch_storage_plugins.filesystem import FilesystemStorage
+
+
+def test_format_invalid() -> None:
+    with pytest.raises(InvalidSimpleFormat):
+        SimpleAPI(Storage(), "l33t", [], "digest", False, None)
+
+
+def test_format_valid() -> None:
+    s = SimpleAPI(Storage(), "ALL", [], "digest", False, None)
+    assert s.format == SimpleFormat.ALL
+
+
+def test_json_package_page() -> None:
+    s = SimpleAPI(Storage(), SimpleFormat.JSON, [], "digest", False, None)
+    p = Package("69")
+    p._metadata = SIXTYNINE_METADATA
+    assert EXPECTED_SIMPLE_SIXTYNINE_JSON == s.generate_json_simple_page(p)
+    # Only testing pretty so it's easier for humans ...
+    assert EXPECTED_SIMPLE_SIXTYNINE_JSON_PRETTY == s.generate_json_simple_page(
+        p, pretty=True
+    )
+
+
+def test_json_index_page() -> None:
+    c = ConfigParser()
+    c.add_section("mirror")
+    c["mirror"]["workers"] = "1"
+    s = SimpleAPI(
+        FilesystemStorage(config=c), SimpleFormat.ALL, [], "digest", False, None
+    )
+    with TemporaryDirectory() as td:
+        td_path = Path(td)
+        simple_dir = td_path / "simple"
+        sixtynine_dir = simple_dir / "69"
+        foo_dir = simple_dir / "foo"
+        for a_dir in (sixtynine_dir, foo_dir):
+            a_dir.mkdir(parents=True)
+
+        sixtynine_html = sixtynine_dir / "index.html"
+        foo_html = foo_dir / "index.html"
+        for a_file in (sixtynine_html, foo_html):
+            a_file.touch()
+
+        s.sync_index_page(True, td_path, 12345, pretty=True)
+        # See we get the files we expect on the file system
+        # index.html is needed to trigger the global index finding the package
+        assert """\
+simple
+simple{0}69
+simple{0}69{0}index.html
+simple{0}foo
+simple{0}foo{0}index.html
+simple{0}index.html
+simple{0}index.v1_html
+simple{0}index.v1_json""".format(
+            sep
+        ) == utils.find(
+            td_path
+        )
+        # Check format of JSON
+        assert (simple_dir / "index.v1_json").open(
+            "r"
+        ).read() == EXPECTED_SIMPLE_GLOBAL_JSON_PRETTY

--- a/src/bandersnatch/tests/test_simple_fixtures.py
+++ b/src/bandersnatch/tests/test_simple_fixtures.py
@@ -1,0 +1,160 @@
+# flake8: noqa
+
+SIXTYNINE_METADATA = {
+    "info": {
+        "author": "Cooper Lees",
+        "author_email": "me@cooperlees.com",
+        "bugtrack_url": None,
+        "classifiers": [
+            "Development Status :: 3 - Alpha",
+            "License :: OSI Approved :: BSD License",
+            "Programming Language :: Python :: 3 :: Only",
+            "Programming Language :: Python :: 3.6",
+        ],
+        "description": "# 69",
+        "description_content_type": "",
+        "docs_url": None,
+        "download_url": "",
+        "downloads": {"last_day": -1, "last_month": -1, "last_week": -1},
+        "home_page": "http://github.com/cooperlees/69",
+        "keywords": "",
+        "license": "BSD",
+        "maintainer": "",
+        "maintainer_email": "",
+        "name": "69",
+        "package_url": "https://pypi.org/project/69/",
+        "platform": "",
+        "project_url": "https://pypi.org/project/69/",
+        "project_urls": {"Homepage": "http://github.com/cooperlees/69"},
+        "release_url": "https://pypi.org/project/69/6.9/",
+        "requires_dist": None,
+        "requires_python": ">=3.6",
+        "summary": "Handy module for 2",
+        "version": "6.9",
+        "yanked": False,
+        "yanked_reason": None,
+    },
+    "last_serial": 10333928,
+    "releases": {
+        "0.69": [
+            {
+                "comment_text": "",
+                "digests": {
+                    "md5": "4328d962656395fbd3e730c9d30bb48c",
+                    "sha256": "5c11f48399f9b1bca802751513f1f97bff6ce97e6facb576b7729e1351453c10",
+                },
+                "downloads": -1,
+                "filename": "69-0.69.tar.gz",
+                "has_sig": False,
+                "md5_digest": "4328d962656395fbd3e730c9d30bb48c",
+                "packagetype": "sdist",
+                "python_version": "source",
+                "requires_python": ">=3.6",
+                "size": 1078,
+                "upload_time": "2018-05-17T03:37:19",
+                "upload_time_iso_8601": "2018-05-17T03:37:19.330556Z",
+                "url": "https://files.pythonhosted.org/packages/d3/cc/95dc5434362bd333a1fec275231775d748315b26edf1e7e568e6f8660238/69-0.69.tar.gz",
+                "yanked": False,
+                "yanked_reason": None,
+            }
+        ],
+        "6.9": [
+            {
+                "comment_text": "",
+                "digests": {
+                    "md5": "ff4bf804ef3722a1fd8853a8a32513d4",
+                    "sha256": "0c8deb7c8574787283c3fc08b714ee63fd6752a38d13515a9d8508798d428597",
+                },
+                "downloads": -1,
+                "filename": "69-6.9.tar.gz",
+                "has_sig": False,
+                "md5_digest": "ff4bf804ef3722a1fd8853a8a32513d4",
+                "packagetype": "sdist",
+                "python_version": "source",
+                "requires_python": ">=3.6",
+                "size": 1077,
+                "upload_time": "2018-05-17T03:47:45",
+                "upload_time_iso_8601": "2018-05-17T03:47:45.953704Z",
+                "url": "https://files.pythonhosted.org/packages/7b/6e/7c4ce77c6ca092e94e19b78282b459e7f8270362da655cbc6a75eeb9cdd7/69-6.9.tar.gz",
+                "yanked": False,
+                "yanked_reason": None,
+            }
+        ],
+    },
+    "urls": [
+        {
+            "comment_text": "",
+            "digests": {
+                "md5": "ff4bf804ef3722a1fd8853a8a32513d4",
+                "sha256": "0c8deb7c8574787283c3fc08b714ee63fd6752a38d13515a9d8508798d428597",
+            },
+            "downloads": -1,
+            "filename": "69-6.9.tar.gz",
+            "has_sig": False,
+            "md5_digest": "ff4bf804ef3722a1fd8853a8a32513d4",
+            "packagetype": "sdist",
+            "python_version": "source",
+            "requires_python": ">=3.6",
+            "size": 1077,
+            "upload_time": "2018-05-17T03:47:45",
+            "upload_time_iso_8601": "2018-05-17T03:47:45.953704Z",
+            "url": "https://files.pythonhosted.org/packages/7b/6e/7c4ce77c6ca092e94e19b78282b459e7f8270362da655cbc6a75eeb9cdd7/69-6.9.tar.gz",
+            "yanked": False,
+            "yanked_reason": None,
+        }
+    ],
+    "vulnerabilities": [],
+}
+
+EXPECTED_SIMPLE_SIXTYNINE_JSON = """\
+{"files": [{"filename": "69-0.69.tar.gz", "hashes": {"md5": "4328d962656395fbd3e730c9d30bb48c", "sha256": "5c11f48399f9b1bca802751513f1f97bff6ce97e6facb576b7729e1351453c10"}, "requires-python": ">=3.6", "url": "../../packages/d3/cc/95dc5434362bd333a1fec275231775d748315b26edf1e7e568e6f8660238/69-0.69.tar.gz", "yanked": false}, {"filename": "69-6.9.tar.gz", "hashes": {"md5": "ff4bf804ef3722a1fd8853a8a32513d4", "sha256": "0c8deb7c8574787283c3fc08b714ee63fd6752a38d13515a9d8508798d428597"}, "requires-python": ">=3.6", "url": "../../packages/7b/6e/7c4ce77c6ca092e94e19b78282b459e7f8270362da655cbc6a75eeb9cdd7/69-6.9.tar.gz", "yanked": false}], "meta": {"api-version": "1.0", "_last-serial": "10333928"}, "name": "69"}\
+"""
+
+EXPECTED_SIMPLE_SIXTYNINE_JSON_PRETTY = """\
+{
+    "files": [
+        {
+            "filename": "69-0.69.tar.gz",
+            "hashes": {
+                "md5": "4328d962656395fbd3e730c9d30bb48c",
+                "sha256": "5c11f48399f9b1bca802751513f1f97bff6ce97e6facb576b7729e1351453c10"
+            },
+            "requires-python": ">=3.6",
+            "url": "../../packages/d3/cc/95dc5434362bd333a1fec275231775d748315b26edf1e7e568e6f8660238/69-0.69.tar.gz",
+            "yanked": false
+        },
+        {
+            "filename": "69-6.9.tar.gz",
+            "hashes": {
+                "md5": "ff4bf804ef3722a1fd8853a8a32513d4",
+                "sha256": "0c8deb7c8574787283c3fc08b714ee63fd6752a38d13515a9d8508798d428597"
+            },
+            "requires-python": ">=3.6",
+            "url": "../../packages/7b/6e/7c4ce77c6ca092e94e19b78282b459e7f8270362da655cbc6a75eeb9cdd7/69-6.9.tar.gz",
+            "yanked": false
+        }
+    ],
+    "meta": {
+        "api-version": "1.0",
+        "_last-serial": "10333928"
+    },
+    "name": "69"
+}\
+"""
+
+EXPECTED_SIMPLE_GLOBAL_JSON_PRETTY = """\
+{
+    "meta": {
+        "_last-serial": 12345,
+        "api-version": "1.0"
+    },
+    "projects": [
+        {
+            "name": "69"
+        },
+        {
+            "name": "foo"
+        }
+    ]
+}\
+"""

--- a/src/bandersnatch/tests/test_sync.py
+++ b/src/bandersnatch/tests/test_sync.py
@@ -26,7 +26,11 @@ packages{0}2.7{0}f{0}foo{0}foo.whl
 packages{0}any{0}f{0}foo{0}foo.zip
 pypi{0}foo{0}json
 simple{0}foo{0}index.html
-simple{0}index.html""".format(
+simple{0}foo{0}index.v1_html
+simple{0}foo{0}index.v1_json
+simple{0}index.html
+simple{0}index.v1_html
+simple{0}index.v1_json""".format(
         sep
     ) == utils.find(
         mirror.webdir, dirs=False

--- a/src/bandersnatch/unittest.conf
+++ b/src/bandersnatch/unittest.conf
@@ -42,6 +42,10 @@ workers = 3
 ; Recommended setting: the default of false for full pip/pypi compatibility.
 hash-index = false
 
+; Format for simple API to be stored in
+; Since PEP691 we have HTML and JSON
+simple-format = ALL
+
 ; Whether to stop a sync quickly after an error is found or whether to continue
 ; syncing but not marking the sync as successful. Value should be "true" or
 ; "false".

--- a/test_runner.py
+++ b/test_runner.py
@@ -8,6 +8,7 @@ Integration Tests will go off and hit PyPI + pull allowlisted packages
 then check for expected outputs to exist
 """
 
+import json
 from configparser import ConfigParser
 from os import environ
 from pathlib import Path
@@ -42,6 +43,7 @@ A_BLACK_WHL = (
 def check_ci(suppress_errors: bool = False) -> int:
     black_index = MIRROR_BASE / "simple/b/black/index.html"
     pyaib_index = MIRROR_BASE / "simple/p/pyaib/index.html"
+    pyaib_json_index = MIRROR_BASE / "simple/p/pyaib/index.v1_json"
     pyaib_json = MIRROR_BASE / "json/pyaib"
     pyaib_tgz = (
         MIRROR_BASE
@@ -76,6 +78,13 @@ def check_ci(suppress_errors: bool = False) -> int:
     if not suppress_errors and A_BLACK_WHL.exists():
         print(f"{EOP} {A_BLACK_WHL} exists ... delete failed?")
         return 74
+
+    if not suppress_errors and not pyaib_json_index.exists():
+        print(f"{EOP} {pyaib_json_index} does not exist ...")
+        return 75
+    else:
+        with pyaib_json_index.open("r") as fp:
+            json.load(fp)  # Check it's valid JSON
 
     rmtree(MIRROR_ROOT)
 


### PR DESCRIPTION
- Move to 6.0.0.dev0 version
- Add config for setting formats to save to storage
  - `simple-format`
  - Valid options: ALL, HTML or JSON
- Move `mirror` simple generation functions to new simple module
- Add new tests to test_simple.py
  - Made tests be included with install by adding an __init__.py

Tests
- Add unittest coverage to SimpleAPI object
  - Test valid and invalid format requests
  - Test the JSON output for PEP691 compliance
    - Per pacakge
    - Global index
- Add check to Integration test to expect json index ...