### PR TITLE
Update version to 6.3.0 for release

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,9 +1,12 @@
-# Unreleased
+# 6.3.0
 
 ## Bug Fixes
 
 - Fix digest used for file hashes in PEP 691 simple JSON file output `PR #1442`
   - The `digest_name` setting from configuration (default value: `sha256`) will now be used for both HTML and JSON files.
+  - This mirrors pypi.org ("Warehouse") behavior
+  - Please use `bandersnatch mirror --force-check` to regenerate all your mirror's simple API
+    - `bandersnatch sync` could also be a way to update important packages faster too
 
 # 6.2.0
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,7 +17,7 @@ project_urls =
     Source Code = https://github.com/pypa/bandersnatch
     Change Log = https://github.com/pypa/bandersnatch/blob/master/CHANGES.md
 url = https://github.com/pypa/bandersnatch/
-version = 6.2.0
+version = 6.3.0
 
 [options]
 install_requires =

--- a/src/bandersnatch/__init__.py
+++ b/src/bandersnatch/__init__.py
@@ -20,7 +20,7 @@ class _VersionInfo(NamedTuple):
 
 __version_info__ = _VersionInfo(
     major=6,
-    minor=2,
+    minor=3,
     micro=0,
     releaselevel="",
     serial=0,  # Not currently in use with Bandersnatch versioning

--- a/src/bandersnatch/main.py
+++ b/src/bandersnatch/main.py
@@ -28,7 +28,6 @@ except ImportError:
 logger = logging.getLogger(__name__)  # pylint: disable=C0103
 
 
-# TODO: Workout why argparse.ArgumentParser causes type errors
 def _delete_parser(subparsers: argparse._SubParsersAction) -> None:
     d = subparsers.add_parser(
         "delete",

--- a/src/bandersnatch/mirror.py
+++ b/src/bandersnatch/mirror.py
@@ -64,7 +64,7 @@ class Mirror:
             # Changelog-based synchronization
             await self.determine_packages_to_sync()
         else:
-            # Synchronize specific packages. This method doesn't update the statusfile
+            # Synchronize specific packages. This method doesn't update the status file
             # Pass serial number 0 to bypass the stale serial check in Package class
             SERIAL_DONT_CARE = 0
             self.packages_to_sync = {


### PR DESCRIPTION
- Fix + delete some uneeded comments
- Add more verbosity to release notes encouraging users to update all the Simple API files