### PR TITLE
Add parameter to allow passing "--force-check" to bandersnatch.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@
 - Add scandir() as Storage plugin API to speedup large directory read when generating global index `PR #1340`
 - Declare support for Python 3.11 `PR #1338`
 - Move Docker to build in 3.11 `PR #1341`
+- Add "--force-check" parameter to runner.py `PR #1347`
 
 # 6.1.0
 

--- a/src/runner.py
+++ b/src/runner.py
@@ -39,7 +39,17 @@ def main() -> int:
         help="Hours of day interval expresses as 0-23 or 2",
         type=parseHourList,
     )
+    parser.add_argument(
+        "--force-check",
+        default="false",
+        help="Force bandersnatch to reset the PyPI serial to perform a full sync",
+    )
     args = parser.parse_args()
+
+    if args.force_check == "true":
+        force_check = "--force-check"
+    else:
+        force_check = ""
 
     print(f"Running bandersnatch every {args.interval}s", file=sys.stderr)
     try:
@@ -55,6 +65,7 @@ def main() -> int:
                         "--config",
                         args.config,
                         "mirror",
+                        force_check,
                     ]
                     run(cmd, check=True)
                 except CalledProcessError as cpe:


### PR DESCRIPTION
When running this as a mirror container, it might be desired to always update.

Signed-off-by: Tim Beermann <beermann@osism.tech>
