### PR TITLE
Add mdformat to pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,4 @@
+---
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.3.0
@@ -37,6 +38,14 @@ repos:
     hooks:
       - id: flake8
         additional_dependencies: [flake8-bugbear]
+
+  - repo: https://github.com/executablebooks/mdformat
+    rev: 0.7.16
+    hooks:
+      - id: mdformat
+        additional_dependencies:
+          - mdformat-gfm
+          - mdformat-black
 
 ci:
   autofix_prs: false

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -71,7 +71,7 @@
 - Add bandersnatch command line help to the documentation main page `PR #920` - Thanks **ichard26**
 - Generate data-yanked tag in simple page `PR #931` - Thanks **happyaron**
 - Protect repository metadata from being trashed when disk is full `PR #962` - Thanks **happyaron**
-- Fix tox to used pinned requirements*.txt files for deps - `PR #1011` - Thanks **cooperlees**
+- Fix tox to used pinned requirements\*.txt files for deps - `PR #1011` - Thanks **cooperlees**
 
 ## Documentation
 
@@ -107,7 +107,7 @@
 - Migrated Markdown documentation from recommonmark to MyST-Parser + docs config clean up - `PR #879` - Thanks **ichard26**
 - Use `shutil.move()` for temp file management - `PR #883` - Thanks **happyaron**
 - Fixed logging bug in `SizeProjectMetadataFilter` to show it activated - `PR #889` - Thanks **cooperlees**
-- Attempt to wrap all potentially block calls in a ThreadPoolExecutor - `PR #894` - Thanks **cooperlees**`
+- Attempt to wrap all potentially block calls in a ThreadPoolExecutor - `PR #894` - Thanks **cooperlees**
 
 # 4.4.0 (2020-12-31)
 
@@ -158,12 +158,12 @@ Thanks to RedHat engineers **@dalley** + **@gerrod3** for all this refactor work
 
 - Old Mirror class has been renamed to BandersnatchMirror.  Performs same functionality with use of new Mirror API.
 - BandersnatchMirror now performs all filesystem operations throughout the sync process including the ones previously
-in Package.
+  in Package.
 - Package no longer performs filesystem operations.  Properties `json_file`, `json_pypi_symlink`, `simple_directory`
-and methods `save_json_metadata`, `sync_release_files`, `gen_data_requires_python`, `generate_simple_page`,
-`sync_simple_page`, `_save_simple_page_version`, `_prepare_versions_path`, `_file_url_to_local_url`,
-`_file_url_to_local_path`, `download_file` have all been moved into BandersnatchMirror. Package's `sync` has been
- refactored into Bandersnatch's `process_package`.
+  and methods `save_json_metadata`, `sync_release_files`, `gen_data_requires_python`, `generate_simple_page`,
+  `sync_simple_page`, `_save_simple_page_version`, `_prepare_versions_path`, `_file_url_to_local_url`,
+  `_file_url_to_local_path`, `download_file` have all been moved into BandersnatchMirror. Package's `sync` has been
+  refactored into Bandersnatch's `process_package`.
 - Package class is no longer created with an instance of Mirror
 - StaleMetadata exception has been moved to new errors.py file
 - PackageNotFound exception has been moved to new errors.py file
@@ -292,6 +292,7 @@ and methods `save_json_metadata`, `sync_release_files`, `gen_data_requires_pytho
 - Many pyup.io dependency upgrades
 
 ### Known Bug
+
 - From 3.0.0 we've been implicitly turning on *ALL* plugins - This version reverses that
 
 ## 3.1.3 (2018-12-26)
@@ -342,8 +343,7 @@ and methods `save_json_metadata`, `sync_release_files`, `gen_data_requires_pytho
 - Allow digest_name to be specified. `Fixes #105` - Thanks **@ewdurbin** !
 - synchronize generated index pages with warehouse - Thanks **@ewdurbin** !
 - Allow root_uri to be configured - Thanks **@ewdurbin** !
--- This is how warehouse (pypi.org) will function
-
+  - This is how warehouse (pypi.org) will function
 
 ## 2.1.3 (2018-03-04)
 
