### PR TITLE
Add PEP 691 config to banderx

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,10 @@
 
 ----
 
-This is a PyPI mirror client according to `PEP 381` + `PEP 503`
+This is a PyPI mirror client according to `PEP 381` + `PEP 503` + `PEP 691`
 http://www.python.org/dev/peps/pep-0381/.
 
+- bandersnatch >=6.0 implements PEP691
 - bandersnatch >=4.0 supports *Linux*, *MacOSX* + *Windows*
 - [Documentation](https://bandersnatch.readthedocs.io/en/latest/)
 
@@ -69,18 +70,12 @@ bandersnatch/bin/bandersnatch --help
 ### Webserver
 
 Configure your webserver to serve the ``web/`` sub-directory of the mirror.
-For nginx it should look something like this:
+For PEP691 support we need to respect the format the client requests.
 
-```conf
-    server {
-        listen 127.0.0.1:80;
-        listen [::1]:80;
-        server_name <mymirrorname>;
-        root <path-to-mirror>/web;
-        autoindex on;
-        charset utf-8;
-    }
-```
+For an [nginx](https://www.nginx.com/) example, please look at our
+[banderx](https://github.com/pypa/bandersnatch/tree/main/src/banderx)
+docker container and [nginx.conf](https://github.com/pypa/bandersnatch/blob/main/src/banderx/nginx.conf)
+example configuration.
 
 - Note that it is a good idea to have your webserver publish the HTML index
   files correctly with UTF-8 as the charset. The index pages will work without

--- a/src/banderx/README.md
+++ b/src/banderx/README.md
@@ -1,0 +1,13 @@
+# banderx
+
+Simple nginx PEP 501 + 691 mirror filesystem serving example.
+
+- You will need to attach the bandersantch file system via a bind mount or some other means.
+
+## Build
+
+- `docker build --tag banderx src/banderx`
+
+## Run
+
+- `docker run --detach --name banderx banderx`

--- a/src/banderx/nginx.conf
+++ b/src/banderx/nginx.conf
@@ -27,6 +27,14 @@ http {
     include             /etc/nginx/mime.types;
     default_type        application/octet-stream;
 
+    map $http_accept $mirror_suffix {
+        default ".html";
+
+        "~*application/vnd\.pypi\.simple\.v1\+json" ".v1_json";
+        "~*application/vnd\.pypi\.simple\.v1\+html" ".v1_html";
+        "~*text/html" ".html";
+    }
+
     server {
         listen       80 default_server;
         listen       [::]:80 default_server;
@@ -35,12 +43,22 @@ http {
         autoindex    on;
         charset      utf-8;
 
+        location /simple/ {
+            # Uncomment to support hash_index = true bandersnatch mirrors
+            # rewrite ^/simple/([^/])([^/]*)/$ /simple/$1/$1$2/ last;
+            # rewrite ^/simple/([^/])([^/]*)/([^/]+)$/ /simple/$1/$1$2/$3 last;
 
-        # Uncomment to support hash_index = true bandersnatch mirrors
-        #location /simple/ {
-        #    rewrite ^/simple/([^/])([^/]*)/$ /simple/$1/$1$2/ last;
-        #    rewrite ^/simple/([^/])([^/]*)/([^/]+)$/ /simple/$1/$1$2/$3 last;
-        #}
+            index index$mirror_suffix;
+
+            types {
+                application/vnd.pypi.simple.v1+json v1_json;
+                application/vnd.pypi.simple.v1+html v1_html;
+                text/html html;
+            }
+
+            try_files $uri$mirror_suffix $uri $uri/ =404;
+        }
+
         # Let us set the correct mime type for all the JSON
         location /json/ {
             default_type        application/json;


### PR DESCRIPTION
banderx is an example way to serve a filesystem bandersnatch.
This PR adds an example to respect PEP691 clients.

- Updated README.md
- Added a README.md to banderx dir to explain how to build + start

Test: Ran the container and ensured nginx did not error and returned via `curl`