### PR TITLE
Add support for py[23] filename filtering

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,10 @@
 
 - Move to >= 3.10 project `PR #1457`
 
+## Bug Fixes
+
+- Support `py2` + `py3` bdist file name filtering `PR #1495`
+
 # 6.3.0
 
 ## Bug Fixes

--- a/src/bandersnatch/tests/plugins/test_filename.py
+++ b/src/bandersnatch/tests/plugins/test_filename.py
@@ -40,6 +40,7 @@ platforms =
     freebsd
     macos
     linux_armv7l
+    py3
     py3.5
     py3.7
     py3.9
@@ -134,6 +135,11 @@ platforms =
                     {
                         "packagetype": "bdist_wheel",
                         "filename": "foobar-0.1-win32.whl",
+                        "flag": "DROP",
+                    },
+                    {
+                        "packagetype": "bdist_wheel",
+                        "filename": "foobar-0.1-py3-none-any.whl",
                         "flag": "DROP",
                     },
                 ],

--- a/src/bandersnatch_filter_plugins/filename_name.py
+++ b/src/bandersnatch_filter_plugins/filename_name.py
@@ -17,10 +17,12 @@ class ExcludePlatformFilter(FilterReleaseFilePlugin):
     _packagetypes: list[str] = []
 
     _pythonversions = [
+        "py2",
         "py2.4",
         "py2.5",
         "py2.6",
         "py2.7",
+        "py3",
         "py3.0",
         "py3.1",
         "py3.2",
@@ -32,6 +34,8 @@ class ExcludePlatformFilter(FilterReleaseFilePlugin):
         "py3.8",
         "py3.9",
         "py3.10",
+        "py3.11",
+        "py3.12",
     ]
 
     _windowsPlatformTypes = [".win32", "-win32", "win_amd64", "win-amd64"]


### PR DESCRIPTION
- Seems the original author had no support for py2 and py3 release filename filtering
- Lets add in support
  - Plus add unit test

Testing:
- Ran locally with setuptools only + filtered via `denylist` all py3 bdist releases
  - `/tmp/tb/bin/bandersnatch -c /tmp/bandersnatch.conf --debug mirror`
  - No longer see any **-py3-** only wheels via `find /tmp/pypi/web/ | grep '\.whl' | grep '\-py3\-'`

Fixes #1494