@@ -351,13 +351,11 @@ and methods `save_json_metadata`, `sync_release_files`, `gen_data_requires_pytho
   `Fixes #98`.
 - Add ability to blacklist packages to sync via conf file. `Fixes #100`.
 
-
 ## 2.1.2
 
 - Add saving of JSON metadata grabbed from pypi.facebook.com for syncing `Fixes #91` - Thanks **@cooperlees**
--- Can be disabled via config and disabled by default
--- bandersnatch symlinks WEB_ROOT/pypi/PKG_NAME/json to WEB_ROOT/json/PKG_NAME
-
+  - Can be disabled via config and disabled by default
+  - bandersnatch symlinks WEB_ROOT/pypi/PKG_NAME/json to WEB_ROOT/json/PKG_NAME
 
 ## 2.1.0
 
@@ -370,7 +368,6 @@ and methods `save_json_metadata`, `sync_release_files`, `gen_data_requires_pytho
 - Tweak atomic file writes in utils.rewrite() to prefix the temporary
   file with the 'hidden' filename of the destination adding more
   support for hashed POSIX filesystems like GlusterFS. - Thanks **@cooperlees**
-
 
 # 2.0.0 (2017-04-05)
 
@@ -392,7 +389,6 @@ and methods `save_json_metadata`, `sync_release_files`, `gen_data_requires_pytho
 
 - Make the package-specific simple pages human-readable again. `Fixes #71`.
 
-
 ## 1.11 (2016-05-18)
 
 - Add option to dir-hash index files. See
@@ -403,16 +399,13 @@ and methods `save_json_metadata`, `sync_release_files`, `gen_data_requires_pytho
   could result in crashing workers that would result in bandersnatch
   getting stuck. Thanks **@wjjt**!
 
-
 ## 1.10.0.1 (2016-05-11)
 
 - Brownbag release for re-upload. My train's Wifi broke while uploading
   ending up with a partial file on PyPI. Can your train service do better
   than mine?
 
-
-1.10 (2016-05-11)
------------------
+## 1.10 (2016-05-11)
 
 This is release is massively supported by **@dstufft** getting bandersnatch
 back in sync with current packaging ecosystem changes. All clap your hands
@@ -428,12 +421,10 @@ now, please.
 - Implement PEP 503 normalization rules while also providing support
   for legacy and very legacy clients.
 
-
 ## 1.9 (2016-04-21)
 
 - Fix a long standing, misunderstood bug: a non-deleting mirror would
   delete packages if they were fully removed from PyPI. `Fixes #61`
-
 
 ## 1.8 (2015-03-16)
 
@@ -443,14 +434,12 @@ now, please.
 - Increase our generation to help mirrors recover potential
   setuptools corruption after some data bug on PyPI.
 
-
 ## 1.7 (2014-12-14)
 
 - Fixes #54 by reordering the simple index page and file fetching
   parts. Thanks **@dstufft** for the inspiration.
 
 - Stop syncing serversig files and even start removing them.
-
 
 ## 1.6.1 (2014-09-24)
 
@@ -488,11 +477,9 @@ now, please.
 - Potential performance improvement: use requests' session object to allow HTTP
   pipelining. Thanks to Wouter Bolsterlee for the recommendation in `Fixes #39`.
 
-
 ## 1.1 (2013-11-26)
 
 - Made code Python 2.6 compatible. Thanks to **@ewdurbin** for the pull request.
-
 
 ## 1.0.5 (2013-07-25)
 
@@ -500,7 +487,6 @@ now, please.
   lockfile vs. acquiring the lock.
 
 - Move from distribute back to setuptools.
-
 
 ## 1.0.4 (2013-07-10)
 
@@ -511,7 +497,6 @@ now, please.
 
 - Fix brownbag release with broken 'stable' tag and missing requirements.txt
   update.
-
 
 ## 1.0.2 (2013-07-08)
 
@@ -536,7 +521,6 @@ now, please.
 
 - Fix packaging: include default config file. (Thanks to **Jannis Leidel**)
 
-
 # 1.0 (2013-04-09)
 
 - Update pip install documentation to use the a URL for referring to the
