### PR TITLE
fix: draft fix for sync vulnerability

### DIFF
--- a/src/bandersnatch/mirror.py
+++ b/src/bandersnatch/mirror.py
@@ -31,7 +31,7 @@ class Mirror:
     synced_serial: Optional[int] = 0  # The last serial we have consistently synced to.
     target_serial: Optional[int] = None  # What is the serial we are trying to reach?
     packages_to_sync: Dict[str, Union[int, str]] = {}
-    removed_package_list: Set[Package] = set()
+    removed_package_list: Set[str] = set()
 
     # We are required to leave a 'last changed' timestamp. I'd rather err
     # on the side of giving a timestamp that is too old so we keep track
@@ -54,7 +54,7 @@ class Mirror:
         self,
         specific_packages: Optional[List[str]] = None,
         sync_simple_index: bool = True,
-    ) -> Tuple[Dict[str, Set[str]], Set[Package]]:
+    ) -> Tuple[Dict[str, Set[str]], Set[str]]:
         logger.info(f"Syncing with {self.master.url}.")
         self.now = datetime.datetime.utcnow()
         # Lets ensure we get a new dict each run
@@ -354,7 +354,10 @@ class BandersnatchMirror(Mirror):
     def finalize_sync(self, sync_index_page: bool = True) -> None:
         if sync_index_page:
             self.simple_api.sync_index_page(
-                self.need_index_sync, self.webdir, self.synced_serial, packages_to_remove=self.removed_package_list
+                self.need_index_sync,
+                self.webdir,
+                self.synced_serial,
+                self.removed_package_list,
             )
         if self.need_wrapup:
             self.wrapup_successful_sync()
@@ -989,7 +992,10 @@ async def mirror(
             specific_packages, sync_simple_index=sync_simple_index
         )
 
-    logger.info(f"{len(changed_packages)} packages had changes, {len(removed_packages)} packages was removed.")
+    logger.info(
+        f"{len(changed_packages)} packages had changes,"
+        f" {len(removed_packages)} packages was removed."
+    )
     for package_name, changes in changed_packages.items():
         package_changes = []
         for change in changes:

--- a/src/bandersnatch/simple.py
+++ b/src/bandersnatch/simple.py
@@ -1,12 +1,13 @@
 import html
 import json
 import logging
+import os
+import shutil
 import sys
 from enum import Enum, auto
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Dict, List, NamedTuple, Optional, Union, Set
+from typing import TYPE_CHECKING, Any, Dict, List, NamedTuple, Optional, Set, Union
 from urllib.parse import urlparse
-import shutil, os
 
 from .package import Package
 
@@ -253,7 +254,13 @@ class SimpleAPI:
         return SimpleFormats(simple_html_content, simple_json_content)
 
     def sync_index_page(
-        self, need_index_sync: bool, webdir: Path, serial: int, *, pretty: bool = False, packages_to_remove: Set[str] = []
+        self,
+        need_index_sync: bool,
+        webdir: Path,
+        serial: int,
+        packages_to_remove: Set[str],
+        *,
+        pretty: bool = False,
     ) -> None:
         if not need_index_sync:
             return
@@ -270,7 +277,10 @@ class SimpleAPI:
         }
 
         if len(packages_to_remove) > 0:
-            logger.info(f'{len(packages_to_remove)} packages will be removed becuase they are no longer exist on master.')
+            logger.info(
+                f"{len(packages_to_remove)} packages will be removed becuase they are"
+                " no longer exist on master."
+            )
 
         with self.storage_backend.rewrite(str(simple_html_path)) as f:
             f.write("<!DOCTYPE html>\n")

--- a/src/bandersnatch/tests/test_mirror.py
+++ b/src/bandersnatch/tests/test_mirror.py
@@ -353,7 +353,7 @@ async def test_mirror_sync_package_error_no_early_exit(
 ) -> None:
     mirror.master.all_packages = mock.AsyncMock(return_value={"foo": 1})  # type: ignore
     mirror.errors = True
-    changed_packages = await mirror.synchronize()
+    changed_packages, _ = await mirror.synchronize()
 
     expected = """\
 .lock

--- a/src/bandersnatch/tests/test_simple.py
+++ b/src/bandersnatch/tests/test_simple.py
@@ -85,7 +85,7 @@ def test_json_index_page() -> None:
         for a_file in (sixtynine_html, foo_html):
             a_file.touch()
 
-        s.sync_index_page(True, td_path, 12345, pretty=True)
+        s.sync_index_page(True, td_path, 12345, set(), pretty=True)
         # See we get the files we expect on the file system
         # index.html is needed to trigger the global index finding the package
         assert """\


### PR DESCRIPTION
This pull request fixes a bug where bandersnatch did not properly handle deletion of a project/all releases of a project. 

The vulnerability occurs when bandersnatch failed to generate the correct Simple Index and notify the client (which is usually pip or poetry) that some packages have already been deleted by the upstream repo (PyPI.org). 

For example, **_project A_** was completely removed by PyPI (which means all associated releases or the project on PyPI is removed). However, third-party PyPI mirrors using unpatched version of bandersnatch not only still keeps the source and the wheel of **_project A_**, and would still make **_project A_** downloadable and installable by client who decided to use that mirror.