### PR TITLE
Add command options and documentation to Docker Compose

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,7 +4,7 @@
 
 - Add option to filter releases based on upload time `PR #1594`
 - `project_requirements_pinned` with a pinned version (range) disables additional release filter for this package `PR #1601`
-- Add command configuration for bandersnatch in Docker Compose, including 'mirror' default, 'verify' and 'once' options, improve documentation for docker compose, and added "Removing the Repository" section in Docker Compose README with a link in the main README. `PR #1645
+- Add command configuration for bandersnatch in Docker Compose, including 'mirror' default, 'verify' and 'once' options, improve documentation for docker compose, and added "Removing the Repository" section in Docker Compose README with a link in the main README. `PR #1645`
 
 # 6.4.0
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@
 
 - Add option to filter releases based on upload time `PR #1594`
 - `project_requirements_pinned` with a pinned version (range) disables additional release filter for this package `PR #1601`
+- Add command configuration for bandersnatch in Docker Compose, including 'mirror' default, 'verify' and 'once' options, improve documentation for docker compose, and added "Removing the Repository" section in Docker Compose README with a link in the main README. `PR #1645
 
 # 6.4.0
 

--- a/README.md
+++ b/README.md
@@ -43,6 +43,10 @@ docker pull pypa/bandersnatch
 docker run pypa/bandersnatch bandersnatch --help
 ```
 