@@ -549,31 +533,25 @@ now, please.
 
 - Hopefully fixed updating the stable tag when releasing.
 
-
 ## 1.0rc5 (2013-04-09)
 
 - Experiment with zest.releaser integration to automatically generate
   requirements.txt during release process.
 
-
 ## 1.0rc4 (2013-04-09)
--------------------
 
 - Experiment with zest.releaser integration to automatically generate
   requirements.txt during release process.
-
 
 ## 1.0rc3 (2013-04-09)
 
 - Experiment with zest.releaser integration to automatically generate
   requirements.txt during release process.
 
-
 ## 1.0rc2 (2013-04-09)
 
 - Experiment with zest.releaser integration to automatically generate
   requirements.txt during release process.
-
 
 ## 1.0rc1 (2013-04-09)
 

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -31,13 +31,15 @@ compatible way like a PEP381 mirror. Simple is always better than complex and al
 issues need to be reproducible for our developers.
 
 #### pyup.io
+
 - Remember it's not perfect
   - It does not take into account modules pinned dependencies
-  - e.g. If requests wants *urllib3<1.25* *pyup.io* can still try and update it
+  - e.g. If requests wants *urllib3\<1.25* *pyup.io* can still try and update it
 - Until we have **CI** that effectively runs `pip freeze` from time to time we
   should recheck our minimal deps that we pin in `requirements.txt`
 
 ### Releasing to PyPI
+
 Every maintainer can release to PyPI. A maintainer should have agreement of
 two or more Maintainers that it is a suitable time for a release.
 
@@ -50,7 +52,6 @@ two or more Maintainers that it is a suitable time for a release.
   - Tag with the semantic version number
 - Build a `sdist` + `wheel`
 - Use `twine` to upload to PyPI
-
 
 ### Building Docker Image
 

