### PR TITLE
Move to a >= 3.10 project for 6.4.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.10", "3.11"]
         os: [macOS-latest, windows-latest]
 
     steps:

--- a/.github/workflows/ci_ubuntu.yml
+++ b/.github/workflows/ci_ubuntu.yml
@@ -18,7 +18,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.10", "3.11"]
         os: [ubuntu-latest]
 
     steps:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,7 +19,7 @@ repos:
     rev: v3.4.0
     hooks:
       - id: pyupgrade
-        args: [--py38-plus]
+        args: [--py310-plus]
 
   - repo: https://github.com/PyCQA/isort
     rev: 5.12.0

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+# 6.4.0 (Unreleased)
+
+- Move to >= 3.10 project `PR #1457`
+
 # 6.3.0
 
 ## Bug Fixes

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,5 +1,5 @@
 [mypy]
-python_version = 3.8
+python_version = 3.10
 check_untyped_defs = True
 disallow_incomplete_defs = True
 disallow_untyped_defs = True

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,8 +3,6 @@ author = Christian Theune
 author_email = ct@flyingcircus.io
 classifiers =
     Programming Language :: Python :: 3 :: Only
-    Programming Language :: Python :: 3.8
-    Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
 description = Mirroring tool that implements the client (mirror) side of PEP 381
@@ -17,7 +15,7 @@ project_urls =
     Source Code = https://github.com/pypa/bandersnatch
     Change Log = https://github.com/pypa/bandersnatch/blob/master/CHANGES.md
 url = https://github.com/pypa/bandersnatch/
-version = 6.3.0
+version = 6.4.0.dev0
 
 [options]
 install_requires =
@@ -31,7 +29,7 @@ install_requires =
 package_dir =
     =src
 packages = find:
-python_requires = >=3.8
+python_requires = >=3.10
 
 [options.packages.find]
 where=src

--- a/src/bandersnatch/__init__.py
+++ b/src/bandersnatch/__init__.py
@@ -20,9 +20,9 @@ class _VersionInfo(NamedTuple):
 
 __version_info__ = _VersionInfo(
     major=6,
-    minor=3,
+    minor=4,
     micro=0,
-    releaselevel="",
+    releaselevel="dev0",
     serial=0,  # Not currently in use with Bandersnatch versioning
 )
 __version__ = __version_info__.version_str

--- a/src/bandersnatch/configuration.py
+++ b/src/bandersnatch/configuration.py
@@ -5,7 +5,7 @@ import configparser
 import importlib.resources
 import logging
 from pathlib import Path
-from typing import Any, Dict, List, NamedTuple, Optional, Type
+from typing import Any, NamedTuple
 
 from .simple import SimpleDigest, SimpleFormat, get_digest_value, get_format_value
 
@@ -28,9 +28,9 @@ class SetConfigValues(NamedTuple):
 
 
 class Singleton(type):  # pragma: no cover
-    _instances: Dict["Singleton", Type] = {}
+    _instances: dict["Singleton", type] = {}
 
-    def __call__(cls, *args: Any, **kwargs: Any) -> Type:
+    def __call__(cls, *args: Any, **kwargs: Any) -> type:
         if cls not in cls._instances:
             cls._instances[cls] = super().__call__(*args, **kwargs)
         return cls._instances[cls]
@@ -40,7 +40,7 @@ class BandersnatchConfig(metaclass=Singleton):
     # Ensure we only show the deprecations once
     SHOWN_DEPRECATIONS = False
 
-    def __init__(self, config_file: Optional[str] = None) -> None:
+    def __init__(self, config_file: str | None = None) -> None:
         """
         Bandersnatch configuration class singleton
 
@@ -52,9 +52,10 @@ class BandersnatchConfig(metaclass=Singleton):
         config_file: str, optional
             Path to the configuration file to use
         """
-        self.found_deprecations: List[str] = []
-        with importlib.resources.path("bandersnatch", "default.conf") as config_path:
-            self.default_config_file = str(config_path)
+        self.found_deprecations: list[str] = []
+        self.default_config_file = str(
+            importlib.resources.files("bandersnatch") / "default.conf"
+        )
         self.config_file = config_file
         self.load_configuration()
         # Keeping for future deprecations ... Commenting to save function call etc.

--- a/src/bandersnatch/delete.py
+++ b/src/bandersnatch/delete.py
@@ -4,11 +4,11 @@ import asyncio
 import concurrent.futures
 import logging
 from argparse import Namespace
+from collections.abc import Awaitable
 from configparser import ConfigParser
 from functools import partial
 from json import JSONDecodeError, load
 from pathlib import Path
-from typing import Awaitable, List
 from urllib.parse import urlparse
 
 from packaging.utils import canonicalize_name
@@ -97,7 +97,7 @@ async def delete_packages(config: ConfigParser, args: Namespace, master: Master)
     pypi_base_path = storage_backend.pypi_base_path
     simple_base_path = storage_backend.simple_base_path
 
-    delete_coros: List[Awaitable] = []
+    delete_coros: list[Awaitable] = []
     for package in args.pypi_packages:
         canon_name = canonicalize_name(package)
         need_nc_paths = canon_name != package

--- a/src/bandersnatch/filter.py
+++ b/src/bandersnatch/filter.py
@@ -2,7 +2,7 @@
 Blocklist management
 """
 from collections import defaultdict
-from typing import TYPE_CHECKING, Any, Dict, List
+from typing import TYPE_CHECKING, Any
 
 import pkg_resources
 
@@ -145,16 +145,16 @@ class LoadedFilters:
         Loads and stores all of specified filters from the config file
         """
         self.config = BandersnatchConfig().config
-        self.loaded_filter_plugins: Dict[str, List["Filter"]] = defaultdict(list)
+        self.loaded_filter_plugins: dict[str, list["Filter"]] = defaultdict(list)
         self.enabled_plugins = self._load_enabled()
         if load_all:
             self._load_filters(self.ENTRYPOINT_GROUPS)
 
-    def _load_enabled(self) -> List[str]:
+    def _load_enabled(self) -> list[str]:
         """
         Reads the config and returns all the enabled plugins
         """
-        enabled_plugins: List[str] = []
+        enabled_plugins: list[str] = []
         try:
             config_plugins = self.config["plugins"]["enabled"]
             split_plugins = config_plugins.split("\n")
@@ -169,7 +169,7 @@ class LoadedFilters:
             pass
         return enabled_plugins
 
-    def _load_filters(self, groups: List[str]) -> None:
+    def _load_filters(self, groups: list[str]) -> None:
         """
         Loads filters from the entry-point groups specified in groups
         """
@@ -187,7 +187,7 @@ class LoadedFilters:
 
             self.loaded_filter_plugins[group] = list(plugins)
 
-    def filter_project_plugins(self) -> List[Filter]:
+    def filter_project_plugins(self) -> list[Filter]:
         """
         Load and return the project filtering plugin objects
 
@@ -200,7 +200,7 @@ class LoadedFilters:
             self._load_filters([PROJECT_PLUGIN_RESOURCE])
         return self.loaded_filter_plugins[PROJECT_PLUGIN_RESOURCE]
 
-    def filter_metadata_plugins(self) -> List[Filter]:
+    def filter_metadata_plugins(self) -> list[Filter]:
         """
         Load and return the metadata filtering plugin objects
 
@@ -213,7 +213,7 @@ class LoadedFilters:
             self._load_filters([METADATA_PLUGIN_RESOURCE])
         return self.loaded_filter_plugins[METADATA_PLUGIN_RESOURCE]
 
-    def filter_release_plugins(self) -> List[Filter]:
+    def filter_release_plugins(self) -> list[Filter]:
         """
         Load and return the release filtering plugin objects
 
@@ -226,7 +226,7 @@ class LoadedFilters:
             self._load_filters([RELEASE_PLUGIN_RESOURCE])
         return self.loaded_filter_plugins[RELEASE_PLUGIN_RESOURCE]
 
-    def filter_release_file_plugins(self) -> List[Filter]:
+    def filter_release_file_plugins(self) -> list[Filter]:
         """
         Load and return the release file filtering plugin objects
 

