### PR TITLE
Added possibility to limit hours range of mirroring activity

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+# Unreleased
+
+## New Features
+
+- Added the possibility to limit the time range in which the docker image runner can execute the bandersnatch mirroring activity. This can be done by providing an optional command line argument with like `--hours-range 23-7` where the interval is expressed as `<start_hour>-<end_hour>`.
+
 # 6.0.0
 
 ## New Features

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,8 +8,8 @@
 
 ## New Features
 
-- Added the possibility to limit the time range in which the docker image runner can execute the bandersnatch mirroring activity. 
-  This can be done by providing an optional command line argument with like `--hours-range 23-7` where the interval is expressed 
+- Added the possibility to limit the time range in which the docker image runner can execute the bandersnatch mirroring activity.
+  This can be done by providing an optional command line argument with like `--hours-range 23-7` where the interval is expressed
   as `<start_hour>-<end_hour>`. `PR #1232`
 - Add support for globbing in the allowed requirements list.
   User can specify `requirements*.txt` or `*.txt` to merge multiple requirements files `PR #1230`

--- a/src/runner.py
+++ b/src/runner.py
@@ -8,13 +8,14 @@ import sys
 from datetime import datetime
 from subprocess import CalledProcessError, run
 from time import sleep, time
+from typing import List
 
 
-def parseNumList(string):
-    m = re.match(r"(\d+)(?:-(\d+))?$", string)
+def parseHourList(time_str: str) -> List[int]:
+    m = re.match(r"(\d+)(?:-(\d+))?$", time_str)
     if not m:
         raise argparse.ArgumentTypeError(
-            f"'{string}' is not a range. Expected '0-5', '20-6' or '1'."
+            f"'{time_str}' is not a range. Expected '0-5', '20-6' or '1'."
         )
     start = int(m.group(1))
     end = int(m.group(2) or start)
@@ -36,7 +37,7 @@ def main() -> int:
         "--hours-range",
         default="0-23",
         help="Hours of day interval expresses as 0-23 or 2",
-        type=parseNumList,
+        type=parseHourList,
     )
     args = parser.parse_args()
 

--- a/src/runner.py
+++ b/src/runner.py
@@ -3,9 +3,24 @@
 # Simple Script to replace cron for Docker
 
 import argparse
+import re
 import sys
+from datetime import datetime
 from subprocess import CalledProcessError, run
 from time import sleep, time
+
+
+def parseNumList(string):
+    m = re.match(r"(\d+)(?:-(\d+))?$", string)
+    if not m:
+        raise argparse.ArgumentTypeError(
+            f"'{string}' is not a range. Expected '0-5', '20-6' or '1'."
+        )
+    start = int(m.group(1))
+    end = int(m.group(2) or start)
+    if start <= end:
+        return list(range(start, end + 1))
+    return list(range(start, 23 + 1)) + list(range(0, end + 1))
 
 
 def main() -> int:
@@ -17,31 +32,40 @@ def main() -> int:
         help="Configuration location",
     )
     parser.add_argument("interval", help="Time in seconds between runs", type=int)
+    parser.add_argument(
+        "--hours-range",
+        default="0-23",
+        help="Hours of day interval expresses as 0-23 or 2",
+        type=parseNumList,
+    )
     args = parser.parse_args()
 
     print(f"Running bandersnatch every {args.interval}s", file=sys.stderr)
     try:
         while True:
-            start_time = time()
+            if datetime.now().hour in args.hours_range:
+                start_time = time()
 
-            try:
-                cmd = [
-                    sys.executable,
-                    "-m",
-                    "bandersnatch.main",
-                    "--config",
-                    args.config,
-                    "mirror",
-                ]
-                run(cmd, check=True)
-            except CalledProcessError as cpe:
-                return cpe.returncode
+                try:
+                    cmd = [
+                        sys.executable,
+                        "-m",
+                        "bandersnatch.main",
+                        "--config",
+                        args.config,
+                        "mirror",
+                    ]
+                    run(cmd, check=True)
+                except CalledProcessError as cpe:
+                    return cpe.returncode
 