--- a/README.md
+++ b/README.md
@@ -4,10 +4,10 @@
 [![Documentation Status](https://readthedocs.org/projects/bandersnatch/badge/?version=latest)](http://bandersnatch.readthedocs.io/en/latest/?badge=latest)
 [![Downloads](https://pepy.tech/badge/bandersnatch)](https://pepy.tech/project/bandersnatch)
 
-----
+______________________________________________________________________
 
 This is a PyPI mirror client according to `PEP 381` + `PEP 503` + `PEP 691`
-http://www.python.org/dev/peps/pep-0381/.
+<http://www.python.org/dev/peps/pep-0381/>.
 
 - bandersnatch >=6.0 implements PEP691
 - bandersnatch >=4.0 supports *Linux*, *MacOSX* + *Windows*
@@ -55,21 +55,21 @@ bandersnatch/bin/bandersnatch --help
 
 ## Quickstart
 
-- Run ``bandersnatch mirror`` - it will create an empty configuration file
-  for you in ``/etc/bandersnatch.conf``.
-- Review ``/etc/bandersnatch.conf`` and adapt to your needs.
-- Run ``bandersnatch mirror`` again. It will populate your mirror with the
+- Run `bandersnatch mirror` - it will create an empty configuration file
+  for you in `/etc/bandersnatch.conf`.
+- Review `/etc/bandersnatch.conf` and adapt to your needs.
+- Run `bandersnatch mirror` again. It will populate your mirror with the
   current status of all PyPI packages.
-  Current mirror package size can be seen here: https://pypi.org/stats/
-- A ``blocklist`` or ``allowlist`` can be created to cut down your mirror size.
+  Current mirror package size can be seen here: <https://pypi.org/stats/>
+- A `blocklist` or `allowlist` can be created to cut down your mirror size.
   You might want to [Analyze PyPI downloads](https://packaging.python.org/guides/analyzing-pypi-package-downloads/)
   to determine which packages to add to your list.
-- Run ``bandersnatch mirror`` regularly to update your mirror with any
+- Run `bandersnatch mirror` regularly to update your mirror with any
   intermediate changes.
 
 ### Webserver
 
-Configure your webserver to serve the ``web/`` sub-directory of the mirror.
+Configure your webserver to serve the `web/` sub-directory of the mirror.
 For PEP691 support we need to respect the format the client requests.
 
 For an [nginx](https://www.nginx.com/) example, please look at our
@@ -98,7 +98,7 @@ Here's a sample that you could place in `/etc/cron.d/bandersnatch`:
     */2 * * * * root bandersnatch mirror |& logger -t bandersnatch[mirror]
 ```
 
-This assumes that you have a ``logger`` utility installed that will convert the
+This assumes that you have a `logger` utility installed that will convert the
 output of the commands to syslog entries.
 
 [SystemD Timers](https://www.freedesktop.org/software/systemd/man/systemd.timer.html)
@@ -164,7 +164,7 @@ An example of an unsupported API is [PyPI's XML-RPC interface](https://warehouse
 
 The bandersnatch project strives to:
 
-- Mirror all static objects of the Python Package Index (https://pypi.org/)
+- Mirror all static objects of the Python Package Index (<https://pypi.org/>)
 - bandersnatch's main goal is to support the main global index to local syncing **only**
 - This will allow organizations to have lower latency access to PyPI and
   save bandwidth on their WAN connections and more importantly the PyPI CDN
@@ -174,9 +174,9 @@ The bandersnatch project strives to:
 ### Contact
 
 If you have questions or comments, please submit a bug report to
-https://github.com/pypa/bandersnatch/issues/new
+<https://github.com/pypa/bandersnatch/issues/new>
 
-- Discord: #bandersnatch now sit in the *PyPA Discord* server. To join visit https://discord.com/invite/pypa
+- Discord: #bandersnatch now sit in the *PyPA Discord* server. To join visit <https://discord.com/invite/pypa>
 
 ### Code of Conduct
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -55,7 +55,7 @@ Successfully installed pip-10.0.1
 
 - Then install the dependencies to the venv:
 
-``` console
+```console
 /path/to/venv/bin/pip install -r requirements.txt -r test-requirements.txt
 ```
 
@@ -93,7 +93,7 @@ Congrats, now you have a bandersnatch development environment ready to go! Just 
 S3 unittests are more integration tests. They depend on [minio](https://docs.min.io/) to work.
 
 - You will either need to skip them or install mino
-- Install options: https://docs.min.io/docs/
+- Install options: <https://docs.min.io/docs/>
 
 #### Docker Install
 
@@ -137,7 +137,7 @@ You will need to customize `src/bandersnatch/default.conf` and run via the follo
 
 **WARNING: Bandersnatch will go off and sync from pypi.org and use large amounts of disk space!**
 
-``` console
+```console
 cd bandersnatch
 /path/to/venv/bin/pip install --upgrade .
 /path/to/venv/bin/bandersnatch -c src/bandersnatch/default.conf mirror
@@ -211,11 +211,11 @@ GitHub actions to build and upload our releases.
 - To cut a release first make a PR updating:
   - the version in `setup.cfg` + `src/badnersnatch/__init__.py`
   - Update `CHANGES.md`. Here check for typos + missing commits that should be mentioned
-    - Example PR: https://github.com/pypa/bandersnatch/pull/1069
+    - Example PR: <https://github.com/pypa/bandersnatch/pull/1069>
 - THen, once merged and CI is passing
   - Cut a [GitHub Release](https://docs.github.com/en/repositories/releasing-projects-on-github/managing-releases-in-a-repository)
-and GitHub Actions will package and upload to PyPI.
-  - https://github.com/pypa/bandersnatch/releases
+    and GitHub Actions will package and upload to PyPI.
+  - <https://github.com/pypa/bandersnatch/releases>
     - Select "Draft a new release"
 
 ### Conventions

--- a/docs/filtering_configuration.md
+++ b/docs/filtering_configuration.md
@@ -75,6 +75,7 @@ packages =
 ```
 
 ## Metadata Filtering
+
 Packages and release files may be selected by filtering on specific metadata value.
 
 General form of configuration entries is:
@@ -87,6 +88,7 @@ tag:tag:path.to.object =
 ```
 
 ## requirements files Filtering
+
 Packages and releases might be given as requirements.txt files
 
 if requirements_path is missing it is assumed to be system root folder ('/')
@@ -130,7 +132,6 @@ Valid tags are `all`,`any`,`none`,`match-null`,`not-null`, with default of `any:
 
 All metadata provided by json is available, including `info`, `last_serial`, `releases`, etc. headings.
 
-
 ### Release File Regex Matching
 
 Filter release files to be downloaded for projects based on regex matches against the stored metadata entries for each release file.
@@ -149,7 +150,6 @@ Valid tags are the same as for projects.
 Metadata available to match consists of `info`, `release`, and `release_file` top level structures, with `info`
 containing the package-wide info, `release` containing the version of the release and `release_file` the metadata
 for an individual file for that release.
-
 
 ## Prerelease filtering
 
@@ -189,13 +189,11 @@ releases =
 
 Note the same `filter_regex` section may include a `packages` and a `releases` entry with any number of regular expressions.
 
-
 ## Platform/Python-specific binaries filtering
 
 This filter allows advanced users not interesting in Windows/macOS/Linux specific binaries to not mirror the corresponding files.
 
 You can also exclude Python versions by their minor version (ex. Python 2.6, 2.7) if you're sure your mirror does not need to serve these binaries.
-
 
 ```ini
 [plugins]
@@ -209,15 +207,16 @@ platforms =
 ```
 
 Available platforms are:
+
 - `windows`
 - `macos`
 - `freebsd`
 - `linux`
 
 Available python versions are:
+
 - `py2.4` ~ `py2.7`
 - `py3.1` ~ `py3.10`
-
 
 ## Keep only latest releases
 
@@ -235,7 +234,6 @@ keep = 3
 By default, the plugin does not filter out any release. You have to add the `keep` setting.
 
 You should be aware that it can break requirements. Prereleases are also kept.
-
 
 ## Block projects above a specified size threshold
 
@@ -263,7 +261,7 @@ readable value as shown.)
 
 It can be combined with an allowlist to overrule the size limit for large projects
 you are actually interested in and want make exceptions for. The following has the
-logic of including all projects where the size is <1GB *or* the name is
+logic of including all projects where the size is \<1GB *or* the name is
 [numpy](https://pypi.org/project/numpy/).
 
 ```ini
@@ -280,7 +278,7 @@ max_package_size = 1G
 ```
 
 If the allowlist_project is also enabled, then the filter becomes a logical
-and, e.g. the following will include all projects where the size is <1GB *and* the
+and, e.g. the following will include all projects where the size is \<1GB *and* the
 name appears in the allowlist:
 
 ```ini

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -5,13 +5,12 @@ virtualenv under `bandersnatch/bin/bandersnatch`.
 
 - bandersnatch **requires** `>= Python 3.8.0`
 
-
 ## pip
 
 This installs the latest stable, released version.
 
-```
-  $ python3.8 -m venv bandersnatch
-  $ bandersnatch/bin/pip install bandersnatch
-  $ bandersnatch/bin/bandersnatch --help
+```console
+  python3.8 -m venv bandersnatch
+  bandersnatch/bin/pip install bandersnatch
+  bandersnatch/bin/bandersnatch --help
 ```

--- a/docs/mirror_configuration.md
+++ b/docs/mirror_configuration.md
@@ -11,12 +11,14 @@ The mirror directory setting is a string that specifies the directory to
 store the mirror files.
 
 The directory used must meet the following requirements:
+
 - The filesystem must be case-sensitive filesystem.
 - The filesystem must support large numbers of sub-directories.
 - The filesystem must support large numbers of files (inodes)
 
 Example:
-``` ini
+
+```ini
 [mirror]
 directory = /srv/pypi
 ```
@@ -27,7 +29,8 @@ The mirror json setting is a boolean (true/false) setting that indicates that
 the json packaging metadata should be mirrored in addition to the packages.
 
 Example:
-``` ini
+
+```ini
 [mirror]
 json = false
 ```
@@ -37,10 +40,11 @@ json = false
 The mirror release-files setting is a boolean (true/false) setting that indicates that
 the package release files should be mirrored. Defaults to `true`. When this option is disabled (via setting to false), you
 should also specify the `root_uri` configuration. If the uri is empty, it will be set
-to https://files.pythonhosted.org/.
+to <https://files.pythonhosted.org/>.
 
 Example:
-``` ini
+
+```ini
 [mirror]
 release-files = true
 ```
@@ -51,13 +55,14 @@ The master setting is a string containing a url of the server which will be mirr
 
 The master url string must use https: protocol.
 
-The default value is: https://pypi.org
+The default value is: <https://pypi.org>
 
 If you would like to configure an alternative download mirror of package distribution artifacts
 please also take a look at the `download-mirror` option.
 
 Example:
-``` ini
+
+```ini
 [mirror]
 master = https://pypi.org
 ```
@@ -69,7 +74,8 @@ The timeout value is an integer that indicates the maximum number of seconds for
 The default value for this setting is 10 seconds.
 
 Example:
-``` ini
+
+```ini
 [mirror]
 timeout = 10
 ```
@@ -81,6 +87,7 @@ The global-timeout value is an integer that indicates the maximum runtime of ind
 The default value for this setting is 18000 seconds, or 5 hours.
 
 Example:
+
 ```ini
 [mirror]
 global-timeout = 18000
@@ -93,6 +100,7 @@ The workers value is an integer from from 1-10 that indicates the number of conc
 The default value is 3.
 
 Recommendations for the workers setting:
+
 - leave the default of 3 to avoid overloading the pypi master
 - official servers located in data centers could run 10 workers
 - anything beyond 10 is probably unreasonable and is not allowed.
@@ -111,7 +119,7 @@ Package index directory hashing is incompatible with pip, and so this should onl
 
 When using this setting with an apache server.  The apache server will need the following rewrite rules:
 
-```
+```text
 RewriteRule ^([^/])([^/]*)/$ /mirror/pypi/web/simple/$1/$1$2/
 RewriteRule ^([^/])([^/]*)/([^/]+)$/ /mirror/pypi/web/simple/$1/$1$2/$3
 ```
@@ -120,7 +128,7 @@ RewriteRule ^([^/])([^/]*)/([^/]+)$/ /mirror/pypi/web/simple/$1/$1$2/$3
 
 When using this setting with an nginx server.  The nginx server will need the following rewrite rules:
 
-```
+```text
 rewrite ^/simple/([^/])([^/]*)/$ /simple/$1/$1$2/ last;
 rewrite ^/simple/([^/])([^/]*)/([^/]+)$/ /simple/$1/$1$2/$3 last;
 ```
@@ -133,7 +141,7 @@ should stop immediately if it encounters an error.
 If this setting is false it will not stop when an error is encountered but it will not
 mark the sync as successful when the sync is complete.
 
-``` ini
+```ini
 [mirror]
 stop-on-error = false
 ```
@@ -144,6 +152,7 @@ The log-config setting is a string containing the filename of a python logging c
 file.
 
 Example:
+
 ```ini
 [mirror]
 log-config = /etc/bandersnatch-log.conf
@@ -154,37 +163,38 @@ log-config = /etc/bandersnatch-log.conf
 The root_uri is a string containing a uri which is the root added to relative links.
 
 :::{note}
-This is generally not necessary, but was added for the official internal PyPI mirror, which requires serving packages from https://files.pythonhosted.org
+This is generally not necessary, but was added for the official internal PyPI mirror, which requires serving packages from <https://files.pythonhosted.org>
 :::
 
 Example:
+
 ```ini
 [mirror]
 root_uri = https://example.com
 ```
-
 
 ## diff-file
 
 The diff file is a string containing the filename to log the files that were downloaded during the mirror.
 This file can then be used to synchronize external disks or send the files through some other mechanism to offline systems.
 You can then sync the list of files to an attached drive or ssh destination such as a diode:
-```
+
+```console
 rsync -av --files-from=/srv/pypi/mirrored-files / /mnt/usb/
 ```
 
 You can also use this file list as an input to 7zip to create split archives for transfers, allowing you to size the files as you needed:
-```
+
+```console
 7za a -i@"/srv/pypi/mirrored-files" -spf -v100m path_to_new_zip.7z
 ```
 
 Example:
+
 ```ini
 [mirror]
 diff-file = /srv/pypi/mirrored-files
 ```
-
-
 
 ## diff-append-epoch
 
@@ -192,6 +202,7 @@ The diff append epoch is a boolean (true/false) setting that indicates if the di
 This can be used to track diffs over time so the diff file doesn't get cobbered each run.  It is only used when diff-file is used.
 
 Example:
+
 ```ini
 [mirror]
 diff-append-epoch = true
@@ -200,10 +211,12 @@ diff-append-epoch = true
 ## compare-method
 
 The compare method is used to set how to compare an existing file with upstream file to determine whether a download is required:
-  - hash: this is the default which reads local file content and computes hashes (currently sha256sum), it is reliable but sometimes slower;
-  - stat: use file size and change time to compare, which is named after the stat() syscall, this avoids retrieving the full file content thus reducing some io workloads.
+
+- hash: this is the default which reads local file content and computes hashes (currently sha256sum), it is reliable but sometimes slower;
+- stat: use file size and change time to compare, which is named after the stat() syscall, this avoids retrieving the full file content thus reducing some io workloads.
 
 Example:
+
 ```ini
 [mirror]
 compare-method = hash
@@ -213,9 +226,10 @@ compare-method = hash
 
 The proxy is used only when requesting master server, eg. downloading index or package file from pypi.org.
 The proxy value will be passed to aiohttp as proxy parameter, like `aiohttp.get(link, proxy=yourproxy)`,
-check the aioproxy manual for more details: https://docs.aiohttp.org/en/stable/client_advanced.html#proxy-support
+check the aioproxy manual for more details: <https://docs.aiohttp.org/en/stable/client_advanced.html#proxy-support>
 
 Example:
+
 ```ini
 [mirror]
 proxy=http://myproxy.com
@@ -230,6 +244,7 @@ This is useful to sync most of the files from an existing, nearby mirror, for ex
 server sitting next to an existing one for the purpose of load sharing.
 
 Example:
+
 ```ini
 [mirror]
 download-mirror = https://pypi-mirror.example.com/

--- a/docs/storage_options.md
+++ b/docs/storage_options.md
@@ -78,18 +78,18 @@ If your mirror is targeted to global clients, you can use CloudFront or other CD
 
 Please read Amazon documents to get [detailed instructions](https://docs.aws.amazon.com/AmazonS3/latest/userguide/website-hosting-cloudfront-walkthrough.html)
 
-
 ### Set redirect or url rewrite in CloudFront or other cdn(optional)
 
-In most cases, packages and index pages are all inside ``/my-s3-bucket/prefix/web``, if you set up a steps above, you should be able to use the mirror like this:
+In most cases, packages and index pages are all inside `/my-s3-bucket/prefix/web`, if you set up a steps above, you should be able to use the mirror like this:
 
 ```shell
 pip install -i my-s3-bucket.cloudfront.net/prefix/web/simple install django
 ```
 
 But there are two main disadvantages:
+
 1. The url is quite long and exposing the structure of bucket.
-2. Users will be able to view all content in the bucket, including bandersnatch todo file and status file.
+1. Users will be able to view all content in the bucket, including bandersnatch todo file and status file.
 
 It is strongly recommended to set redirect or url rewrite for CDN. Please contact your service assistant for detailed instructions.
 


### PR DESCRIPTION
https://github.com/pypa/bandersnatch/issues/1183 suggests adding "prettier" markdown formatter to pre-commit/ci, not sure if that means just any formatter to make markdown prettier or specifically the formatter called [prettier](https://prettier.io/) :stuck_out_tongue: 

This PR:

- Adds the [ExecutableBooks Markdown formatter](https://github.com/executablebooks/mdformat) to pre-commit. I chose this instead of prettier as for the reasons mentioned in the ['Why not use prettier instead?'](https://github.com/executablebooks/mdformat#why-not-use-prettier-instead) section of their readme
- Adds in a separate pre-commit workflow to execute pre-commit. Personally I prefer having these linting checks in a different workflow to the CI one, as this way the CI will still execute even if there are formatting issues, but I don't have a strong preference
- Makes required changes to existing markdown files (found by running `pre-commit run --all`) 

Closes https://github.com/pypa/bandersnatch/issues/1183