### PR TITLE
Latest and version pinning clash

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+# 6.5.0
+
+- `project_requirements_pinned` with a pinned version (range) disables additional release filter for this package `PR #1601`
+
 # 6.4.0
 
 - Move JSON Simple API to version 1.1 (as per PEP700) `PR #1557`

--- a/docs/filtering_configuration.md
+++ b/docs/filtering_configuration.md
@@ -13,6 +13,10 @@ converted.
 E.g. to Blocklist [discord.py](https://pypi.org/project/discord.py/) the string 'discord-py'
 is correct, but 'discord.PY' will also work.
 
+Plugins for release version filtering usually act in a way, that releases are only downloaded if all filter plugin rules are satisfied.
+An exception to this rule is the `project_requirements_pinned` filter: if there is a version number/range specified no other filter are applied.
+This allows smaller mirrors with newest versions and specifically needed ones.
+
 ## Plugins Enabling
 
 The plugins setting is a list of plugins to enable.

--- a/src/bandersnatch/filter.py
+++ b/src/bandersnatch/filter.py
@@ -66,6 +66,17 @@ class Filter:
         # and check_match methods that are called in the fast path.
         pass
 
+    def pinned_version_exists(self, metadata: dict) -> bool:
+        """
+        Check if version specifier exist.
+
+        Returns
+        =======
+        bool:
+            True if version specifier exist, False otherwise
+        """
+        return False
+
     def filter(self, metadata: dict) -> bool:
         """
         Check if the plugin matches based on the package's metadata.

--- a/src/bandersnatch/package.py
+++ b/src/bandersnatch/package.py
@@ -1,6 +1,5 @@
 import asyncio
 import logging
-#import copy
 from typing import TYPE_CHECKING, Any
 
 from packaging.utils import canonicalize_name
@@ -108,11 +107,8 @@ class Package:
                 if plugin.pinned_version_exists(release_data):
                     pinned_version = True
                     break
-        #filters = copy.deepcopy(release_filters)
         if pinned_version:
-            #pinned_filter = filters[pinned_plugin]
             pinned_filter = release_filters[pinned_plugin]
-            #del filters[pinned_plugin]
             for version in releases:
                 release_data = {
                     "version": version,
@@ -122,14 +118,12 @@ class Package:
                 if not pinned_filter.filter(release_data):
                     del self.releases[version]
         else:
-            releases = list(self.releases.keys())
             for version in releases:
                 release_data = {
                     "version": version,
                     "releases": self.releases,
                     "info": self.info,
                 }
-                #if not all(plugin.filter(release_data) for plugin in filters):
                 if not all(plugin.filter(release_data) for plugin in release_filters):
                     del self.releases[version]
         if releases:

--- a/src/bandersnatch/package.py
+++ b/src/bandersnatch/package.py
@@ -103,7 +103,7 @@ class Package:
         pinned_plugin = -1
         for plugin in release_filters:
             pinned_plugin += 1
-            if plugin.name == 'project_requirements_pinned':
+            if plugin.name == "project_requirements_pinned":
                 if plugin.pinned_version_exists(release_data):
                     pinned_version = True
                     break

--- a/src/bandersnatch/tests/plugins/test_allowlist_name.py
+++ b/src/bandersnatch/tests/plugins/test_allowlist_name.py
@@ -409,15 +409,12 @@ requirements =
     def test__filter__matches__release_latest(self) -> None:
         with open(Path(self.tempdir.name) / "requirements.txt", "w") as fh:
             fh.write("""\
-#    This is needed for workshop 1
-#
 foo==1.2.0             # via -r requirements.in
 """)
 
         mock_config(f"""\
 [mirror]
 storage-backend = filesystem
-workers = 2
 
 [plugins]
 enabled =

--- a/src/bandersnatch/tests/plugins/test_allowlist_name.py
+++ b/src/bandersnatch/tests/plugins/test_allowlist_name.py
@@ -406,6 +406,43 @@ requirements =
 
         self.assertEqual({"1.2.0": {}}, pkg.releases)
 
+    def test__filter__matches__release_latest(self) -> None:
+        with open(Path(self.tempdir.name) / "requirements.txt", "w") as fh:
+            fh.write("""\
+#    This is needed for workshop 1
+#
+foo==1.2.0             # via -r requirements.in
+""")
+
+        mock_config(f"""\
+[mirror]
+storage-backend = filesystem
+workers = 2
+
+[plugins]
+enabled =
+    project_requirements
+    project_requirements_pinned
+    latest_release
+[latest_release]
+keep = 2
+[allowlist]
+requirements_path = {self.tempdir.name}
+requirements =
+    requirements.txt
+""")
+
+        mirror = BandersnatchMirror(Path("."), Master(url="https://foo.bar.com"))
+        pkg = Package("foo", 1)
+        pkg._metadata = {
+            "info": {"name": "foo"},
+            "releases": {"1.2.0": {}, "1.2.1": {}, "1.2.2": {}},
+        }
+
+        pkg.filter_all_releases(mirror.filters.filter_release_plugins())
+
+        self.assertEqual({"1.2.0": {}}, pkg.releases)
+
     def test__filter__find_files(self) -> None:
         absolute_file_path = Path(self.tempdir.name) / "requirements.txt"
         with open(absolute_file_path, "w") as fh:

--- a/src/bandersnatch_filter_plugins/allowlist_name.py
+++ b/src/bandersnatch_filter_plugins/allowlist_name.py
@@ -207,10 +207,7 @@ class AllowListRelease(FilterReleasePlugin):
         for requirement in self.allowlist_release_requirements:
             if name != requirement.name:
                 continue
-            elif len(requirement.specifier) > 0:
-                return True
-            else:
-                return False
+            return len(requirement.specifier) > 0
         return False
 
     def filter(self, metadata: dict) -> bool:

--- a/src/bandersnatch_filter_plugins/allowlist_name.py
+++ b/src/bandersnatch_filter_plugins/allowlist_name.py
@@ -212,6 +212,7 @@ class AllowListRelease(FilterReleasePlugin):
             else:
                 return False
         return False
+
     def filter(self, metadata: dict) -> bool:
         """
         Returns False if version fails the filter,

--- a/src/bandersnatch_filter_plugins/allowlist_name.py
+++ b/src/bandersnatch_filter_plugins/allowlist_name.py
@@ -202,6 +202,16 @@ class AllowListRelease(FilterReleasePlugin):
             package_lines = []
         return list(_parse_package_lines(package_lines))
 
+    def pinned_version_exists(self, metadata: dict) -> bool:
+        name = canonicalize_name(metadata["info"]["name"])
+        for requirement in self.allowlist_release_requirements:
+            if name != requirement.name:
+                continue
+            elif len(requirement.specifier) > 0:
+                return True
+            else:
+                return False
+        return False
     def filter(self, metadata: dict) -> bool:
         """
         Returns False if version fails the filter,


### PR DESCRIPTION
Make sure that pinned versions defined with `project_requirements_pinned` plugins are downloaded by disabling additional filter if version (range) is specified.

implements https://github.com/pypa/bandersnatch/issues/1599