### PR TITLE
Remove LegacyVersion support from latest_name plugin

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,10 @@
 - Format with black `--preview` style `PR #1313`
   - I contribute to black and want to help find bugs ...
 
+## Dropped Support
+
+- Dropped LegacyVersion support for latest_name plugin `PR #1315`
+
 # 6.0.1
 
 ## Bug Fixes

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ humanfriendly==10.0
 idna==3.4
 lxml==4.9.1
 multidict==6.0.3
-packaging==21.3
+packaging==22.0
 pyparsing==3.0.9
 setuptools==65.6.3
 six==1.16.0

--- a/src/bandersnatch_filter_plugins/latest_name.py
+++ b/src/bandersnatch_filter_plugins/latest_name.py
@@ -1,6 +1,6 @@
 import logging
 from operator import itemgetter
-from typing import Dict, Iterator, Tuple, Union
+from typing import Dict, Iterator, Tuple
 
 from packaging.version import Version, parse
 

--- a/src/bandersnatch_filter_plugins/latest_name.py
+++ b/src/bandersnatch_filter_plugins/latest_name.py
@@ -2,7 +2,7 @@ import logging
 from operator import itemgetter
 from typing import Dict, Iterator, Tuple, Union
 
-from packaging.version import LegacyVersion, Version, parse
+from packaging.version import Version, parse
 
 from bandersnatch.filter import FilterReleasePlugin
 
@@ -45,7 +45,7 @@ class LatestReleaseFilter(FilterReleasePlugin):
         if self.keep == 0 or self.keep > len(releases):
             return True
 
-        versions_pair: Iterator[Tuple[Union[LegacyVersion, Version], str]] = map(
+        versions_pair: Iterator[Tuple[Version, str]] = map(
             lambda v: (parse(v), v), releases.keys()
         )
         # Sort all versions


### PR DESCRIPTION
- Allows moving to packaging 22.0
- Since this breaks no tests will drop the support
  - Please feel free to come by and do a PR if this support is needed ... I'm not sure of options

Fixes #1311