### PR TITLE
Issue #1033 - Fixed requirements file parsing when it contains pip options

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+# PR #1231
+
+## Bug Fixes
+
+- Fixed requirements file parsing when it contains pip options
+
 # 6.0.0
 
 ## New Features

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,8 +1,8 @@
-# PR #1231
+# Unreleased
 
 ## Bug Fixes
 
-- Fixed requirements file parsing when it contains pip options
+- Fixed requirements file parsing when it contains pip options `PR #1231`
 
 # 6.0.0
 

--- a/src/bandersnatch/tests/plugins/test_allowlist_name.py
+++ b/src/bandersnatch/tests/plugins/test_allowlist_name.py
@@ -482,7 +482,8 @@ requirements =
         with open(absolute_file_path, "w") as fh:
             fh.write(
                 """\
---extra-index-url https://self-hosted-foo.netname/simple --trusted-host self-hosted-foo.netname
+--extra-index-url https://self-hosted-foo.netname/simple
+--trusted-host self-hosted-foo.netname
 foo==1.2.0             # via -r requirements.in
 """
             )

--- a/src/bandersnatch/tests/plugins/test_allowlist_name.py
+++ b/src/bandersnatch/tests/plugins/test_allowlist_name.py
@@ -477,7 +477,6 @@ requirements =
         mirror._filter_packages()
         self.assertEqual({"foo": ""}, mirror.packages_to_sync)
 
-
     def test__filter__requirements__pip__options(self) -> None:
         absolute_file_path = Path(self.tempdir.name) / "requirements.txt"
         with open(absolute_file_path, "w") as fh:
@@ -575,4 +574,3 @@ requirements =
         # Check that the package in the last file, excluded
         # from the glob is not considered
         self.assertNotIn("baz", mirror.packages_to_sync)
-

--- a/src/bandersnatch/tests/plugins/test_allowlist_name.py
+++ b/src/bandersnatch/tests/plugins/test_allowlist_name.py
@@ -476,3 +476,38 @@ requirements =
         }
         mirror._filter_packages()
         self.assertEqual({"foo": ""}, mirror.packages_to_sync)
+
+    def test__filter__requirements__pip__options(self) -> None:
+        absolute_file_path = Path(self.tempdir.name) / "requirements.txt"
+        with open(absolute_file_path, "w") as fh:
+            fh.write(
+                """\
+--extra-index-url https://self-hosted-foo.netname/simple --trusted-host self-hosted-foo.netname
+foo==1.2.0             # via -r requirements.in
+"""
+            )
+
+        mock_config(
+            f"""\
+[mirror]
+storage-backend = filesystem
+workers = 2
+
+[plugins]
+enabled =
+    project_requirements
+[allowlist]
+requirements =
+    {absolute_file_path}
+"""
+        )
+
+        mirror = BandersnatchMirror(Path("."), Master(url="https://foo.bar.com"))
+
+        mirror.packages_to_sync = {
+            "foo": "",
+            "bar": "",
+            "baz": "",
+        }
+        mirror._filter_packages()
+        self.assertEqual({"foo": ""}, mirror.packages_to_sync)

--- a/src/bandersnatch_filter_plugins/allowlist_name.py
+++ b/src/bandersnatch_filter_plugins/allowlist_name.py
@@ -121,7 +121,7 @@ def _parse_package_lines(package_lines: List[str]) -> Set[Requirement]:
     filtered_requirements: Set[Requirement] = set()
     for package_line in package_lines:
         package_line = package_line.strip()
-        if not package_line or package_line.startswith(("#", "-"))):
+        if not package_line or package_line.startswith(("#", "-")):
             continue
         package_line, *_ = package_line.split("#", maxsplit=1)
         requirement = Requirement(package_line.strip())

--- a/src/bandersnatch_filter_plugins/allowlist_name.py
+++ b/src/bandersnatch_filter_plugins/allowlist_name.py
@@ -121,7 +121,7 @@ def _parse_package_lines(package_lines: List[str]) -> Set[Requirement]:
     filtered_requirements: Set[Requirement] = set()
     for package_line in package_lines:
         package_line = package_line.strip()
-        if not package_line or package_line.startswith("#") or package_line.startswith("-"):
+        if not package_line or package_line.startswith(("#", "-"))):
             continue
         package_line, *_ = package_line.split("#", maxsplit=1)
         requirement = Requirement(package_line.strip())

--- a/src/bandersnatch_filter_plugins/allowlist_name.py
+++ b/src/bandersnatch_filter_plugins/allowlist_name.py
@@ -121,7 +121,7 @@ def _parse_package_lines(package_lines: List[str]) -> Set[Requirement]:
     filtered_requirements: Set[Requirement] = set()
     for package_line in package_lines:
         package_line = package_line.strip()
-        if not package_line or package_line.startswith("#"):
+        if not package_line or package_line.startswith("#") or package_line.startswith("-"):
             continue
         package_line, *_ = package_line.split("#", maxsplit=1)
         requirement = Requirement(package_line.strip())


### PR DESCRIPTION
Fixed bandersnatch crash when requirements file contains [pip options.](https://pip.pypa.io/en/latest/reference/requirements-file-format/#supported-options)

Test result before the PR:

```
self = <[AttributeError("'Requirement' object has no attribute 'name'") raised in repr()] Requirement object at 0x7f230a96c5e0>
requirement_string = '--extra-index-url https://self-hosted-foo.netname/simple --trusted-host self-hosted-foo.netname'

    def __init__(self, requirement_string: str) -> None:
        try:
            req = REQUIREMENT.parseString(requirement_string)
        except ParseException as e:
>           raise InvalidRequirement(
                f'Parse error at "{ requirement_string[e.loc : e.loc + 8]!r}": {e.msg}'
            )
E           packaging.requirements.InvalidRequirement: Parse error at "'--extra-'": Expected W:(0-9A-Za-z)

venv/lib/python3.8/site-packages/packaging/requirements.py:104: InvalidRequirement
```