+### Docker Compose
+
+Bandersnatch setup using docker-compose is available [here](https://github.com/benjisho/bandersnatch/tree/main/src/bandersnatch_docker_compose)
+
 ### pip
 
 This installs the latest stable, released version.

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ docker run pypa/bandersnatch bandersnatch --help
 
 ### Docker Compose
 
-Bandersnatch setup using docker-compose is available [here](https://github.com/benjisho/bandersnatch/tree/main/src/bandersnatch_docker_compose)
+Bandersnatch setup using docker-compose is available [here](https://github.com/pypa/bandersnatch/tree/main/src/bandersnatch_docker_compose)
 
 ### pip
 

--- a/src/bandersnatch_docker_compose/README.md
+++ b/src/bandersnatch_docker_compose/README.md
@@ -14,15 +14,40 @@ defined networks. But it might also happen that your network allows jumbo frames
 and then an MTU of 1500 is more like an artificial limitation. As stated, the
 example took an MTU of 800 to make sure.
 
+## Pull the Docker Image
+```bash
+docker pull pypa/bandersnatch:latest
+```
+
 ## Run (with docker-compose v2)
+```bash
+docker compose up -d
+```
 
-- `docker compose up -d`
+## Removing the Repository
 
+To remove the Bandersnatch repository that you've set up using Docker Compose, follow these steps. Please be aware that this process will delete all the packages and configuration files you have downloaded or created. Ensure you have backups if necessary.
+
+1. **Stop the Docker Containers**: Before removing any files, it's important to stop the running Docker containers to prevent any file corruption or data loss. Use the command:
+```bash
+docker compose down
+```
+
+2. **Remove the Packages and Configuration Files**: To delete all the downloaded packages and configuration files, run the following command. This will remove the `packages` and entire `config` directory directory inside your `config` folder, which contains all the mirrored Python packages.
+```bash
+rm -rf ./data/
+rm -rf ./config/
+```
+
+3. **Clean up Docker Artifacts**: Finally, to remove any Docker volumes, networks, or other artifacts that were created with the Docker Compose file, you can use the following command:
+```bash
+docker system prune --volumes
+```
 ## Caveats
 
 Watch out for your docker MTU settings. Changing the MTU of the daemon is not going to help (see issue #1271).
 Otherwise you might get error messages like these:
 
-```
+```bash
 ERROR: Call to list_packages_with_serial @ https://pypi.org/pypi timed out: Connection timeout to host https://pypi.org/pypi (master.py:218)
 ```

--- a/src/bandersnatch_docker_compose/README.md
+++ b/src/bandersnatch_docker_compose/README.md
@@ -15,16 +15,19 @@ and then an MTU of 1500 is more like an artificial limitation. As stated, the
 example took an MTU of 800 to make sure.
 
 ## Pull the Docker Image
+
 ```bash
 docker pull pypa/bandersnatch:latest
 ```
 
 ## Run (with docker-compose v2)
+
 ```bash
 docker compose up -d
 ```
 
 ## Watching live logs
+
 ```bash
 docker compose logs -f bandersnatch
 docker compose logs -f bandersnatch_nginx
@@ -35,20 +38,24 @@ docker compose logs -f bandersnatch_nginx
 To remove the Bandersnatch repository that you've set up using Docker Compose, follow these steps. Please be aware that this process will delete all the packages and configuration files you have downloaded or created. Ensure you have backups if necessary.
 
 1. **Stop the Docker Containers**: Before removing any files, it's important to stop the running Docker containers to prevent any file corruption or data loss. Use the command:
+
 ```bash
 docker compose down
 ```
 
 2. **Remove the Packages and Configuration Files**: To delete all the downloaded packages and configuration files, run the following command. This will remove the `packages` and entire `config` directory directory inside your `config` folder, which contains all the mirrored Python packages.
+
 ```bash
 rm -rf ./data/
 rm -rf ./config/
 ```
 
 3. **Clean up Docker Artifacts**: Finally, to remove any Docker volumes, networks, or other artifacts that were created with the Docker Compose file, you can use the following command:
+
 ```bash
 docker system prune --volumes
 ```
+
 ## Caveats
 
 Watch out for your docker MTU settings. Changing the MTU of the daemon is not going to help (see issue #1271).

--- a/src/bandersnatch_docker_compose/README.md
+++ b/src/bandersnatch_docker_compose/README.md
@@ -24,6 +24,12 @@ docker pull pypa/bandersnatch:latest
 docker compose up -d
 ```
 
+## Watching live logs
+```bash
+docker compose logs -f bandersnatch
+docker compose logs -f bandersnatch_nginx
+```
+
 ## Removing the Repository
 
 To remove the Bandersnatch repository that you've set up using Docker Compose, follow these steps. Please be aware that this process will delete all the packages and configuration files you have downloaded or created. Ensure you have backups if necessary.

--- a/src/bandersnatch_docker_compose/docker-compose.yml
+++ b/src/bandersnatch_docker_compose/docker-compose.yml
@@ -5,15 +5,24 @@ services:
     volumes:
       - "./config:/conf"  # Mount the local configuration directory to the container
       - "./data:/srv/pypi/web"  # Mount the local data directory where the mirror will be stored
-    command: bandersnatch mirror
-    # Uncomment the command you want to use:
-    # command: bandersnatch verify  # Verifies the integrity of the mirror
-    # command: bandersnatch once    # Runs the mirror operation once and then exits
-
-      # Default command is 'mirror', which synchronizes the mirror with PyPI
-      # You can append additional flags to customize the 'mirror' behavior:
-      # "--force-check" to force a recheck of all packages
-      # "--delete-packages" to remove packages that have been deleted from PyPI
+    # To run bandersnatch in mirror mode.
+    # It will mirror all the packages in the mirror list of the config file.
+    command: bandersnatch mirror --config-file /conf/bandersnatch.conf
+    # To run bandersnatch in --force mode, uncomment the following line.
+    # It will delete all packages that are not in the mirror list.
+    # command: bandersnatch mirror --config-file /conf/bandersnatch.conf --force
+    # To run bandersnatch in --debug mode, uncomment the following line.
+    # It will print out all the debug messages. This is useful for debugging.
+    # command: bandersnatch mirror --config-file /conf/bandersnatch.conf --debug
+    # To run bandersnatch in --verbose mode, uncomment the following line.
+    # It will print out all the verbose messages. This is useful for debugging.
+    # command: bandersnatch mirror --config-file /conf/bandersnatch.conf --verbose
+    # To run bandersnatch in verify mode, uncomment the following line.
+    # It will verify all the packages in the mirror list and delete the ones that are not in the list anymore.
+    # command: bandersnatch verify --config-file /conf/bandersnatch.conf
+    # To run bandersnatch in once mode, uncomment the following line.
+    # It will run bandersnatch once and exit. This is useful for testing.
+    # command: bandersnatch once --config-file /conf/bandersnatch.conf
     networks:
       - bandersnatch_net  # Connects the service to the custom bridge network
 

--- a/src/bandersnatch_docker_compose/docker-compose.yml
+++ b/src/bandersnatch_docker_compose/docker-compose.yml
@@ -1,18 +1,31 @@
 services:
+  # The bandersnatch service configuration
   bandersnatch:
-    image: pypa/bandersnatch:latest
+    image: pypa/bandersnatch:latest  # Use the latest version of bandersnatch
     volumes:
-      - "./config:/conf"
-      - "./data:/srv/pypi/web"
+      - "./config:/conf"  # Mount the local configuration directory to the container
+      - "./data:/srv/pypi/web"  # Mount the local data directory where the mirror will be stored
+    command: bandersnatch mirror
+    # Uncomment the command you want to use:
+    # command: bandersnatch verify  # Verifies the integrity of the mirror
+    # command: bandersnatch once    # Runs the mirror operation once and then exits
+
+      # Default command is 'mirror', which synchronizes the mirror with PyPI
+      # You can append additional flags to customize the 'mirror' behavior:
+      # "--force-check" to force a recheck of all packages
+      # "--delete-packages" to remove packages that have been deleted from PyPI
     networks:
-      - bandersnatch_net
+      - bandersnatch_net  # Connects the service to the custom bridge network
+
+  # The nginx service configuration for serving the mirror
   bandersnatch_nginx:
     image: bandersnatch_nginx
+    # If the image not built yet, it will be built from the nginx image from the Dockerfile in the current directory
     build: .
     volumes:
-      - "./data:/data/pypi/web:ro"
+      - "./data:/data/pypi/web:ro"  # Mount the data directory as read-only for nginx
     ports:
-      - "40080:80"
+      - "40080:80"  # Map port 40080 on the host to port 80 in the container
     networks:
       - bandersnatch_net
 


### PR DESCRIPTION
This PR introduces the command configuration for the bandersnatch service in Docker Compose setup. It includes the default 'mirror' command and adds commented options for 'verify' and 'once' to provide alternatives for running bandersnatch.

The 'command' section is now clearly documented, making it easier for developers and sysadmins to understand and modify the behavior of the bandersnatch service.

Changes:
- Added 'command' directive to bandersnatch service with the default 'mirror' option.
- Included comments explaining how to use the 'verify' and 'once' commands.
- Explained the purpose of additional flags for the 'mirror' command.
- Provided documentation for the build context of the bandersnatch_nginx image.