--- a/src/bandersnatch/main.py
+++ b/src/bandersnatch/main.py
@@ -7,7 +7,6 @@ import sys
 from configparser import ConfigParser
 from pathlib import Path
 from tempfile import gettempdir
-from typing import Optional
 
 import bandersnatch.configuration
 import bandersnatch.delete
@@ -191,7 +190,7 @@ async def async_main(args: argparse.Namespace, config: ConfigParser) -> int:
     return await bandersnatch.mirror.mirror(config)
 
 
-def main(loop: Optional[asyncio.AbstractEventLoop] = None) -> int:
+def main(loop: asyncio.AbstractEventLoop | None = None) -> int:
     parser = _make_parser()
     if len(sys.argv) < 2:
         parser.print_help()

--- a/src/bandersnatch/package.py
+++ b/src/bandersnatch/package.py
@@ -1,6 +1,6 @@
 import asyncio
 import logging
-from typing import TYPE_CHECKING, Any, Dict, List, Optional
+from typing import TYPE_CHECKING, Any
 
 from packaging.utils import canonicalize_name
 
@@ -21,10 +21,10 @@ class Package:
         self.raw_name = name
         self.serial = serial
 
-        self._metadata: Optional[Dict] = None
+        self._metadata: dict | None = None
 
     @property
-    def metadata(self) -> Dict[str, Any]:
+    def metadata(self) -> dict[str, Any]:
         assert self._metadata is not None, "Must fetch metadata before accessing it"
         return self._metadata
 
@@ -41,8 +41,8 @@ class Package:
         return self.metadata["releases"]
 
     @property
-    def release_files(self) -> List:
-        release_files: List[Dict] = []
+    def release_files(self) -> list:
+        release_files: list[dict] = []
 
         for release in self.releases.values():
             release_files.extend(release)
@@ -85,13 +85,13 @@ class Package:
                 )
                 raise error_class(package_name=self.name, attempts=attempts)
 
-    def filter_metadata(self, metadata_filters: List["Filter"]) -> bool:
+    def filter_metadata(self, metadata_filters: list["Filter"]) -> bool:
         """
         Run the metadata filtering plugins
         """
         return all(plugin.filter(self.metadata) for plugin in metadata_filters)
 
-    def filter_all_releases(self, release_filters: List["Filter"]) -> bool:
+    def filter_all_releases(self, release_filters: list["Filter"]) -> bool:
         """
         Filter releases and removes releases that fail the filters
         """
@@ -108,7 +108,7 @@ class Package:
             return True
         return False
 
-    def filter_all_releases_files(self, release_file_filters: List["Filter"]) -> bool:
+    def filter_all_releases_files(self, release_file_filters: list["Filter"]) -> bool:
         """
         Filter release files and remove empty releases after doing so.
         """

--- a/src/bandersnatch/simple.py
+++ b/src/bandersnatch/simple.py
@@ -4,7 +4,7 @@ import logging
 import sys
 from enum import Enum, auto
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Dict, List, NamedTuple, Optional, Union
+from typing import TYPE_CHECKING, Any, NamedTuple
 from urllib.parse import urlparse
 
 from .package import Package
@@ -87,11 +87,11 @@ class SimpleAPI:
     def __init__(
         self,
         storage_backend: "Storage",
-        format: Union[SimpleFormat, str],
-        diff_file_list: List[Path],
-        digest_name: Union[SimpleDigest, str],
+        format: SimpleFormat | str,
+        diff_file_list: list[Path],
+        digest_name: SimpleDigest | str,
         hash_index: bool,
-        root_uri: Optional[str],
+        root_uri: str | None,
     ) -> None:
         self.diff_file_list = diff_file_list
         self.digest_name = (
@@ -110,7 +110,7 @@ class SimpleAPI:
     def json_enabled(self) -> bool:
         return self.format in {SimpleFormat.ALL, SimpleFormat.JSON}
 
-    def find_packages_in_dir(self, simple_dir: Path) -> List[str]:
+    def find_packages_in_dir(self, simple_dir: Path) -> list[str]:
         """Given a directory that contains simple packages indexes, return
         a sorted list of normalized package names.  This presumes every
         directory within is a simple package index directory."""
@@ -122,7 +122,7 @@ class SimpleAPI:
             }
         )
 
-    def gen_html_file_tags(self, release: Dict) -> str:
+    def gen_html_file_tags(self, release: dict) -> str:
         file_tags = ""
 
         # data-requires-python: requires_python
@@ -141,7 +141,7 @@ class SimpleAPI:
         return file_tags
 
     # TODO: This can return SwiftPath types now
-    def get_simple_dirs(self, simple_dir: Path) -> List[Path]:
+    def get_simple_dirs(self, simple_dir: Path) -> list[Path]:
         """Return a list of simple index directories that should be searched
         for package indexes when compiling the main index page."""
         if self.hash_index:
@@ -209,7 +209,7 @@ class SimpleAPI:
     def generate_json_simple_page(
         self, package: Package, *, pretty: bool = False
     ) -> str:
-        package_json: Dict[str, Any] = {
+        package_json: dict[str, Any] = {
             "files": [],
             "meta": {
                 "api-version": self.pypi_simple_api_version,
@@ -263,7 +263,7 @@ class SimpleAPI:
         simple_html_version_path = simple_dir / "index.v1_html"
         simple_json_path = simple_dir / "index.v1_json"
 
-        simple_json: Dict[str, Any] = {
+        simple_json: dict[str, Any] = {
             "meta": {"_last-serial": serial, "api-version": "1.0"},
             "projects": [],
         }

--- a/src/bandersnatch/storage.py
+++ b/src/bandersnatch/storage.py
@@ -9,21 +9,9 @@ import hashlib
 import logging
 import pathlib
 from collections import defaultdict
+from collections.abc import Generator, Iterable, Sequence
 from concurrent.futures import ThreadPoolExecutor
-from typing import (
-    IO,
-    Any,
-    Dict,
-    Generator,
-    Iterable,
-    List,
-    Optional,
-    Protocol,
-    Sequence,
-    Set,
-    Type,
-    Union,
-)
+from typing import IO, Any, Protocol
 
 import filelock
 import pkg_resources
@@ -31,7 +19,7 @@ from packaging.utils import canonicalize_name
 
 from .configuration import BandersnatchConfig
 
-PATH_TYPES = Union[pathlib.Path, str]
+PATH_TYPES = pathlib.Path | str
 
 # The API_REVISION is incremented if the plugin class is modified in a
 # backwards incompatible way.  In order to prevent loading older
@@ -39,18 +27,18 @@ PATH_TYPES = Union[pathlib.Path, str]
 # the methods of the classes.
 PLUGIN_API_REVISION = 1
 STORAGE_PLUGIN_RESOURCE = f"bandersnatch_storage_plugins.v{PLUGIN_API_REVISION}.backend"
-loaded_storage_plugins: Dict[str, List["Storage"]] = defaultdict(list)
+loaded_storage_plugins: dict[str, list["Storage"]] = defaultdict(list)
 
 logger = logging.getLogger("bandersnatch")
 
 
 class StorageDirEntry(Protocol):
     @property
-    def name(self) -> Union[str, bytes]:
+    def name(self) -> str | bytes:
         ...
 
     @property
-    def path(self) -> Union[str, bytes]:
+    def path(self) -> str | bytes:
         ...
 
     def is_dir(self) -> bool:
@@ -69,12 +57,12 @@ class Storage:
     """
 
     name = "storage"
-    PATH_BACKEND: Type[pathlib.Path] = pathlib.Path
+    PATH_BACKEND: type[pathlib.Path] = pathlib.Path
 
     def __init__(
         self,
         *args: Any,
-        config: Optional[configparser.ConfigParser] = None,
+        config: configparser.ConfigParser | None = None,
         **kwargs: Any,
     ) -> None:
         self.flock_path: PATH_TYPES = ".lock"
@@ -212,7 +200,7 @@ class Storage:
         """
         raise NotImplementedError
 
-    def write_file(self, path: PATH_TYPES, contents: Union[str, bytes]) -> None:
+    def write_file(self, path: PATH_TYPES, contents: str | bytes) -> None:
         """Write data to the provided path.  If **contents** is a string, the file will
         be opened and written in "r" + "utf-8" mode, if bytes are supplied it will be
         accessed using "rb" mode (i.e. binary write)."""
@@ -231,8 +219,8 @@ class Storage:
         path: PATH_TYPES,
         text: bool = True,
         encoding: str = "utf-8",
-        errors: Optional[str] = None,
-    ) -> Union[str, bytes]:
+        errors: str | None = None,
+    ) -> str | bytes:
         """Yield a file context to iterate over. If text is true, open the file with
         'rb' mode specified."""
         raise NotImplementedError
@@ -333,10 +321,10 @@ class StoragePlugin(Storage):
 
 def load_storage_plugins(
     entrypoint_group: str,
-    enabled_plugin: Optional[str] = None,
-    config: Optional[configparser.ConfigParser] = None,
+    enabled_plugin: str | None = None,
+    config: configparser.ConfigParser | None = None,
     clear_cache: bool = False,
-) -> Set[Storage]:
+) -> set[Storage]:
     """
     Load all storage plugins that are registered with pkg_resources
 
@@ -395,8 +383,8 @@ def load_storage_plugins(
 
 
 def storage_backend_plugins(
-    backend: Optional[str] = "filesystem",
-    config: Optional[configparser.ConfigParser] = None,
+    backend: str | None = "filesystem",
+    config: configparser.ConfigParser | None = None,
     clear_cache: bool = False,
 ) -> Iterable[Storage]:
     """

--- a/src/bandersnatch/tests/conftest.py
+++ b/src/bandersnatch/tests/conftest.py
@@ -1,8 +1,9 @@
 # flake8: noqa
 import os
 import unittest.mock as mock
+from collections.abc import Iterator
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Dict, Iterator
+from typing import TYPE_CHECKING, Any, Dict
 
 import boto3
 import pytest
@@ -53,7 +54,7 @@ def package(package_json: dict) -> "Package":
 
 
 @pytest.fixture
-def package_json() -> Dict[str, Any]:
+def package_json() -> dict[str, Any]:
     return {
         "info": {"name": "Foo", "version": "0.1"},
         "last_serial": 654_321,
@@ -90,7 +91,7 @@ def package_json() -> Dict[str, Any]:
 
 
 @pytest.fixture
-def master(package_json: Dict[str, Any]) -> "Master":
+def master(package_json: dict[str, Any]) -> "Master":
     from bandersnatch.master import Master
 
     class FakeReader:
@@ -110,7 +111,7 @@ def master(package_json: Dict[str, Any]) -> "Master":
         def content(self) -> "FakeReader":
             return FakeReader()
 
-        async def json(self, *args: Any) -> Dict[str, Any]:
+        async def json(self, *args: Any) -> dict[str, Any]:
             return package_json
 
     def session_side_effect(*args: Any, **kwargs: Any) -> Any:

--- a/src/bandersnatch/tests/plugins/test_storage_plugins.py
+++ b/src/bandersnatch/tests/plugins/test_storage_plugins.py
@@ -10,8 +10,9 @@ import shutil
 import sys
 import tempfile
 import unittest
+from collections.abc import Iterator
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Dict, Iterator, List, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Any
 from unittest import TestCase, mock
 
 import bandersnatch.storage
@@ -34,7 +35,7 @@ SWIFT_CONTAINER_FILE = os.path.join(
 )
 
 
-def get_swift_file_attrs(path: Path, base: Path, container: str = "") -> Dict[str, Any]:
+def get_swift_file_attrs(path: Path, base: Path, container: str = "") -> dict[str, Any]:
     path = strip_dir_prefix(base, path, container=container)
     if not path.is_absolute():
         path = "/" / path
@@ -69,7 +70,7 @@ def get_swift_file_attrs(path: Path, base: Path, container: str = "") -> Dict[st
 
 
 def strip_dir_prefix(
-    base_dir: Path, subdir: Path, container: Optional[str] = None
+    base_dir: Path, subdir: Path, container: str | None = None
 ) -> Path:
     if container is not None:
         base_dir = base_dir.joinpath(container)
@@ -81,8 +82,8 @@ def strip_dir_prefix(
 
 
 def iter_dir(
-    path: Path, base: Optional[Path] = None, recurse: bool = False, container: str = ""
-) -> Iterator[Dict[str, Any]]:
+    path: Path, base: Path | None = None, recurse: bool = False, container: str = ""
+) -> Iterator[dict[str, Any]]:
     if base is None:
         base = path
     if path.is_dir():
@@ -151,7 +152,7 @@ class MockConnection:
             obj = Path(f"/{obj!s}")
         return obj
 
-    def _strip_prefix(self, prefix: str, container: Optional[str] = None) -> str:
+    def _strip_prefix(self, prefix: str, container: str | None = None) -> str:
         base_dir_prefix = self.tmpdir.name[1:]
         if container is not None:
             base_dir_prefix = os.path.join(base_dir_prefix, container)
@@ -159,10 +160,10 @@ class MockConnection:
             return prefix[len(base_dir_prefix) :].lstrip("/")  # noqa:E203
         return prefix.lstrip("/")
 
-    def get_account(self) -> Tuple[Dict[Any, Any], Dict[Any, Any]]:
+    def get_account(self) -> tuple[dict[Any, Any], dict[Any, Any]]:
         return {}, {}
 
-    def get_object(self, container: str, obj: str) -> Tuple[Dict[Any, Any], bytes]:
+    def get_object(self, container: str, obj: str) -> tuple[dict[Any, Any], bytes]:
         path = self.clean_path(container, obj)
         if not path.exists():
             from swiftclient.exceptions import ClientException
@@ -174,9 +175,9 @@ class MockConnection:
         self,
         container: str,
         obj: str,
-        headers: Optional[Dict[str, str]] = None,
-        query_string: Optional[str] = None,
-    ) -> Dict[str, str]:
+        headers: dict[str, str] | None = None,
+        query_string: str | None = None,
+    ) -> dict[str, str]:
         path = self.clean_path(container, obj)
         if not path.exists():
             from swiftclient.exceptions import ClientException
@@ -213,8 +214,8 @@ class MockConnection:
         self,
         container: str,
         obj: str,
-        headers: Dict[str, str],
-        response_dict: Optional[Dict[str, Any]] = None,
+        headers: dict[str, str],
+        response_dict: dict[str, Any] | None = None,
     ) -> None:
         path = self.clean_path(container, obj)
         path.touch()
@@ -222,16 +223,16 @@ class MockConnection:
     def _get_container(
         self,
         container: str,
-        marker: Optional[str] = None,
-        limit: Optional[int] = None,
-        prefix: Optional[str] = None,
-        delimiter: Optional[str] = None,
-        end_marker: Optional[str] = None,
-        path: Optional[Path] = None,
+        marker: str | None = None,
+        limit: int | None = None,
+        prefix: str | None = None,
+        delimiter: str | None = None,
+        end_marker: str | None = None,
+        path: Path | None = None,
         full_listing: bool = False,
-        headers: Optional[Dict[str, str]] = None,
-        query_string: Optional[str] = None,
-    ) -> List[Dict[str, Any]]:
+        headers: dict[str, str] | None = None,
+        query_string: str | None = None,
+    ) -> list[dict[str, Any]]:
         base = self.base
         if container:
             base = base / container
@@ -248,16 +249,16 @@ class MockConnection:
     def get_container(
         self,
         container: str,
-        marker: Optional[str] = None,
-        limit: Optional[int] = None,
-        prefix: Optional[str] = None,
-        delimiter: Optional[str] = None,
-        end_marker: Optional[str] = None,
-        path: Optional[Path] = None,
+        marker: str | None = None,
+        limit: int | None = None,
+        prefix: str | None = None,
+        delimiter: str | None = None,
+        end_marker: str | None = None,
+        path: Path | None = None,
         full_listing: bool = False,
-        headers: Optional[Dict[str, str]] = None,
-        query_string: Optional[str] = None,
-    ) -> List[Dict[str, Any]]:
+        headers: dict[str, str] | None = None,
+        query_string: str | None = None,
+    ) -> list[dict[str, Any]]:
         with open(SWIFT_CONTAINER_FILE) as fh:
             contents = json.load(fh)
         if prefix:
