### PR TITLE
#1433 improve release filtering by adding time based option

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+# 6.5.0
+
+## New Features
+
+- Add option to filter releases based on upload time `PR #1594`
+
 # 6.4.0
 
 - Move JSON Simple API to version 1.1 (as per PEP700) `PR #1557`

--- a/docs/filtering_configuration.md
+++ b/docs/filtering_configuration.md
@@ -237,9 +237,12 @@ enabled =
 
 [latest_release]
 keep = 3
+sort_by = [version/time]
 ```
 
 By default, the plugin does not filter out any release. You have to add the `keep` setting.
+The default is to sort by `version` number (parsed according to semantic versioning).
+As an alternative, `time` can be used to sort releases chronologically by upload time and select the last `keep` ones.
 
 You should be aware that it can break requirements. Prereleases are also kept.
 

--- a/docs/filtering_configuration.md
+++ b/docs/filtering_configuration.md
@@ -241,7 +241,7 @@ enabled =
 
 [latest_release]
 keep = 3
-sort_by = [version/time]
+sort_by = [version|time]
 ```
 
 By default, the plugin does not filter out any release. You have to add the `keep` setting.

--- a/src/bandersnatch/tests/plugins/test_latest_release.py
+++ b/src/bandersnatch/tests/plugins/test_latest_release.py
@@ -74,6 +74,30 @@ keep = 2
 
         assert pkg.releases == {"1.1.3": {}, "2.0.0": {}}
 
+    def test_latest_releases_keep_latest_time(self) -> None:
+        mock_config(self.config_contents + "\nsort_by = time")
+
+        mirror = BandersnatchMirror(Path("."), Master(url="https://foo.bar.com"))
+        pkg = Package("foo", 1)
+        pkg._metadata = {
+            "info": {"name": "foo", "version": "2.0.0"},
+            "releases": {
+                "1.0.0": [{"upload_time_iso_8601": "2013-10-01T15:24:37.255645Z"}],
+                "1.1.0": [{"upload_time_iso_8601": "2014-10-01T15:24:37.255645Z"}],
+                "1.1.1": [{"upload_time_iso_8601": "2015-10-01T15:24:37.255645Z"}],
+                "1.1.1d": [{"upload_time_iso_8601": "2020-10-01T15:24:37.255645Z"}],
+                "1.1.2": [{"upload_time_iso_8601": "2016-10-01T15:24:37.255645Z"}],
+                "1.1.3": [{"upload_time_iso_8601": "2017-10-01T15:24:37.255645Z"}],
+                "2.0.0": [{"upload_time_iso_8601": "2018-10-01T15:24:37.255645Z"}],
+            },
+        }
+
+        pkg.filter_all_releases(mirror.filters.filter_release_plugins())
+
+        assert pkg.releases == {"1.1.1d": [{"upload_time_iso_8601": "2020-10-01T15:24:37.255645Z"}],
+                                "2.0.0": [{"upload_time_iso_8601": "2018-10-01T15:24:37.255645Z"}]}
+
+
     def test_latest_releases_keep_stable(self) -> None:
         mock_config(self.config_contents)
 

--- a/src/bandersnatch/tests/plugins/test_latest_release.py
+++ b/src/bandersnatch/tests/plugins/test_latest_release.py
@@ -94,9 +94,10 @@ keep = 2
 
         pkg.filter_all_releases(mirror.filters.filter_release_plugins())
 
-        assert pkg.releases == {"1.1.1d": [{"upload_time_iso_8601": "2020-10-01T15:24:37.255645Z"}],
-                                "2.0.0": [{"upload_time_iso_8601": "2018-10-01T15:24:37.255645Z"}]}
-
+        assert pkg.releases == {
+            "1.1.1d": [{"upload_time_iso_8601": "2020-10-01T15:24:37.255645Z"}],
+            "2.0.0": [{"upload_time_iso_8601": "2018-10-01T15:24:37.255645Z"}],
+        }
 
     def test_latest_releases_keep_stable(self) -> None:
         mock_config(self.config_contents)

--- a/src/bandersnatch_filter_plugins/latest_name.py
+++ b/src/bandersnatch_filter_plugins/latest_name.py
@@ -38,6 +38,10 @@ class LatestReleaseFilter(FilterReleasePlugin):
             sort_by = self.configuration["latest_release"]["sort_by"]
             if sort_by in ["time", "version"]:
                 self.sort_by = sort_by
+            else:
+                logger.debug(
+                    "sort_by only allows 'time' and 'version', and not '{}'".format(sort_by)
+                )
             logger.info(
                 f"Initialized latest releases plugin with sort_by={self.sort_by}"
             )

