### PR TITLE
Don't run docker_upload workflow on forks

### DIFF
--- a/.github/workflows/docker_upload.yml
+++ b/.github/workflows/docker_upload.yml
@@ -10,6 +10,7 @@ on:
 jobs:
   docker:
     runs-on: ubuntu-latest
+    if: github.repository == 'pypa/bandersnatch'
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
Fixes #934.

Example run: https://github.com/ichard26/bandersnatch/actions/runs/3826906255