### PR TITLE
Use the configurable digest_name for simple JSON

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,10 @@
+# Unreleased
+
+## Bug Fixes
+
+- Fix digest used for file hashes in PEP 691 simple JSON file output `PR #1442`
+  - The `digest_name` setting from configuration (default value: `sha256`) will now be used for both HTML and JSON files.
+
 # 6.2.0
 
 ## New Features

--- a/src/bandersnatch/configuration.py
+++ b/src/bandersnatch/configuration.py
@@ -135,7 +135,7 @@ def validate_config_values(  # noqa: C901
     except configparser.NoOptionError:
         digest_name = SimpleDigest.SHA256
         logger.debug(f"Using digest {digest_name} by default ...")
-    except KeyError as e:
+    except ValueError as e:
         logger.error(
             f"Supplied digest_name {config.get('mirror', 'digest_name')} is "
             + "not supported! Please update the digest_name in the [mirror] "

--- a/src/bandersnatch/simple.py
+++ b/src/bandersnatch/simple.py
@@ -36,7 +36,7 @@ def get_format_value(format: str) -> SimpleFormat:
     try:
         return SimpleFormat[format.upper()]
     except KeyError:
-        valid_formats = [v.name for v in SimpleFormat].sort()
+        valid_formats = sorted([v.name for v in SimpleFormat])
         raise InvalidSimpleFormat(
             f"{format.upper()} is not a valid Simple API format. "
             + f"Valid Options: {valid_formats}"

--- a/src/bandersnatch/simple.py
+++ b/src/bandersnatch/simple.py
@@ -42,7 +42,7 @@ class InvalidSimpleFormat(KeyError):
     pass
 
 
-class InvalidDigestFormat(KeyError):
+class InvalidDigestFormat(ValueError):
     """We don't have a valid digest choice from configuration"""
 
     pass
@@ -65,7 +65,7 @@ def get_digest_value(digest: str) -> SimpleDigest:
     except KeyError:
         valid_digests = sorted([v.name for v in SimpleDigest])
         raise InvalidDigestFormat(
-            f"{digest.upper()} is not a valid Simple API file hash digest. "
+            f"{digest} is not a valid Simple API file hash digest. "
             + f"Valid Options: {valid_digests}"
         )
 

--- a/src/bandersnatch/simple.py
+++ b/src/bandersnatch/simple.py
@@ -1,6 +1,7 @@
 import html
 import json
 import logging
+import sys
 from enum import Enum, auto
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Dict, List, NamedTuple, Optional, Union
@@ -10,6 +11,11 @@ from .package import Package
 
 if TYPE_CHECKING:
     from .storage import Storage
+
+if sys.version_info >= (3, 11):
+    from enum import StrEnum
+else:
+    from .utils import StrEnum
 
 
 class SimpleFormats(NamedTuple):
@@ -28,7 +34,7 @@ class SimpleDigests(NamedTuple):
     md5: str
 
 
-class SimpleDigest(str, Enum):
+class SimpleDigest(StrEnum):
     SHA256 = "sha256"
     MD5 = "md5"
 

--- a/src/bandersnatch/simple.py
+++ b/src/bandersnatch/simple.py
@@ -190,8 +190,7 @@ class SimpleAPI:
                 {
                     "filename": r["filename"],
                     "hashes": {
-                        digest_name: digest_hash
-                        for digest_name, digest_hash in r["digests"].items()
+                        self.digest_name: r["digests"][self.digest_name],
                     },
                     "requires-python": r.get("requires_python", ""),
                     "url": self._file_url_to_local_url(r["url"]),

--- a/src/bandersnatch/tests/test_main.py
+++ b/src/bandersnatch/tests/test_main.py
@@ -128,7 +128,7 @@ def test_main_throws_exception_on_unsupported_digest_name(
     with pytest.raises(ValueError) as e:
         main(asyncio.new_event_loop())
 
-    assert "foobar is not supported" in str(e.value)
+    assert "foobar is not a valid" in str(e.value)
 
 
 @pytest.fixture

--- a/src/bandersnatch/tests/test_simple_fixtures.py
+++ b/src/bandersnatch/tests/test_simple_fixtures.py
@@ -109,7 +109,7 @@ SIXTYNINE_METADATA = {
 }
 
 EXPECTED_SIMPLE_SIXTYNINE_JSON = """\
-{"files": [{"filename": "69-0.69.tar.gz", "hashes": {"md5": "4328d962656395fbd3e730c9d30bb48c", "sha256": "5c11f48399f9b1bca802751513f1f97bff6ce97e6facb576b7729e1351453c10"}, "requires-python": ">=3.6", "url": "../../packages/d3/cc/95dc5434362bd333a1fec275231775d748315b26edf1e7e568e6f8660238/69-0.69.tar.gz", "yanked": false}, {"filename": "69-6.9.tar.gz", "hashes": {"md5": "ff4bf804ef3722a1fd8853a8a32513d4", "sha256": "0c8deb7c8574787283c3fc08b714ee63fd6752a38d13515a9d8508798d428597"}, "requires-python": ">=3.6", "url": "../../packages/7b/6e/7c4ce77c6ca092e94e19b78282b459e7f8270362da655cbc6a75eeb9cdd7/69-6.9.tar.gz", "yanked": false}], "meta": {"api-version": "1.0", "_last-serial": "10333928"}, "name": "69"}\
+{"files": [{"filename": "69-0.69.tar.gz", "hashes": {"sha256": "5c11f48399f9b1bca802751513f1f97bff6ce97e6facb576b7729e1351453c10"}, "requires-python": ">=3.6", "url": "../../packages/d3/cc/95dc5434362bd333a1fec275231775d748315b26edf1e7e568e6f8660238/69-0.69.tar.gz", "yanked": false}, {"filename": "69-6.9.tar.gz", "hashes": {"sha256": "0c8deb7c8574787283c3fc08b714ee63fd6752a38d13515a9d8508798d428597"}, "requires-python": ">=3.6", "url": "../../packages/7b/6e/7c4ce77c6ca092e94e19b78282b459e7f8270362da655cbc6a75eeb9cdd7/69-6.9.tar.gz", "yanked": false}], "meta": {"api-version": "1.0", "_last-serial": "10333928"}, "name": "69"}\
 """
 
 EXPECTED_SIMPLE_SIXTYNINE_JSON_PRETTY = """\
@@ -118,7 +118,6 @@ EXPECTED_SIMPLE_SIXTYNINE_JSON_PRETTY = """\
         {
             "filename": "69-0.69.tar.gz",
             "hashes": {
-                "md5": "4328d962656395fbd3e730c9d30bb48c",
                 "sha256": "5c11f48399f9b1bca802751513f1f97bff6ce97e6facb576b7729e1351453c10"
             },
             "requires-python": ">=3.6",
@@ -128,7 +127,6 @@ EXPECTED_SIMPLE_SIXTYNINE_JSON_PRETTY = """\
         {
             "filename": "69-6.9.tar.gz",
             "hashes": {
-                "md5": "ff4bf804ef3722a1fd8853a8a32513d4",
                 "sha256": "0c8deb7c8574787283c3fc08b714ee63fd6752a38d13515a9d8508798d428597"
             },
             "requires-python": ">=3.6",

--- a/src/bandersnatch/utils.py
+++ b/src/bandersnatch/utils.py
@@ -9,6 +9,7 @@ import shutil
 import sys
 import tempfile
 from datetime import datetime
+from enum import Enum
 from pathlib import Path
 from typing import IO, Any, Generator, List, Set, Union
 from urllib.parse import urlparse
@@ -35,6 +36,15 @@ def user_agent() -> str:
 SAFE_NAME_REGEX = re.compile(r"[^A-Za-z0-9.]+")
 USER_AGENT = user_agent()
 WINDOWS = bool(platform.system() == "Windows")
+
+
+class StrEnum(str, Enum):
+    """Enumeration class where members can be treated as strings."""
+
+    value: str
+
+    def __str__(self) -> str:
+        return self.value
 
 
 def make_time_stamp() -> str:


### PR DESCRIPTION
PEP 691 specifies that each file's hashes dictionary must contain only
hash algorithms that can be passed, without arguments, to hashlib.new().
PyPI has started using a "blake2b_256" key for digests, which is blake2b
with the digest size set to 32 bytes, and makes it so that contents of
"digests" can't just be reused for the hashes dictionary.

This commit uses the value of configuration option digest_name to pick
a single supported key/value pair from the digests for use in the hashes
dictionary.