-            run_time = time() - start_time
-            if run_time < args.interval:
-                sleep_time = args.interval - run_time
-                print(f"Sleeping for {sleep_time}s", file=sys.stderr)
-                sleep(sleep_time)
+                run_time = time() - start_time
+                if run_time < args.interval:
+                    sleep_time = args.interval - run_time
+                    print(f"Sleeping for {sleep_time}s", file=sys.stderr)
+                    sleep(sleep_time)
+            else:
+                sleep(60)
     except KeyboardInterrupt:
         pass
 

--- a/src/test_docker_runner.py
+++ b/src/test_docker_runner.py
@@ -1,0 +1,51 @@
+import argparse
+from unittest import TestCase
+
+from runner import parseHourList
+
+
+class TestRunner(TestCase):
+    """
+    Tests for the bandersnatch runner script
+    """
+
+    def setUp(self) -> None:
+        pass
+
+    def tearDown(self) -> None:
+        pass
+
+    def test__parseHourList__function(self) -> None:
+
+        # Case where start time is less than end time
+        input_time_range = "10-18"
+        expected_hours_list = [10, 11, 12, 13, 14, 15, 16, 17, 18]
+        hours_list = parseHourList(input_time_range)
+        self.assertEqual(hours_list, expected_hours_list)
+
+        # Case where start and end time match, but they are expressed as a range
+        input_time_range = "18-18"
+        expected_hours_list = [18]
+        hours_list = parseHourList(input_time_range)
+        self.assertEqual(hours_list, expected_hours_list)
+
+        # Case where start time is less than end time
+        input_time_range = "23-5"
+        expected_hours_list = [23, 0, 1, 2, 3, 4, 5]
+        hours_list = parseHourList(input_time_range)
+        self.assertEqual(hours_list, expected_hours_list)
+
+        # Case where the string is a single number and not a range
+        input_time_range = "23"
+        expected_hours_list = [23]
+        hours_list = parseHourList(input_time_range)
+        self.assertEqual(hours_list, expected_hours_list)
+
+        # Case where the string is a text, should raise ArgumentTypeError
+        input_time_range = "foo"
+        with self.assertRaises(argparse.ArgumentTypeError) as context:
+            parseHourList(input_time_range)
+        self.assertEqual(
+            str(context.exception),
+            "'foo' is not a range. Expected '0-5', '20-6' or '1'.",
+        )

--- a/src/test_docker_runner.py
+++ b/src/test_docker_runner.py
@@ -29,7 +29,7 @@ class TestRunner(TestCase):
         hours_list = parseHourList(input_time_range)
         self.assertEqual(hours_list, expected_hours_list)
 
-        # Case where start time is less than end time
+        # Case where time range crosses the day
         input_time_range = "23-5"
         expected_hours_list = [23, 0, 1, 2, 3, 4, 5]
         hours_list = parseHourList(input_time_range)
@@ -45,7 +45,5 @@ class TestRunner(TestCase):
         input_time_range = "foo"
         with self.assertRaises(argparse.ArgumentTypeError) as context:
             parseHourList(input_time_range)
-        self.assertEqual(
-            str(context.exception),
-            "'foo' is not a range. Expected '0-5', '20-6' or '1'.",
-        )
+        # Assert that the error message contains the user input string
+        self.assertIn(input_time_range, str(context.exception))


### PR DESCRIPTION
Added a runner optional argument, which does not break backwards compatibilty to limit the working hours of the mirroring process. This could be useful for peolpe who want to have full download bandwidth for their work / activities during the day and sync the repo during the night.

Hour range is expressed as `10-16`, `20-6` (with day-carry) or single hour `3`.

The optional parameter name is `--hours-range` and it defaults to `0-23` for backward compatibility.