@@ -288,9 +289,9 @@ class MockConnection:
         container: str,
         obj: str,
         destination: str,
-        headers: Optional[Dict[str, str]] = None,
+        headers: dict[str, str] | None = None,
         fresh_metadata: Any = None,
-        response_dict: Optional[Dict[str, Any]] = None,
+        response_dict: dict[str, Any] | None = None,
     ) -> None:
         # destination path always starts with container/
         dest_container, _, dest_path = destination.partition("/")
@@ -304,14 +305,14 @@ class MockConnection:
         self,
         container: str,
         obj: str,
-        contents: Union[str, bytes],
-        content_length: Optional[int] = None,
+        contents: str | bytes,
+        content_length: int | None = None,
         etag: Any = None,
-        chunk_size: Optional[int] = None,
-        content_type: Optional[str] = None,
-        headers: Optional[Dict[str, str]] = None,
-        query_string: Optional[str] = None,
-        response_dict: Optional[Dict[str, Any]] = None,
+        chunk_size: int | None = None,
+        content_type: str | None = None,
+        headers: dict[str, str] | None = None,
+        query_string: str | None = None,
+        response_dict: dict[str, Any] | None = None,
     ) -> None:
         dest = self.clean_path(container, obj)
         if not dest.parent.exists():
@@ -333,9 +334,9 @@ class MockConnection:
         self,
         container: str,
         obj: str,
-        query_string: Optional[str] = None,
-        response_dict: Optional[Dict[str, Any]] = None,
-        headers: Optional[Dict[str, str]] = None,
+        query_string: str | None = None,
+        response_dict: dict[str, Any] | None = None,
+        headers: dict[str, str] | None = None,
     ) -> None:
         target = self.clean_path(container, obj)
         if not target.exists():
@@ -350,7 +351,7 @@ class MockConnection:
 class BasePluginTestCase(TestCase):
     tempdir = None
     cwd = None
-    backend: Optional[str] = None
+    backend: str | None = None
 
     config_contents = """\
 [mirror]
@@ -375,8 +376,8 @@ workers = 3
             raise unittest.SkipTest("Skipping base test case")
         self.cwd = os.getcwd()
         self.tempdir = tempfile.TemporaryDirectory()
-        self.pkgs: List[Package] = []
-        self.container: Optional[str] = None
+        self.pkgs: list[Package] = []
+        self.container: str | None = None
         self.config_data = mock_config(self.config_contents.format(self.backend))
         os.chdir(self.tempdir.name)
         self.setUp_backEnd()
@@ -755,12 +756,12 @@ web{0}simple{0}index.html""".format(os.sep).strip()
                     self.assertEqual(fh.read(), rv)
 
     def test_write_file(self) -> None:
-        data: List[Union[str, bytes]] = ["this is some text", b"this is some text"]
+        data: list[str | bytes] = ["this is some text", b"this is some text"]
         tmp_path = os.path.join(self.mirror_base_path, "test_write_file.txt")
         for write_val in data:
             with self.subTest(write_val=write_val):
                 self.plugin.write_file(tmp_path, write_val)
-                rv: Union[str, bytes]
+                rv: str | bytes
                 if not isinstance(write_val, str):
                     rv = self.plugin.PATH_BACKEND(tmp_path).read_bytes()
                 else:

--- a/src/bandersnatch/tests/test_configuration.py
+++ b/src/bandersnatch/tests/test_configuration.py
@@ -43,11 +43,11 @@ class TestBandersnatchConf(TestCase):
         self.assertEqual(id(instance1), id(instance2))
 
     def test_single_config__default__all_sections_present(self) -> None:
-        with importlib.resources.path("bandersnatch", "unittest.conf") as config_file:
-            instance = BandersnatchConfig(str(config_file))
-            # All default values should at least be present and be the write types
-            for section in ["mirror", "plugins", "blocklist"]:
-                self.assertIn(section, instance.config.sections())
+        config_file = str(importlib.resources.files("bandersnatch") / "unittest.conf")
+        instance = BandersnatchConfig(str(config_file))
+        # All default values should at least be present and be the write types
+        for section in ["mirror", "plugins", "blocklist"]:
+            self.assertIn(section, instance.config.sections())
 
     def test_single_config__default__mirror__setting_attributes(self) -> None:
         instance = BandersnatchConfig()

--- a/src/bandersnatch/tests/test_main.py
+++ b/src/bandersnatch/tests/test_main.py
@@ -4,7 +4,7 @@ import sys
 import tempfile
 import unittest.mock as mock
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Dict
+from typing import TYPE_CHECKING, Any
 
 import pytest
 from _pytest.capture import CaptureFixture
@@ -20,7 +20,7 @@ if TYPE_CHECKING:
     from bandersnatch.mirror import BandersnatchMirror
 
 
-async def empty_dict(*args: Any, **kwargs: Any) -> Dict:
+async def empty_dict(*args: Any, **kwargs: Any) -> dict:
     return {}
 
 

--- a/src/bandersnatch/tests/test_master.py
+++ b/src/bandersnatch/tests/test_master.py
@@ -91,7 +91,8 @@ async def test_session_raise_for_status(master: Master) -> None:
         assert create_session.call_args_list[0][1]["raise_for_status"]
 
 
-def test_check_for_socks_proxy(master: Master) -> None:
+@pytest.mark.asyncio
+async def test_check_for_socks_proxy(master: Master) -> None:
     assert master._check_for_socks_proxy() is None
 
     from os import environ

--- a/src/bandersnatch/tests/test_mirror.py
+++ b/src/bandersnatch/tests/test_mirror.py
@@ -1,10 +1,11 @@
 import os.path
 import sys
 import unittest.mock as mock
+from collections.abc import Iterator
 from os import sep
 from pathlib import Path
 from tempfile import TemporaryDirectory
-from typing import Any, Dict, Iterator, List, NoReturn
+from typing import Any, NoReturn
 
 import pytest
 from freezegun import freeze_time
@@ -64,7 +65,7 @@ FAKE_RELEASE_DATA = JsonDict(
 )
 
 
-def touch_files(paths: List[Path]) -> None:
+def touch_files(paths: list[Path]) -> None:
     for path in paths:
         if not path.parent.exists():
             path.parent.mkdir(parents=True)
