### PR TITLE
Storage.scandir() method for replacing glob()s

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@
 ## New Features
 
 - Declare support for Python 3.11 `PR #1338`
+- Add scandir() as Storage plugin API to speedup large directory read when generating global index `PR #1340`
 
 # 6.1.0
 

--- a/src/bandersnatch/mirror.py
+++ b/src/bandersnatch/mirror.py
@@ -455,7 +455,7 @@ class BandersnatchMirror(Mirror):
                     f"Attempting to cleanup non PEP 503 simple dir: {deprecated_dir}"
                 )
                 try:
-                    for file in deprecated_dir.glob("*"):
+                    for file in deprecated_dir.iterdir():
                         file.unlink(missing_ok=True)
                     deprecated_dir.rmdir()
                 except Exception:

--- a/src/bandersnatch/storage.py
+++ b/src/bandersnatch/storage.py
@@ -18,6 +18,7 @@ from typing import (
     Iterable,
     List,
     Optional,
+    Protocol,
     Sequence,
     Set,
     Type,
@@ -41,6 +42,25 @@ STORAGE_PLUGIN_RESOURCE = f"bandersnatch_storage_plugins.v{PLUGIN_API_REVISION}.
 loaded_storage_plugins: Dict[str, List["Storage"]] = defaultdict(list)
 
 logger = logging.getLogger("bandersnatch")
+
+
+class StorageDirEntry(Protocol):
+    @property
+    def name(self) -> Union[str, bytes]:
+        ...
+
+    @property
+    def path(self) -> Union[str, bytes]:
+        ...
+
+    def is_dir(self) -> bool:
+        ...
+
+    def is_file(self) -> bool:
+        ...
+
+    def is_symlink(self) -> bool:
+        ...
 
 
 class Storage:
@@ -249,6 +269,10 @@ class Storage:
         self, path: PATH_TYPES, exist_ok: bool = False, parents: bool = False
     ) -> None:
         """Create the provided directory"""
+        raise NotImplementedError
+
+    def scandir(self, path: PATH_TYPES) -> Generator[StorageDirEntry, None, None]:
+        """Read entries from the provided directory"""
         raise NotImplementedError
 
     def rmdir(

--- a/src/bandersnatch/tests/plugins/test_storage_plugin_s3.py
+++ b/src/bandersnatch/tests/plugins/test_storage_plugin_s3.py
@@ -124,6 +124,22 @@ def test_mkdir_rmdir(s3_mock: S3Path) -> None:
     assert not backend.is_dir(f"/{s3_mock.bucket}/test_folder")
 
 
+def test_scandir(s3_mock: S3Path) -> None:
+    backend = s3.S3Storage()
+    backend.mkdir(f"/{s3_mock.bucket}/test_folder")
+    backend.mkdir(f"/{s3_mock.bucket}/test_folder/sub_dir")
+    backend.write_file(f"/{s3_mock.bucket}/test_folder/sub_file", "test")
+    for ent in backend.scandir(f"/{s3_mock.bucket}/test_folder"):
+        if ent.name == "sub_dir":
+            assert ent.is_dir()
+        elif ent.name == "sub_file":
+            assert ent.is_file()
+        # no symlink for S3
+        else:
+            raise ValueError(f"unexpected dir entry {str(ent.name)}")
+    backend.delete(f"/{s3_mock.bucket}/test_folder")
+
+
 def test_plugin_init(s3_mock: S3Path) -> None:
     config_loader = mock_config(
         """

--- a/src/bandersnatch/tests/test_mirror.py
+++ b/src/bandersnatch/tests/test_mirror.py
@@ -649,6 +649,12 @@ def test_find_package_indexes_in_dir_threaded(mirror: BandersnatchMirror) -> Non
         "web/simple/implicit",
         "web/simple/pyaib",
         "web/simple/setuptools",
+        "web_hash/simple/p/peerme",
+        "web_hash/simple/c/click",
+        "web_hash/simple/z/zebra",
+        "web_hash/simple/i/implicit",
+        "web_hash/simple/p/pyaib",
+        "web_hash/simple/s/setuptools",
     )
     with TemporaryDirectory() as td:
         # Create local mirror first so we '_bootstrap'
@@ -662,10 +668,26 @@ def test_find_package_indexes_in_dir_threaded(mirror: BandersnatchMirror) -> Non
             (mirror_base / directory / "index.html").touch()
         with (mirror_base / "web/simple/index.html").open("w") as index:
             index.write("<html></html>")
+        with (mirror_base / "web_hash/simple/index.html").open("w") as index:
+            index.write("<html></html>")
 
-        packages = local_mirror.simple_api.find_package_indexes_in_dir(
-            mirror_base / "web/simple"
-        )
+        packages = [
+            pkg
+            for subdir in local_mirror.simple_api.get_simple_dirs(
+                mirror_base / "web/simple"
+            )
+            for pkg in local_mirror.simple_api.find_packages_in_dir(subdir)
+        ]
+        local_mirror.simple_api.hash_index = True
+        packages_hash = [
+            pkg
+            for subdir in local_mirror.simple_api.get_simple_dirs(
+                mirror_base / "web_hash/simple"
+            )
+            for pkg in local_mirror.simple_api.find_packages_in_dir(subdir)
+        ]
+
+        assert packages == packages_hash
         assert "index.html" not in packages  # This should never be in the list
         assert len(packages) == 6  # We expect 6 packages with 6 dirs created
         assert packages[0] == "click"  # Check sorted - click should be first

--- a/src/bandersnatch_storage_plugins/filesystem.py
+++ b/src/bandersnatch_storage_plugins/filesystem.py
@@ -197,6 +197,12 @@ class FilesystemStorage(StoragePlugin):
             path = pathlib.Path(path)
         return path.mkdir(exist_ok=exist_ok, parents=parents)
 
+    def scandir(self, path: PATH_TYPES) -> Generator[os.DirEntry, None, None]:
+        """Read entries from the provided directory"""
+        if not isinstance(path, pathlib.Path):
+            path = pathlib.Path(path)
+        yield from os.scandir(path)
+
     def rmdir(
         self,
         path: PATH_TYPES,

--- a/src/bandersnatch_storage_plugins/s3.py
+++ b/src/bandersnatch_storage_plugins/s3.py
@@ -14,7 +14,7 @@ from typing import IO, Any, Generator, Iterator
 import boto3
 import filelock
 from botocore.client import Config
-from s3path import PureS3Path
+from s3path import PureS3Path, S3DirEntry
 from s3path import S3Path as _S3Path
 from s3path import register_configuration_parameter
 
@@ -330,6 +330,15 @@ class S3Storage(StoragePlugin):
         if not isinstance(path, self.PATH_BACKEND):
             path = self.PATH_BACKEND(path)
         path.joinpath(self.PATH_BACKEND.keep_file).touch()
+
+    def scandir(self, path: PATH_TYPES) -> Generator[S3DirEntry, None, None]:
+        """Read entries from the provided directory"""
+        if not isinstance(path, self.PATH_BACKEND):
+            path = self.PATH_BACKEND(path)
+        for p in path._accessor.scandir(path):
+            if p.name == self.PATH_BACKEND.keep_file:
+                continue
+            yield p
 
     def rmdir(
         self,


### PR DESCRIPTION
Implemented a new `Storage.scandir(self, path)` API, used to replace `glob("**")`s for large directory listing.
