### PR TITLE
Move Docker to 3.11

### DIFF
--- a/.github/workflows/docker_upload.yml
+++ b/.github/workflows/docker_upload.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Build and push filesystem image
         uses: docker/build-push-action@v3
         env:
-          PY_VERSION: '3.10'
+          PY_VERSION: '3.11'
         with:
           build-args: PY_VERSION
           context: .
@@ -49,7 +49,7 @@ jobs:
       - name: Build and push s3 image
         uses: docker/build-push-action@v3
         env:
-          PY_VERSION: '3.10'
+          PY_VERSION: '3.11'
           WITH_S3: yes
         with:
           build-args: |
@@ -66,7 +66,7 @@ jobs:
       - name: Build and push swift image
         uses: docker/build-push-action@v3
         env:
-          PY_VERSION: '3.10'
+          PY_VERSION: '3.11'
           WITH_SWIFT: yes
         with:
           build-args: |

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@
 ## New Features
 
 - Declare support for Python 3.11 `PR #1338`
+- Move Docker to build in 3.11 `PR 1341`
 
 # 6.1.0
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,7 +3,7 @@
 ## New Features
 
 - Declare support for Python 3.11 `PR #1338`
-- Move Docker to build in 3.11 `PR 1341`
+- Move Docker to build in 3.11 `PR #1341`
 
 # 6.1.0
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG PY_VERSION=3.10
+ARG PY_VERSION=3.11
 
 FROM python:${PY_VERSION} as base
 


### PR DESCRIPTION
We work in 3.11 so might as well start building docker in the faster available Python Runtime.

Please report any bugs!

Will look to go >= 3.10 later this year ... And move code to take advantage of that if we can.