### PR TITLE
Add Command Options for Bandersnatch Service in Docker Compose and README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,9 @@ docker pull pypa/bandersnatch
 docker run pypa/bandersnatch bandersnatch --help
 ```
 
+### Docker Compose
+
+Bandersnatch setup using docker-compose is available [here](https://github.com/benjisho/bandersnatch/tree/main/src/bandersnatch_docker_compose)
 ### pip
 
 This installs the latest stable, released version.

--- a/src/bandersnatch_docker_compose/README.md
+++ b/src/bandersnatch_docker_compose/README.md
@@ -33,17 +33,13 @@ To remove the Bandersnatch repository that you've set up using Docker Compose, f
 docker compose down
 ```
 
-2. **Remove the Packages**: To delete all the downloaded packages, run the following command. This will remove the `packages` directory inside your `config` folder, which contains all the mirrored Python packages.
+2. **Remove the Packages and Configuration Files**: To delete all the downloaded packages and configuration files, run the following command. This will remove the `packages` and entire `config` directory directory inside your `config` folder, which contains all the mirrored Python packages.
 ```bash
 rm -rf ./data/
-```
-
-3. **Remove Configuration Files**: If you also wish to remove the configuration files for Bandersnatch, execute this command. It will delete the entire `config` directory, including your customized `bandersnatch.conf` file.
-```bash
 rm -rf ./config/
 ```
 
-4. **Clean up Docker Artifacts**: Finally, to remove any Docker volumes, networks, or other artifacts that were created with the Docker Compose file, you can use the following command:
+3. **Clean up Docker Artifacts**: Finally, to remove any Docker volumes, networks, or other artifacts that were created with the Docker Compose file, you can use the following command:
 ```bash
 docker system prune --volumes
 ```

--- a/src/bandersnatch_docker_compose/README.md
+++ b/src/bandersnatch_docker_compose/README.md
@@ -14,15 +14,44 @@ defined networks. But it might also happen that your network allows jumbo frames
 and then an MTU of 1500 is more like an artificial limitation. As stated, the
 example took an MTU of 800 to make sure.
 
+## Pull the Docker Image
+```bash
+docker pull pypa/bandersnatch:latest
+```
+
 ## Run (with docker-compose v2)
+```bash
+docker compose up -d
+```
 
-- `docker compose up -d`
+## Removing the Repository
 
+To remove the Bandersnatch repository that you've set up using Docker Compose, follow these steps. Please be aware that this process will delete all the packages and configuration files you have downloaded or created. Ensure you have backups if necessary.
+
+1. **Stop the Docker Containers**: Before removing any files, it's important to stop the running Docker containers to prevent any file corruption or data loss. Use the command:
+```bash
+docker compose down
+```
+
+2. **Remove the Packages**: To delete all the downloaded packages, run the following command. This will remove the `packages` directory inside your `config` folder, which contains all the mirrored Python packages.
+```bash
+rm -rf ./data/
+```
+
+3. **Remove Configuration Files**: If you also wish to remove the configuration files for Bandersnatch, execute this command. It will delete the entire `config` directory, including your customized `bandersnatch.conf` file.
+```bash
+rm -rf ./config/
+```
+
+4. **Clean up Docker Artifacts**: Finally, to remove any Docker volumes, networks, or other artifacts that were created with the Docker Compose file, you can use the following command:
+```bash
+docker system prune --volumes
+```
 ## Caveats
 
 Watch out for your docker MTU settings. Changing the MTU of the daemon is not going to help (see issue #1271).
 Otherwise you might get error messages like these:
 
-```
+```bash
 ERROR: Call to list_packages_with_serial @ https://pypi.org/pypi timed out: Connection timeout to host https://pypi.org/pypi (master.py:218)
 ```

--- a/src/bandersnatch_docker_compose/docker-compose.yml
+++ b/src/bandersnatch_docker_compose/docker-compose.yml
@@ -4,6 +4,24 @@ services:
     volumes:
       - "./config:/conf"
       - "./data:/srv/pypi/web"
+    # To run bandersnatch in mirror mode.
+    # It will mirror all the packages in the mirror list of the config file.
+    command: ["bandersnatch", "mirror", "--config-file", "/conf/bandersnatch.conf"]
+    # To run bandersnatch in --force mode, uncomment the following line.
+    # It will delete all packages that are not in the mirror list.
+    # command: ["bandersnatch", "mirror", "--config-file", "/conf/bandersnatch.conf", "--force"]
+    # To run bandersnatch in --debug mode, uncomment the following line.
+    # It will print out all the debug messages. This is useful for debugging.
+    # command: ["bandersnatch", "mirror", "--config-file", "/conf/bandersnatch.conf", "--debug"]
+    # To run bandersnatch in --verbose mode, uncomment the following line.
+    # It will print out all the verbose messages. This is useful for debugging.
+    # command: ["bandersnatch", "mirror", "--config-file", "/conf/bandersnatch.conf", "--verbose"]
+    # To run bandersnatch in verify mode, uncomment the following line.
+    # It will verify all the packages in the mirror list and delete the ones that are not in the list anymore.
+    # command: ["bandersnatch", "verify", "--config-file", "/conf/bandersnatch.conf"]
+    # To run bandersnatch in once mode, uncomment the following line.
+    # It will run bandersnatch once and exit. This is useful for testing.
+    # command: ["bandersnatch", "once", "--config-file", "/conf/bandersnatch.conf"]
     networks:
       - bandersnatch_net
   bandersnatch_nginx:


### PR DESCRIPTION
This PR adds multiple command options for the bandersnatch service in the docker-compose.yml file.
These options include mirror, force, debug, verbose, verify, and once modes.
Each mode is explained in the comments and can be uncommented to use.
Also updated Docker Compose related documentation.

Changes:
- Added command options for bandersnatch service in docker-compose.yml
- Added "Removing the Repository" section in Docker Compose README.md
- Added link in the main README.md to the Docker Compose section

Users can now choose from several modes by uncommenting the corresponding command in the docker-compose.yml file.

Please review and let me know if any changes are required.