@@ -562,7 +563,7 @@ last-modified""" == utils.find(mirror.webdir, dirs=False)
 
 
 def test_mirror_json_metadata(
-    mirror: BandersnatchMirror, package_json: Dict[str, Any]
+    mirror: BandersnatchMirror, package_json: dict[str, Any]
 ) -> None:
     package = Package("foo", serial=11)
     mirror.json_file(package.name).parent.mkdir(parents=True)
@@ -994,7 +995,7 @@ async def test_package_sync_does_not_touch_existing_local_file(
 
 
 def test_gen_html_file_tags(mirror: BandersnatchMirror) -> None:
-    fake_no_release: Dict[str, str] = {}
+    fake_no_release: dict[str, str] = {}
 
     # only requires_python
     fake_release_1 = {"requires_python": ">=3.6"}

--- a/src/bandersnatch/tests/test_utils.py
+++ b/src/bandersnatch/tests/test_utils.py
@@ -3,7 +3,6 @@ import os.path
 import re
 from pathlib import Path
 from tempfile import NamedTemporaryFile, TemporaryDirectory, gettempdir
-from typing import Set
 
 import aiohttp
 import pytest
@@ -64,7 +63,7 @@ def test_find_files() -> None:
             with afile.open("w") as afp:
                 afp.write("PyPA ftw!")
 
-        found_files: Set[Path] = set()
+        found_files: set[Path] = set()
         find_all_files(found_files, td_path)
         assert found_files == expected_found_files
 

--- a/src/bandersnatch/tests/test_verify.py
+++ b/src/bandersnatch/tests/test_verify.py
@@ -6,7 +6,7 @@ from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 from shutil import rmtree
 from tempfile import gettempdir
-from typing import Any, List
+from typing import Any
 from unittest.mock import AsyncMock
 
 import pytest
@@ -35,11 +35,11 @@ async def fake_fetch(_: str, save_path: Path, *__: Any) -> None:
     save_path.write_text("fake text")
 
 
-def some_dirs(*args: Any, **kwargs: Any) -> List[str]:
+def some_dirs(*args: Any, **kwargs: Any) -> list[str]:
     return ["/data/pypi/web/json/bandersnatch", "/data/pypi/web/json/black"]
 
 
-def some_paths(*_: Any, **__: Any) -> List[Path]:
+def some_paths(*_: Any, **__: Any) -> list[Path]:
     return [Path("/data/pypi/web/json/bandersnatch"), Path("/data/pypi/web/json/black")]
 
 
@@ -249,7 +249,7 @@ async def test_get_latest_json_timeout(
     jsonpath.mkdir(parents=True)
     jsonfile = jsonpath / "bandersnatch"
     jsonfile.touch()
-    all_package_files: List[Path] = []
+    all_package_files: list[Path] = []
 
     await verify(
         master, fc, "bandersnatch", tmp_path, all_package_files, fa  # type: ignore
@@ -279,7 +279,7 @@ async def test_get_latest_json_404(tmp_path: Path, monkeypatch: MonkeyPatch) -> 
     jsonpath.mkdir(parents=True)
     jsonfile = jsonpath / "bandersnatch"
     jsonfile.touch()
-    all_package_files: List[Path] = []
+    all_package_files: list[Path] = []
 
     await verify(
         master, fc, "bandersnatch", tmp_path, all_package_files, fa  # type: ignore # noqa: E501
@@ -312,7 +312,7 @@ async def test_verify_url_exception(tmp_path: Path, monkeypatch: MonkeyPatch) ->
         f.write(
             '{"releases":{"1.0":["url":"https://unittests.org/packages/a0/a0/a0a0/package-1.0.0.exe"}]}}'  # noqa: E501
         )
-    all_package_files: List[Path] = []
+    all_package_files: list[Path] = []
 
     await verify(master, fc, "bandersnatch", tmp_path, all_package_files, fa)  # type: ignore # noqa: E501
     assert jsonfile.exists()

--- a/src/bandersnatch/utils.py
+++ b/src/bandersnatch/utils.py
@@ -8,10 +8,11 @@ import re
 import shutil
 import sys
 import tempfile
+from collections.abc import Generator
 from datetime import datetime
 from enum import Enum
 from pathlib import Path
-from typing import IO, Any, Generator, List, Set, Union
+from typing import IO, Any
 from urllib.parse import urlparse
 
 import aiohttp
@@ -66,7 +67,7 @@ def hash(path: Path, function: str = "sha256") -> str:
     raise TypeError("hashlib did not return str")
 
 
-def find(root: Union[Path, str], dirs: bool = True) -> str:
+def find(root: Path | str, dirs: bool = True) -> str:
     """A test helper simulating 'find'.
 
     Iterates over directories and filenames, given as relative paths to the
@@ -77,7 +78,7 @@ def find(root: Union[Path, str], dirs: bool = True) -> str:
     if isinstance(root, str):
         root = Path(root)
 
-    results: List[Path] = []
+    results: list[Path] = []
     for dirpath, dirnames, filenames in os.walk(root):
         names = filenames
         if dirs:
@@ -90,7 +91,7 @@ def find(root: Union[Path, str], dirs: bool = True) -> str:
 
 @contextlib.contextmanager
 def rewrite(
-    filepath: Union[str, Path], mode: str = "w", **kw: Any
+    filepath: str | Path, mode: str = "w", **kw: Any
 ) -> Generator[IO, None, None]:
     """Rewrite an existing file atomically to avoid programs running in
     parallel to have race conditions while reading."""
