### PR TITLE
Remove PURGE call on StalePage

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,7 +9,7 @@
 ## Dropped Support
 
 - Dropped LegacyVersion support for latest_name plugin `PR #1315`
-- No longer issue PURGE on StalePage `PR #1335`
+- No longer issue PURGE requests on StalePage exceptions as PyPI now requires authentication `PR #1335`
 
 # 6.0.1
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,7 @@
 ## Dropped Support
 
 - Dropped LegacyVersion support for latest_name plugin `PR #1315`
+- No longer issue PURGE on StalePage `PR #1335`
 
 # 6.0.1
 

--- a/src/bandersnatch/master.py
+++ b/src/bandersnatch/master.py
@@ -114,30 +114,10 @@ class Master:
             # really important check to achieve consistency and you should only
             # leave it out if you know what you're doing.
             if not got_serial or got_serial < required_serial:
-                logger.debug(
-                    f"Expected PyPI serial {required_serial} for request {path} "
-                    + f"but got {got_serial}"
-                )
-
-                # HACK: The following attempts to purge the cache of the page we
-                # just tried to fetch. This works around PyPI's caches sometimes
-                # returning a stale serial for a package. Ideally, this should
-                # be fixed on the PyPI side, at which point the following code
-                # should be removed.
-                # Timeout: uses self.sessions's timeout value
-                logger.debug(f"Issuing a PURGE for {path} to clear the cache")
-                try:
-                    async with self.session.request("PURGE", path):
-                        pass
-                except (aiohttp.ClientError, asyncio.TimeoutError):
-                    logger.warning(
-                        "Got an error when attempting to clear the cache", exc_info=True
-                    )
-
                 raise StalePage(
                     f"Expected PyPI serial {required_serial} for request {path} "
-                    + f"but got {got_serial}. "
-                    + "HTTP PURGE has been issued to the request url"
+                    + f"but got {got_serial}. We can no longer issue a PURGE. "
+                    + "Report issue to PyPA Warehouse GitHub if it persists ..."
                 )
 
     async def get(

--- a/src/bandersnatch/tests/test_master.py
+++ b/src/bandersnatch/tests/test_master.py
@@ -61,7 +61,6 @@ async def test_master_raises_if_serial_too_small(master: Master) -> None:
     get_ag = master.get("/asdf", 10)
     with pytest.raises(StalePage):
         await get_ag.asend(None)
-    assert master.session.request.called
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
- This call now 401s so there is no benefit of calling it
- Also spams logs with noise - So lets remove before more people open issues

Test:
- See tests pass
  - Remove assertion of request being sent on StalePage as we no longer do ... That is this PRs purpose

Fixes #1334