### PR TITLE
packages config for prerelease filter

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@
 
 - Format with black `--preview` style `PR #1313`
   - I contribute to black and want to help find bugs ...
+- Add a `packages` config under `[filter_prerelease]` for prerelease filter to filter only specified packages. `PR #1328`
 
 ## Dropped Support
 

--- a/docs/filtering_configuration.md
+++ b/docs/filtering_configuration.md
@@ -161,6 +161,14 @@ enabled =
     prerelease_release
 ```
 
+If you only want to filter out the pre-releases for some specific projects (e.g. with nightly updates), list them in the configuration like:
+
+```ini
+[filter_prerelease]
+packages =
+    duckdb
+```
+
 ## Regex filtering
 
 Advanced users who would like finer control over which packages and releases to filter can use the regex Bandersnatch plugin.


### PR DESCRIPTION
Make prerelease filter able to filter only specified packages.

May be useful for projects like `duckdb`, which publishes new prerelease for each commit.