@@ -119,7 +120,7 @@ def rewrite(
     shutil.move(filepath_tmp, filepath)
 
 
-def find_all_files(files: Set[Path], base_dir: Path) -> None:
+def find_all_files(files: set[Path], base_dir: Path) -> None:
     for f in base_dir.rglob("*"):
         if not f.is_file():
             continue
@@ -174,7 +175,7 @@ def removeprefix(original: str, prefix: str) -> str:
 
 
 # Python tags https://peps.python.org/pep-0425/#python-tag
-def parse_version(version: str) -> List[str]:
+def parse_version(version: str) -> list[str]:
     """Converts a version string to a list of strings to check the 1st part of build
     tags. See PEP 425 (https://peps.python.org/pep-0425/#python-tag) for details.
 
@@ -188,7 +189,7 @@ def parse_version(version: str) -> List[str]:
             Some Windows binaries have only the 1st part before the file extension.
             e.g. ['-cp36-', '-pp36-', '-ip36-', '-jy36-', '-py3.6-', '-py3.6.']
     """
-    _versions: List[str] = []
+    _versions: list[str] = []
 
     _version_with_dot = removeprefix(version.lower(), "py")
     _version_without_dot = _version_with_dot.replace(".", "")

--- a/src/bandersnatch/verify.py
+++ b/src/bandersnatch/verify.py
@@ -9,7 +9,6 @@ from asyncio.queues import Queue
 from configparser import ConfigParser
 from pathlib import Path
 from sys import stderr
-from typing import List, Optional, Set
 from urllib.parse import urlparse
 
 import aiohttp
@@ -44,7 +43,7 @@ def on_error(stop_on_error: bool, exception: BaseException, package: str) -> Non
 async def get_latest_json(
     master: Master,
     json_path: Path,
-    executor: Optional[concurrent.futures.ThreadPoolExecutor] = None,
+    executor: concurrent.futures.ThreadPoolExecutor | None = None,
     delete_removed_packages: bool = False,
 ) -> None:
     url_parts = urlparse(master.url)
@@ -76,12 +75,12 @@ async def get_latest_json(
 async def delete_unowned_files(
     mirror_base: Path,
     executor: concurrent.futures.ThreadPoolExecutor,
-    all_package_files: List[Path],
+    all_package_files: list[Path],
     dry_run: bool,
 ) -> int:
     loop = asyncio.get_event_loop()
     packages_path = mirror_base / "web" / "packages"
-    all_fs_files: Set[Path] = set()
+    all_fs_files: set[Path] = set()
     await loop.run_in_executor(executor, find_all_files, all_fs_files, packages_path)
 
     all_package_files_set = set(all_package_files)
@@ -114,9 +113,9 @@ async def verify(
     config: ConfigParser,
     json_file: str,
     mirror_base_path: Path,
-    all_package_files: List[Path],
+    all_package_files: list[Path],
     args: argparse.Namespace,
-    executor: Optional[concurrent.futures.ThreadPoolExecutor] = None,
+    executor: concurrent.futures.ThreadPoolExecutor | None = None,
     releases_key: str = "releases",
 ) -> None:
     json_base = mirror_base_path / "web" / "json"
@@ -201,11 +200,11 @@ async def verify(
 async def verify_producer(
     master: Master,
     config: ConfigParser,
-    all_package_files: List[Path],
+    all_package_files: list[Path],
     mirror_base_path: Path,
-    json_files: List[str],
+    json_files: list[str],
     args: argparse.Namespace,
-    executor: Optional[concurrent.futures.ThreadPoolExecutor] = None,
+    executor: concurrent.futures.ThreadPoolExecutor | None = None,
 ) -> None:
     queue: asyncio.Queue = asyncio.Queue()
     for jf in json_files:
@@ -232,7 +231,7 @@ async def verify_producer(
 async def metadata_verify(config: ConfigParser, args: Namespace) -> int:
     """Crawl all saved JSON metadata or online to check we have all packages
     if delete - generate a diff of unowned files"""
-    all_package_files: List[Path] = []
+    all_package_files: list[Path] = []
 
     storage_backend = next(
         iter(

--- a/src/bandersnatch_filter_plugins/allowlist_name.py
+++ b/src/bandersnatch_filter_plugins/allowlist_name.py
@@ -1,6 +1,7 @@
 import logging
+from collections.abc import Iterator
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Dict, Iterator, List, Set
+from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from configparser import SectionProxy
@@ -19,7 +20,7 @@ logger = logging.getLogger("bandersnatch")
 class AllowListProject(FilterProjectPlugin):
     name = "allowlist_project"
     # Requires iterable default
-    allowlist_package_names: List[str] = []
+    allowlist_package_names: list[str] = []
 
     def initialize_plugin(self) -> None:
         """
@@ -35,7 +36,7 @@ class AllowListProject(FilterProjectPlugin):
                 + f"{self.allowlist_package_names}"
             )
 
-    def _determine_unfiltered_package_names(self) -> List[str]:
+    def _determine_unfiltered_package_names(self) -> list[str]:
         """
         Return a list of package names to be filtered base on the configuration
         file.
@@ -44,7 +45,7 @@ class AllowListProject(FilterProjectPlugin):
         # configuration contains a PEP440 specifier it will be processed by the
         # allowlist release filter.  So we need to remove any packages that
         # are not applicable for this plugin.
-        unfiltered_packages: Set[str] = set()
+        unfiltered_packages: set[str] = set()
         try:
             lines = self.allowlist["packages"]
             package_lines = lines.split("\n")
@@ -60,7 +61,7 @@ class AllowListProject(FilterProjectPlugin):
             )
         return list(unfiltered_packages)
 
-    def filter(self, metadata: Dict) -> bool:
+    def filter(self, metadata: dict) -> bool:
         return not self.check_match(name=metadata["info"]["name"])
 
     def check_match(self, **kwargs: Any) -> bool:
@@ -121,13 +122,13 @@ def get_requirement_files(allowlist: "SectionProxy") -> Iterator[Path]:
             yield requirements_path / requirement
 
 
-def _parse_package_lines(package_lines: List[str]) -> Set[Requirement]:
+def _parse_package_lines(package_lines: list[str]) -> set[Requirement]:
     """Parse a requirement line
 
     ignores commented line
     and inline comments
     """
-    filtered_requirements: Set[Requirement] = set()
+    filtered_requirements: set[Requirement] = set()
     for package_line in package_lines:
         package_line = package_line.strip()
         if not package_line or package_line.startswith(("#", "-")):
@@ -143,12 +144,12 @@ def _parse_package_lines(package_lines: List[str]) -> Set[Requirement]:
 class AllowListRequirements(AllowListProject):
     name = "project_requirements"
 
-    def _determine_unfiltered_package_names(self) -> List[str]:
+    def _determine_unfiltered_package_names(self) -> list[str]:
         """
         Return a list of package names to be filtered base on the configuration
         file.
         """
-        filtered_requirements: Set[Requirement] = set()
+        filtered_requirements: set[Requirement] = set()
         try:
             filepaths = get_requirement_files(self.allowlist)
         except KeyError:
@@ -164,7 +165,7 @@ class AllowListRequirements(AllowListProject):
 class AllowListRelease(FilterReleasePlugin):
     name = "allowlist_release"
     # Requires iterable default
-    allowlist_package_names: List[Requirement] = []
+    allowlist_package_names: list[Requirement] = []
 
     def initialize_plugin(self) -> None:
         """
@@ -182,7 +183,7 @@ class AllowListRelease(FilterReleasePlugin):
                 + f"{self.allowlist_release_requirements}"
             )
 
-    def _determine_filtered_package_requirements(self) -> List[Requirement]:
+    def _determine_filtered_package_requirements(self) -> list[Requirement]:
         """
         Parse the configuration file for
 
@@ -201,7 +202,7 @@ class AllowListRelease(FilterReleasePlugin):
             package_lines = []
         return list(_parse_package_lines(package_lines))
 
-    def filter(self, metadata: Dict) -> bool:
+    def filter(self, metadata: dict) -> bool:
         """
         Returns False if version fails the filter,
         i.e. doesn't matches an allowlist version specifier
@@ -251,7 +252,7 @@ class AllowListRelease(FilterReleasePlugin):
 class AllowListRequirementsPinned(AllowListRelease):
     name = "project_requirements_pinned"
 
-    def _determine_filtered_package_requirements(self) -> List[Requirement]:
+    def _determine_filtered_package_requirements(self) -> list[Requirement]:
         """
         Parse the configuration file for
         [allowlist]
@@ -264,7 +265,7 @@ class AllowListRequirementsPinned(AllowListRelease):
         list of packaging.requirements.Requirement
             For all PEP440 package specifiers
         """
-        filtered_requirements: Set[Requirement] = set()
+        filtered_requirements: set[Requirement] = set()
 
         try:
             filepaths = get_requirement_files(self.allowlist)

--- a/src/bandersnatch_filter_plugins/blocklist_name.py
+++ b/src/bandersnatch_filter_plugins/blocklist_name.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Any, Dict, List, Set
+from typing import Any
 
 from packaging.requirements import Requirement
 from packaging.utils import canonicalize_name
@@ -13,7 +13,7 @@ logger = logging.getLogger("bandersnatch")
 class BlockListProject(FilterProjectPlugin):
     name = "blocklist_project"
     # Requires iterable default
-    blocklist_package_names: List[str] = []
+    blocklist_package_names: list[str] = []
 
     def initialize_plugin(self) -> None:
         """
@@ -29,7 +29,7 @@ class BlockListProject(FilterProjectPlugin):
                 + f"{self.blocklist_package_names}"
             )
 
-    def _determine_filtered_package_names(self) -> List[str]:
+    def _determine_filtered_package_names(self) -> list[str]:
         """
         Return a list of package names to be filtered base on the configuration
         file.
@@ -38,7 +38,7 @@ class BlockListProject(FilterProjectPlugin):
         # configuration contains a PEP440 specifier it will be processed by the
         # blocklist release filter.  So we need to remove any packages that
         # are not applicable for this plugin.
-        filtered_packages: Set[str] = set()
+        filtered_packages: set[str] = set()
         try:
             lines = self.blocklist["packages"]
             package_lines = lines.split("\n")
@@ -62,7 +62,7 @@ class BlockListProject(FilterProjectPlugin):
         logger.debug("Project blocklist is %r", list(filtered_packages))
         return list(filtered_packages)
 
-    def filter(self, metadata: Dict) -> bool:
+    def filter(self, metadata: dict) -> bool:
         return not self.check_match(name=metadata["info"]["name"])
 
     def check_match(self, **kwargs: Any) -> bool:
@@ -94,7 +94,7 @@ class BlockListProject(FilterProjectPlugin):
 class BlockListRelease(FilterReleasePlugin):
     name = "blocklist_release"
     # Requires iterable default
-    blocklist_package_names: List[Requirement] = []
+    blocklist_package_names: list[Requirement] = []
 
     def initialize_plugin(self) -> None:
         """
@@ -112,7 +112,7 @@ class BlockListRelease(FilterReleasePlugin):
                 + f"{self.blocklist_release_requirements}"
             )
 
-    def _determine_filtered_package_requirements(self) -> List[Requirement]:
+    def _determine_filtered_package_requirements(self) -> list[Requirement]:
         """
         Parse the configuration file for [blocklist]packages
 
@@ -121,7 +121,7 @@ class BlockListRelease(FilterReleasePlugin):
         list of packaging.requirements.Requirement
             For all PEP440 package specifiers
         """
-        filtered_requirements: Set[Requirement] = set()
+        filtered_requirements: set[Requirement] = set()
         try:
             lines = self.blocklist["packages"]
             package_lines = lines.split("\n")
@@ -137,7 +137,7 @@ class BlockListRelease(FilterReleasePlugin):
             filtered_requirements.add(requirement)
         return list(filtered_requirements)
 
-    def filter(self, metadata: Dict) -> bool:
+    def filter(self, metadata: dict) -> bool:
         """
         Returns False if version fails the filter,
         i.e. matches a blocklist version specifier

--- a/src/bandersnatch_filter_plugins/encoding.py
+++ b/src/bandersnatch_filter_plugins/encoding.py
@@ -2,9 +2,8 @@ import codecs
 import locale
 import re
 import sys
-from typing import List, Tuple
 
-BOMS: List[Tuple[bytes, str]] = [
+BOMS: list[tuple[bytes, str]] = [
     (codecs.BOM_UTF8, "utf-8"),
     (codecs.BOM_UTF16, "utf-16"),
     (codecs.BOM_UTF16_BE, "utf-16-be"),

--- a/src/bandersnatch_filter_plugins/filename_name.py
+++ b/src/bandersnatch_filter_plugins/filename_name.py
@@ -1,5 +1,4 @@
 import logging
-from typing import Dict, List
 
 from bandersnatch.filter import FilterReleaseFilePlugin
 from bandersnatch.utils import parse_version
@@ -14,8 +13,8 @@ class ExcludePlatformFilter(FilterReleaseFilePlugin):
 
     name = "exclude_platform"
 
-    _patterns: List[str] = []
-    _packagetypes: List[str] = []
+    _patterns: list[str] = []
+    _packagetypes: list[str] = []
 
     _pythonversions = [
         "py2.4",
@@ -107,14 +106,14 @@ class ExcludePlatformFilter(FilterReleaseFilePlugin):
 
         logger.info(f"Initialized {self.name} plugin with {self._patterns!r}")
 
-    def filter(self, metadata: Dict) -> bool:
+    def filter(self, metadata: dict) -> bool:
         """
         Returns False if file matches any of the filename patterns
         """
         file = metadata["release_file"]
         return not self._check_match(file)
 
-    def _check_match(self, file_desc: Dict) -> bool:
+    def _check_match(self, file_desc: dict) -> bool:
         """
         Check if a release version matches any of the specified patterns.
 

--- a/src/bandersnatch_filter_plugins/latest_name.py
+++ b/src/bandersnatch_filter_plugins/latest_name.py
@@ -1,6 +1,6 @@
 import logging
+from collections.abc import Iterator
 from operator import itemgetter
-from typing import Dict, Iterator, Tuple
 
 from packaging.version import Version, parse
 
@@ -33,19 +33,19 @@ class LatestReleaseFilter(FilterReleasePlugin):
         if self.keep > 0:
             logger.info(f"Initialized latest releases plugin with keep={self.keep}")
 
-    def filter(self, metadata: Dict) -> bool:
+    def filter(self, metadata: dict) -> bool:
         """
         Returns False if version fails the filter, i.e. is not a latest/current release
         """
 
-        info: Dict = metadata["info"]
-        releases: Dict = metadata["releases"]
+        info: dict = metadata["info"]
+        releases: dict = metadata["releases"]
         version: str = metadata["version"]
 
         if self.keep == 0 or self.keep > len(releases):
             return True
 
-        versions_pair: Iterator[Tuple[Version, str]] = map(
+        versions_pair: Iterator[tuple[Version, str]] = map(
             lambda v: (parse(v), v), releases.keys()
         )
         # Sort all versions

--- a/src/bandersnatch_filter_plugins/metadata_filter.py
+++ b/src/bandersnatch_filter_plugins/metadata_filter.py
@@ -1,7 +1,7 @@
 import logging
 import re
 from configparser import SectionProxy
-from typing import Any, Dict, List
+from typing import Any
 
 from humanfriendly import InvalidSize, parse_size
 from packaging.specifiers import SpecifierSet
@@ -27,7 +27,7 @@ class RegexFilter(Filter):
     match_patterns = "any"
     nulls_match = True
     initialized = False
-    patterns: Dict = {}
+    patterns: dict = {}
 
     def initialize_plugin(self) -> None:
         """
@@ -50,7 +50,7 @@ class RegexFilter(Filter):
                 logger.info(f"Initialized {self.name} plugin with {self.patterns}")
                 self.initialized = True
 
-    def filter(self, metadata: Dict) -> bool:
+    def filter(self, metadata: dict) -> bool:
         """
         Filter out all projects that don't match the specified metadata patterns.
         """
@@ -61,7 +61,7 @@ class RegexFilter(Filter):
         # Walk through keys of patterns dict and return True iff all match
         return all(self._match_node_at_path(k, metadata) for k in self.patterns)
 
-    def _match_node_at_path(self, key: str, metadata: Dict) -> bool:
+    def _match_node_at_path(self, key: str, metadata: dict) -> bool:
         # Grab any tags prepended to key
         tags = key.split(":")
 
@@ -98,7 +98,7 @@ class RegexFilter(Filter):
             return self._match_any_patterns(key, node, nulls_match=nulls_match)
 
     # TODO: Add unittest and cleanup code + fix typing
-    def _find_element_by_dotted_path(self, path: str, metadata: Dict) -> List:
+    def _find_element_by_dotted_path(self, path: str, metadata: dict) -> list:
         # Walk our metadata structure following dotted path.
         split_path = path.split(".")
         node = metadata
@@ -113,7 +113,7 @@ class RegexFilter(Filter):
             return [node]
 
     def _match_any_patterns(
-        self, key: str, values: List[str], nulls_match: bool = True
+        self, key: str, values: list[str], nulls_match: bool = True
     ) -> bool:
         results = []
         for pattern in self.patterns[key]:
@@ -125,7 +125,7 @@ class RegexFilter(Filter):
         return any(results)
 
     def _match_all_patterns(
-        self, key: str, values: List[str], nulls_match: bool = True
+        self, key: str, values: list[str], nulls_match: bool = True
     ) -> bool:
         results = []
         for pattern in self.patterns[key]:
@@ -136,7 +136,7 @@ class RegexFilter(Filter):
         return all(results)
 
     def _match_none_patterns(
-        self, key: str, values: List[str], nulls_match: bool = True
+        self, key: str, values: list[str], nulls_match: bool = True
     ) -> bool:
         return not self._match_any_patterns(key, values)
 
@@ -151,12 +151,12 @@ class RegexProjectMetadataFilter(FilterMetadataPlugin, RegexFilter):
     match_patterns = "any"
     nulls_match = True
     initialized = False
-    patterns: Dict = {}
+    patterns: dict = {}
 
     def initilize_plugin(self) -> None:
         RegexFilter.initialize_plugin(self)
 
-    def filter(self, metadata: Dict) -> bool:
+    def filter(self, metadata: dict) -> bool:
         return RegexFilter.filter(self, metadata)
 
 
@@ -170,12 +170,12 @@ class RegexReleaseFileMetadataFilter(FilterReleaseFilePlugin, RegexFilter):
     match_patterns = "any"
     nulls_match = True
     initialized = False
-    patterns: Dict = {}
+    patterns: dict = {}
 
     def initilize_plugin(self) -> None:
         RegexFilter.initialize_plugin(self)
 
-    def filter(self, metadata: Dict) -> bool:
+    def filter(self, metadata: dict) -> bool:
         return RegexFilter.filter(self, metadata)
 
 
@@ -188,7 +188,7 @@ class SizeProjectMetadataFilter(FilterMetadataPlugin, AllowListProject):
     name = "size_project_metadata"
     initialized = False
     max_package_size: int = 0
-    allowlist_package_names: List[str] = []
+    allowlist_package_names: list[str] = []
 
     def initialize_plugin(self) -> None:
         """
@@ -232,7 +232,7 @@ class SizeProjectMetadataFilter(FilterMetadataPlugin, AllowListProject):
 
             self.initialized = True
 
-    def filter(self, metadata: Dict) -> bool:
+    def filter(self, metadata: dict) -> bool:
         """
         Return False for projects with metadata indicating
         total file sizes greater than threshold.
@@ -261,7 +261,7 @@ class VersionRangeFilter(Filter):
 
     name = "version_range_filter"
     initialized = False
-    specifiers: Dict = {}
+    specifiers: dict = {}
     nulls_match = True
 
     def initialize_plugin(self) -> None:
@@ -286,7 +286,7 @@ class VersionRangeFilter(Filter):
                 )
                 self.initialized = True
 
-    def filter(self, metadata: Dict) -> bool:
+    def filter(self, metadata: dict) -> bool:
         """
         Return False for input not having metadata
         entries matching the specified version specifier.
@@ -298,7 +298,7 @@ class VersionRangeFilter(Filter):
 
         return all(self._match_node_at_path(k, metadata) for k in self.specifiers)
 
-    def _find_element_by_dotted_path(self, path: str, metadata: Dict) -> Any:
+    def _find_element_by_dotted_path(self, path: str, metadata: dict) -> Any:
         # Walk our metadata structure following dotted path.
         split_path = path.split(".")
         node = metadata
@@ -310,7 +310,7 @@ class VersionRangeFilter(Filter):
 
         return node
 
-    def _match_node_at_path(self, key: str, metadata: Dict) -> bool:
+    def _match_node_at_path(self, key: str, metadata: dict) -> bool:
         # Grab any tags prepended to key
         tags = key.split(":")
 
@@ -356,7 +356,7 @@ class VersionRangeProjectMetadataFilter(FilterMetadataPlugin, VersionRangeFilter
 
     name = "version_range_project_metadata"
     initialized = False
-    specifiers: Dict = {}
+    specifiers: dict = {}
     nulls_match = True
 
     def initialize_plugin(self) -> None:
@@ -376,7 +376,7 @@ class VersionRangeReleaseFileMetadataFilter(
 
     name = "version_range_release_file_metadata"
     initialized = False
-    specifiers: Dict = {}
+    specifiers: dict = {}
     nulls_match = True
 
     def initialize_plugin(self) -> None:

--- a/src/bandersnatch_filter_plugins/prerelease_name.py
+++ b/src/bandersnatch_filter_plugins/prerelease_name.py
@@ -1,6 +1,6 @@
 import logging
 import re
-from typing import Dict, List, Pattern
+from re import Pattern
 
 from packaging.utils import canonicalize_name
 
@@ -21,8 +21,8 @@ class PreReleaseFilter(FilterReleasePlugin):
         r".+b(eta)?\d+$",
         r".+dev\d+$",
     )
-    patterns: List[Pattern] = []
-    package_names: List[str] = []
+    patterns: list[Pattern] = []
+    package_names: list[str] = []
 
     def initialize_plugin(self) -> None:
         """
@@ -50,7 +50,7 @@ class PreReleaseFilter(FilterReleasePlugin):
                 + f"{self.package_names if self.package_names else 'all packages'}"
             )
 
-    def filter(self, metadata: Dict) -> bool:
+    def filter(self, metadata: dict) -> bool:
         """
         Returns False if version fails the filter, i.e. follows a prerelease pattern
         """

--- a/src/bandersnatch_filter_plugins/regex_name.py
+++ b/src/bandersnatch_filter_plugins/regex_name.py
@@ -1,6 +1,7 @@
 import logging
 import re
-from typing import Any, Dict, List, Pattern
+from re import Pattern
+from typing import Any
 
 from bandersnatch.filter import FilterProjectPlugin, FilterReleasePlugin
 
@@ -14,7 +15,7 @@ class RegexReleaseFilter(FilterReleasePlugin):
 
     name = "regex_release"
     # Has to be iterable to ensure it works with any()
-    patterns: List[Pattern] = []
+    patterns: list[Pattern] = []
 
     def initialize_plugin(self) -> None:
         """
@@ -34,7 +35,7 @@ class RegexReleaseFilter(FilterReleasePlugin):
 
                 logger.info(f"Initialized regex release plugin with {self.patterns}")
 
-    def filter(self, metadata: Dict) -> bool:
+    def filter(self, metadata: dict) -> bool:
         """
         Returns False if version fails the filter, i.e. follows a regex pattern
         """
@@ -49,7 +50,7 @@ class RegexProjectFilter(FilterProjectPlugin):
 
     name = "regex_project"
     # Has to be iterable to ensure it works with any()
-    patterns: List[Pattern] = []
+    patterns: list[Pattern] = []
 
     def initialize_plugin(self) -> None:
         """
@@ -68,7 +69,7 @@ class RegexProjectFilter(FilterProjectPlugin):
 
                 logger.info(f"Initialized regex release plugin with {self.patterns}")
 
-    def filter(self, metadata: Dict) -> bool:
+    def filter(self, metadata: dict) -> bool:
         return not self.check_match(name=metadata["info"]["name"])
 
     def check_match(self, **kwargs: Any) -> bool:

--- a/src/bandersnatch_storage_plugins/filesystem.py
+++ b/src/bandersnatch_storage_plugins/filesystem.py
@@ -7,7 +7,8 @@ import os
 import pathlib
 import shutil
 import tempfile
-from typing import IO, Any, Generator, List, Optional, Type, Union
+from collections.abc import Generator
+from typing import IO, Any
 
 import filelock
 
@@ -18,12 +19,12 @@ logger = logging.getLogger("bandersnatch")
 
 class FilesystemStorage(StoragePlugin):
     name = "filesystem"
-    PATH_BACKEND: Type[pathlib.Path] = pathlib.Path
+    PATH_BACKEND: type[pathlib.Path] = pathlib.Path
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
-    def get_lock(self, path: Optional[str] = None) -> filelock.FileLock:
+    def get_lock(self, path: str | None = None) -> filelock.FileLock:
         """
         Retrieve the appropriate `FileLock` backend for this storage plugin
 
@@ -36,11 +37,11 @@ class FilesystemStorage(StoragePlugin):
         logger.debug(f"Retrieving FileLock instance @ {path}")
         return filelock.FileLock(path)
 
-    def walk(self, root: PATH_TYPES, dirs: bool = True) -> List[pathlib.Path]:
+    def walk(self, root: PATH_TYPES, dirs: bool = True) -> list[pathlib.Path]:
         if not isinstance(root, pathlib.Path):
             root = pathlib.Path(str(root))
 
-        results: List[pathlib.Path] = []
+        results: list[pathlib.Path] = []
         for pth in root.iterdir():
             if pth.is_dir():
                 if dirs:
@@ -140,7 +141,7 @@ class FilesystemStorage(StoragePlugin):
         shutil.move(str(source), dest)
         return
 
-    def write_file(self, path: PATH_TYPES, contents: Union[str, bytes]) -> None:
+    def write_file(self, path: PATH_TYPES, contents: str | bytes) -> None:
         """Write data to the provided path.  If **contents** is a string, the file will
         be opened and written in "r" + "utf-8" mode, if bytes are supplied it will be
         accessed using "rb" mode (i.e. binary write)."""
@@ -171,12 +172,12 @@ class FilesystemStorage(StoragePlugin):
         path: PATH_TYPES,
         text: bool = True,
         encoding: str = "utf-8",
-        errors: Optional[str] = None,
-    ) -> Union[str, bytes]:
+        errors: str | None = None,
+    ) -> str | bytes:
         """Return the contents of the requested file, either a bytestring or a unicode
         string depending on whether **text** is True"""
         with self.open_file(path, text=text, encoding=encoding) as fh:
-            contents: Union[str, bytes] = fh.read()
+            contents: str | bytes = fh.read()
         return contents
 
     def delete_file(self, path: PATH_TYPES, dry_run: bool = False) -> int:

--- a/src/bandersnatch_storage_plugins/s3.py
+++ b/src/bandersnatch_storage_plugins/s3.py
@@ -8,8 +8,9 @@ import logging
 import os
 import pathlib
 import tempfile
+from collections.abc import Generator, Iterator
 from fnmatch import fnmatch
-from typing import IO, Any, Generator, Iterator
+from typing import IO, Any
 
 import boto3
 import filelock

--- a/src/runner.py
+++ b/src/runner.py
@@ -8,10 +8,9 @@ import sys
 from datetime import datetime
 from subprocess import CalledProcessError, run
 from time import sleep, time
-from typing import List
 
 
-def parseHourList(time_str: str) -> List[int]:
+def parseHourList(time_str: str) -> list[int]:
     m = re.match(r"(\d+)(?:-(\d+))?$", time_str)
     if not m:
         raise argparse.ArgumentTypeError(


### PR DESCRIPTION
- Update setup.cfg + `__init__.py`
- Update actions to only run >= 3.10
- Update pre-commit running pyupgrade to `--py310-plus`
  - Let pyupgrade change a lot of syntax
  - Fix no longer needed imports
  - Fix new found mypy error - e.g. swift subclass method wrong signature
- Remove some deprecated methods etc.
  - Move to importlib.resources.files in configuration.py + test_configuration.py
  - Move a socks proxy text into an `async def` to make aiohttp happy

Test:
- Run pre-commit for `pyupgrade + mypy`
  - `/tmp/tb/bin/pre-commit run -a`
- `/tmp/tb/bin/tox`