### PR TITLE
Update to mypy 1.0.1 + ignore subclass wrong typing

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,7 +27,7 @@ repos:
       - id: isort
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.991
+    rev: v1.0.1
     hooks:
       - id: mypy
         exclude: (docs/.*)

--- a/src/bandersnatch_storage_plugins/swift.py
+++ b/src/bandersnatch_storage_plugins/swift.py
@@ -431,7 +431,8 @@ class SwiftPath(pathlib.Path):
             src_container=src_container,
         )
 
-    def write_bytes(
+    # Different signature than Path.write_bytes
+    def write_bytes(  # type: ignore
         self,
         contents: bytes,
         encoding: Optional[str] = "utf-8",


### PR DESCRIPTION
- swift needs extra params then Path
  - Adding comment explaining and type ignore ...

Allows mypy upgrade ...