--- a/src/bandersnatch_filter_plugins/latest_name.py
+++ b/src/bandersnatch_filter_plugins/latest_name.py
@@ -40,7 +40,9 @@ class LatestReleaseFilter(FilterReleasePlugin):
                 self.sort_by = sort_by
             else:
                 logger.debug(
-                    "sort_by only allows 'time' and 'version', and not '{}'".format(sort_by)
+                    "sort_by only allows 'time' and 'version', and not '{}'".format(
+                        sort_by
+                    )
                 )
             logger.info(
                 f"Initialized latest releases plugin with sort_by={self.sort_by}"

--- a/src/bandersnatch_filter_plugins/latest_name.py
+++ b/src/bandersnatch_filter_plugins/latest_name.py
@@ -49,8 +49,6 @@ class LatestReleaseFilter(FilterReleasePlugin):
             )
         except KeyError:
             return
-        except ValueError:
-            return
 
     def filter(self, metadata: dict) -> bool:
         """

--- a/src/bandersnatch_filter_plugins/latest_name.py
+++ b/src/bandersnatch_filter_plugins/latest_name.py
@@ -38,7 +38,9 @@ class LatestReleaseFilter(FilterReleasePlugin):
             sort_by = self.configuration["latest_release"]["sort_by"]
             if sort_by in ["time", "version"]:
                 self.sort_by = sort_by
-            logger.info(f"Initialized latest releases plugin with sort_by={self.sort_by}")
+            logger.info(
+                f"Initialized latest releases plugin with sort_by={self.sort_by}"
+            )
         except KeyError:
             return
         except ValueError:

--- a/src/bandersnatch_filter_plugins/latest_name.py
+++ b/src/bandersnatch_filter_plugins/latest_name.py
@@ -16,6 +16,7 @@ class LatestReleaseFilter(FilterReleasePlugin):
 
     name = "latest_release"
     keep = 0  # by default, keep 'em all
+    sort_by = "version"  # by default, sort by parsed version string, time (of release) is the other option
 
     def initialize_plugin(self) -> None:
         """
@@ -32,6 +33,15 @@ class LatestReleaseFilter(FilterReleasePlugin):
             return
         if self.keep > 0:
             logger.info(f"Initialized latest releases plugin with keep={self.keep}")
+        try:
+            sort_by = self.configuration["latest_release"]["sort_by"]
+            if sort_by in ["time", "version"]:
+                self.sort_by = sort_by
+            logger.info(f"Initialized latest releases plugin with sort_by={self.sort_by}")
+        except KeyError:
+            return
+        except ValueError:
+            return
 
     def filter(self, metadata: dict) -> bool:
         """
@@ -45,15 +55,20 @@ class LatestReleaseFilter(FilterReleasePlugin):
         if self.keep == 0 or self.keep > len(releases):
             return True
 
-        versions_pair: Iterator[tuple[Version, str]] = map(
-            lambda v: (parse(v), v), releases.keys()
-        )
-        # Sort all versions
-        versions_sorted = sorted(versions_pair, reverse=True)
+        getter_index = 1
+        if self.sort_by == "time":
+            getter_index = 0
+            versions_sorted = sorted(releases.items(), key=lambda x: x[1][0]['upload_time_iso_8601'], reverse=True)
+        else:
+            versions_pair: Iterator[tuple[Version, str]] = map(
+                lambda v: (parse(v), v), releases.keys()
+            )
+            # Sort all versions
+            versions_sorted = sorted(versions_pair, reverse=True)
         # Select the first few (larger) items
         versions_allowed = versions_sorted[: self.keep]
         # Collect string versions back into a list
-        version_names = list(map(itemgetter(1), versions_allowed))
+        version_names = list(map(itemgetter(getter_index), versions_allowed))
 
         # Add back latest version if necessary
         if info.get("version") not in version_names:

--- a/src/bandersnatch_filter_plugins/latest_name.py
+++ b/src/bandersnatch_filter_plugins/latest_name.py
@@ -16,7 +16,8 @@ class LatestReleaseFilter(FilterReleasePlugin):
 
     name = "latest_release"
     keep = 0  # by default, keep 'em all
-    sort_by = "version"  # by default, sort by parsed version string, time (of release) is the other option
+    # by default, sort by parsed version string, time (of release) is the other option
+    sort_by = "version"
 
     def initialize_plugin(self) -> None:
         """
@@ -58,7 +59,11 @@ class LatestReleaseFilter(FilterReleasePlugin):
         getter_index = 1
         if self.sort_by == "time":
             getter_index = 0
-            versions_sorted = sorted(releases.items(), key=lambda x: x[1][0]['upload_time_iso_8601'], reverse=True)
+            versions_sorted = sorted(
+                releases.items(),
+                key=lambda x: x[1][0]["upload_time_iso_8601"],
+                reverse=True,
+            )
         else:
             versions_pair: Iterator[tuple[Version, str]] = map(
                 lambda v: (parse(v), v), releases.keys()


### PR DESCRIPTION
Time based sorting can be used by setting `sort_by = time` together with `keep`

```
[latest_release]
keep = 3
sort_by = time
```
implements https://github.com/pypa/bandersnatch/issues/1433