### PR TITLE
Declare Python 3.11 Support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
         os: [macOS-latest, windows-latest]
 
     steps:

--- a/.github/workflows/ci_ubuntu.yml
+++ b/.github/workflows/ci_ubuntu.yml
@@ -18,7 +18,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
         os: [ubuntu-latest]
 
     steps:

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+# Unreleased
+
+## New Features
+
+- Declare support Python 3.11 `PR #1338`
+
 # 6.1.0
 
 ## New Features

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,7 +2,7 @@
 
 ## New Features
 
-- Declare support Python 3.11 `PR #1338`
+- Declare support for Python 3.11 `PR #1338`
 
 # 6.1.0
 

--- a/requirements_s3.txt
+++ b/requirements_s3.txt
@@ -2,7 +2,7 @@ boto3==1.26.41
 botocore==1.29.41
 jmespath==1.0.1
 python-dateutil==2.8.2
-s3path==0.3.4
+s3path==0.4.0
 s3transfer==0.6.0
 six==1.16.0
 smart-open==6.3.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,6 +6,7 @@ classifiers =
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
 description = Mirroring tool that implements the client (mirror) side of PEP 381
 long_description = file:README.md
 long_description_content_type = text/markdown
@@ -87,7 +88,7 @@ uvloop =
     uvloop
 
 s3 =
-    s3path>=0.3.3
+    s3path>=0.4.0
 
 [isort]
 atomic = true


### PR DESCRIPTION
- s3path 0.4.0 now supports 3.11
- This unlocks declaring py3.11 support for bandersnatch based on CI

Docker has not been upgraded to 3.11 yet ... Will do a seperate PR for that.

Test: Run tox locally with minio running

Resolves  #1314 