### PR TITLE
(Work-in-progress) Update config file reading and validation

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,7 +31,7 @@ repos:
     hooks:
       - id: mypy
         exclude: (docs/.*)
-        additional_dependencies: ["types-filelock", "types-freezegun", "types-pkg_resources"]
+        additional_dependencies: ["attrs", "types-filelock", "types-freezegun", "types-pkg_resources"]
 
   - repo: https://github.com/PyCQA/flake8
     rev: 7.0.0

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,11 @@
 
 - Updated documentation for `[mirror]` configuration options `PR #1669`
 
+## Bug Fixes
+
+- Don't write a diff file unless the 'diff-file' option is set in the configuration file `PR #1694`
+- Correctly interpret references with surrounding text when using custom reference syntax in 'diff-file' `PR #1694`
+
 # 6.5.0
 
 ## New Features

--- a/src/bandersnatch/config/__init__.py
+++ b/src/bandersnatch/config/__init__.py
@@ -1,0 +1,4 @@
+# flake8: noqa
+from .core import BandersnatchConfig
+from .errors import ConfigurationError, InvalidValueError, MissingOptionError
+from .mirror_options import MirrorOptions

--- a/src/bandersnatch/config/attrs_utils.py
+++ b/src/bandersnatch/config/attrs_utils.py
@@ -1,0 +1,72 @@
+from collections.abc import Callable
+from configparser import ConfigParser
+from typing import Any, TypeAlias, TypeVar
+
+import attrs
+from attrs import Attribute
+
+from . import errors
+
+AttrsConverter: TypeAlias = Callable[[Any], Any]
+AttrsFieldTransformer: TypeAlias = Callable[[type, list[Attribute]], list[Attribute]]
+
+_V = TypeVar("_V")
+AttrsValidator: TypeAlias = Callable[[Any, Attribute, _V], _V]
+
+
+def only_if_str(converter_fn: AttrsConverter) -> AttrsConverter:
+    """Wrap an attrs converter function so it is only applied to strings.
+
+    'converter' functions on attrs fields are applied to all values set to the field,
+    *including* the default value. This causes problems if the default value is already
+    the desired type but the converter only handles strings.
+
+    :param AttrsConverter converter_fn: any attrs converter
+    :return AttrsConverter: converter function that uses `converter_fn` if the passed
+        value is a string, and otherwise returns the value unmodified.
+    """
+
+    def _apply_if_str(value: Any) -> Any:
+        if isinstance(value, str):
+            return converter_fn(value)
+        else:
+            return value
+
+    return _apply_if_str
+
+
+def get_name_value_for_option(
+    config: ConfigParser, section_name: str, option: Attribute
+) -> tuple[str, object | None]:
+    option_name = config.optionxform(option.alias or option.name)
+
+    if option.default is attrs.NOTHING and not config.has_option(
+        section_name, option_name
+    ):
+        raise errors.MissingOptionError.for_option(section_name, option_name)
+
+    getter: Callable[..., Any]
+    if option.converter is not None:
+        getter = config.get
+    elif option.type == bool:
+        getter = config.getboolean
+    elif option.type == float:
+        getter = config.getfloat
+    elif option.type == int:
+        getter = config.getint
+    else:
+        getter = config.get
+
+    try:
+        option_value = getter(section_name, option_name, fallback=None)
+    except ValueError as conversion_error:
+        type_name = option.type.__name__ if option.type else "???"
+        message = f"can't convert option name '{option_name}' to expected type '{type_name}': {conversion_error!s}"
+        raise errors.InvalidValueError.for_option(
+            section_name, option_name, message
+        ) from conversion_error
+
+    return option_name, option_value
+
+
+validate_not_empty: AttrsValidator = attrs.validators.min_len(1)

--- a/src/bandersnatch/config/comparison_method.py
+++ b/src/bandersnatch/config/comparison_method.py
@@ -1,0 +1,30 @@
+"""Enumeration of supported file comparison strategies"""
+
+import sys
+
+if sys.version_info >= (3, 11):
+    from enum import StrEnum
+else:
+    from bandersnatch.utils import StrEnum
+
+
+class ComparisonMethod(StrEnum):
+    HASH = "hash"
+    STAT = "stat"
+
+
+class InvalidComparisonMethod(ValueError):
+    """We don't have a valid comparison method choice from configuration"""
+
+    pass
+
+
+def get_comparison_value(method: str) -> ComparisonMethod:
+    try:
+        return ComparisonMethod(method)
+    except ValueError:
+        valid_methods = sorted(v.value for v in ComparisonMethod)
+        raise InvalidComparisonMethod(
+            f"{method} is not a valid file comparison method. "
+            + f"Valid options are: {valid_methods}"
+        )

--- a/src/bandersnatch/config/core.py
+++ b/src/bandersnatch/config/core.py
@@ -1,0 +1,42 @@
+from collections.abc import Mapping
+from configparser import ConfigParser, ExtendedInterpolation
+from pathlib import Path
+from typing import Protocol, TypeVar, cast
+
+from typing_extensions import Self
+
+
+class ConfigModel(Protocol):
+
+    @classmethod
+    def from_config_parser(cls, source: ConfigParser) -> Self: ...
+
+
+_C = TypeVar("_C", bound=ConfigModel)
+
+
+class BandersnatchConfig(ConfigParser):
+
+    def __init__(self, defaults: Mapping[str, str] | None = None) -> None:
+        super().__init__(
+            defaults=defaults,
+            delimiters=("=",),
+            strict=True,
+            interpolation=ExtendedInterpolation(),
+        )
+
+        self._validate_config_models: dict[str, ConfigModel] = {}
+
+    # This allows writing option names in the config file with either '_' or '-' as word separators
+    def optionxform(self, optionstr: str) -> str:
+        return optionstr.lower().replace("-", "_")
+
+    def read_path(self, file_path: Path) -> None:
+        with file_path.open() as cfg_file:
+            self.read_file(cfg_file)
+
+    def get_validated(self, model: type[_C]) -> _C:
+        name = model.__qualname__
+        if name not in self._validate_config_models:
+            self._validate_config_models[name] = model.from_config_parser(self)
+        return cast(_C, self._validate_config_models[name])

--- a/src/bandersnatch/config/core.py
+++ b/src/bandersnatch/config/core.py
@@ -1,15 +1,19 @@
+import sys
 from collections.abc import Mapping
 from configparser import ConfigParser, ExtendedInterpolation
 from pathlib import Path
 from typing import Protocol, TypeVar, cast
 
-from typing_extensions import Self
+if sys.version_info >= (3, 11):
+    from typing import Self
+else:
+    Self = TypeVar("Self", bound="ConfigModel")
 
 
 class ConfigModel(Protocol):
 
     @classmethod
-    def from_config_parser(cls, source: ConfigParser) -> Self: ...
+    def from_config_parser(cls: type[Self], source: ConfigParser) -> Self: ...
 
 
 _C = TypeVar("_C", bound=ConfigModel)

--- a/src/bandersnatch/config/core.py
+++ b/src/bandersnatch/config/core.py
@@ -1,3 +1,5 @@
+import importlib.resources
+import shutil
 import sys
 from collections.abc import Mapping
 from configparser import ConfigParser, ExtendedInterpolation
@@ -44,3 +46,18 @@ class BandersnatchConfig(ConfigParser):
         if name not in self._validate_config_models:
             self._validate_config_models[name] = model.from_config_parser(self)
         return cast(_C, self._validate_config_models[name])
+
+    @classmethod
+    def from_path(
+        cls, source_file: Path, *, defaults: Mapping[str, str] | None = None
+    ) -> "BandersnatchConfig":
+        config = cls(defaults=defaults)
+        config.read_path(source_file)
+        return config
+
+
+def write_default_config_file(dest: Path) -> None:
+    with importlib.resources.path(
+        "bandersnatch", "default.conf"
+    ) as default_config_path:
+        shutil.copy(default_config_path, dest)

--- a/src/bandersnatch/config/diff_file_reference.py
+++ b/src/bandersnatch/config/diff_file_reference.py
@@ -1,0 +1,60 @@
+"""
+Custom configparser section/option reference syntax for the diff-file option.
+
+diff-file supports a "section reference" syntax for it's value:
+
+    [mirror]
+    ...
+    diff-file = /folder{{ <SECTION>_<OPTION> }}/more
+
+<SECTION> matches a configparser section and <OPTION> matches an option in that section.
+The portion of the diff-file value delimited with {{ and }} is replaced with the
+value from the specified option, which should be a string.
+
+The configparser module's ExtendedInterpolation feature is preferred to this custom syntax.
+"""
+
+import re
+from configparser import ConfigParser, NoOptionError, NoSectionError
+
+# Pattern to check if a string contains a custom section reference
+_LEGACY_REF_PAT = r".*\{\{.+_.+\}\}.*"
+
+# Pattern to decompose a custom section reference into parts
+_LEGACY_REF_COMPONENT_PAT = r"""
+    # capture everything from start-of-line to the opening '{{' braces into group 'pre'
+    ^(?P<pre>.*)\{\{
+    # restrict section names to ignore surrounding whitespace (different from
+    # configparser's default SECTRE) and disallow '_' (since that's our separator)
+    \s*
+    (?P<section>[^_\s](?:[^_]*[^_\s]))
+    # allow (but ignore) whitespace around the section-option delimiter
+    \s*_\s*
+    # option names ignore surrounding whitespace and can include any character, but
+    # must start and end with a non-whitespace character
+    (?P<option>\S(?:.*\S)?)
+    \s*
+    # capture from the closing '}}' braces to end-of-line into group 'post'
+    \}\}(?P<post>.*)$
+"""
+
+
+def has_legacy_config_ref(value: str) -> bool:
+    return re.match(_LEGACY_REF_PAT, value) is not None
+
+
+def eval_legacy_config_ref(config: ConfigParser, value: str) -> str:
+    match_result = re.match(_LEGACY_REF_COMPONENT_PAT, value, re.VERBOSE)
+
+    if match_result is None:
+        raise ValueError(f"Unable to parse config option reference from '{value}'")
+
+    pre, sect_name, opt_name, post = match_result.group(
+        "pre", "section", "option", "post"
+    )
+
+    try:
+        ref_value = config.get(sect_name, opt_name)
+        return pre + ref_value + post
+    except (NoSectionError, NoOptionError) as exc:
+        raise ValueError(exc.message)

--- a/src/bandersnatch/config/errors.py
+++ b/src/bandersnatch/config/errors.py
@@ -1,22 +1,29 @@
-from typing_extensions import Self
+import sys
+
+if sys.version_info >= (3, 11):
+    from typing import Self
+else:
+    from typing import TypeVar
+
+    Self = TypeVar("Self", bound="ConfigurationError")
 
 
 class ConfigurationError(Exception):
 
     @classmethod
-    def for_section(cls, section: str, message: str) -> Self:
+    def for_section(cls: type[Self], section: str, message: str) -> Self:
         return cls(f"Configuration error in [{section}] section: {message}")
 
 
 class MissingOptionError(ConfigurationError):
 
     @classmethod
-    def for_option(cls, section: str, option: str) -> Self:
+    def for_option(cls: type[Self], section: str, option: str) -> Self:
         return cls.for_section(section, f"missing required option '{option}'")
 
 
 class InvalidValueError(ConfigurationError):
 
     @classmethod
-    def for_option(cls, section: str, option: str, info: str) -> Self:
+    def for_option(cls: type[Self], section: str, option: str, info: str) -> Self:
         return cls.for_section(section, f"invalid value for option '{option}': {info}")

--- a/src/bandersnatch/config/errors.py
+++ b/src/bandersnatch/config/errors.py
@@ -1,0 +1,22 @@
+from typing_extensions import Self
+
+
+class ConfigurationError(Exception):
+
+    @classmethod
+    def for_section(cls, section: str, message: str) -> Self:
+        return cls(f"Configuration error in [{section}] section: {message}")
+
+
+class MissingOptionError(ConfigurationError):
+
+    @classmethod
+    def for_option(cls, section: str, option: str) -> Self:
+        return cls.for_section(section, f"missing required option '{option}'")
+
+
+class InvalidValueError(ConfigurationError):
+
+    @classmethod
+    def for_option(cls, section: str, option: str, info: str) -> Self:
+        return cls.for_section(section, f"invalid value for option '{option}': {info}")

--- a/src/bandersnatch/config/mirror_options.py
+++ b/src/bandersnatch/config/mirror_options.py
@@ -136,6 +136,25 @@ class MirrorOptions:
 
         return instance
 
+    @classmethod
+    def populate_defaults(cls, config: ConfigParser) -> None:
+        if not config.has_section("mirror"):
+            config.add_section("mirror")
+        section = config["mirror"]
+
+        option: attrs.Attribute
+        for option in attrs.fields(cls):
+            if option.default is attrs.NOTHING or option.default is None:
+                continue
+            option_name = option.alias or option.name
+            if isinstance(option.default, PurePath):
+                option_value = option.default.as_posix()
+            elif not isinstance(option.default, str):
+                option_value = str(option.default)
+            else:
+                option_value = option.default
+            section[option_name] = option_value
+
 
 def _check_legacy_reference(config: ConfigParser, value: str) -> str | None:
     if not has_legacy_config_ref(value):

--- a/src/bandersnatch/config/mirror_options.py
+++ b/src/bandersnatch/config/mirror_options.py
@@ -1,0 +1,156 @@
+from configparser import ConfigParser, NoOptionError, NoSectionError
+from logging import getLogger
+from pathlib import PurePath
+from typing import Any
+
+import attrs
+
+from bandersnatch.simple import (
+    SimpleDigest,
+    SimpleFormat,
+    get_digest_value,
+    get_format_value,
+)
+
+from .attrs_utils import get_name_value_for_option, only_if_str, validate_not_empty
+from .comparison_method import ComparisonMethod, get_comparison_value
+from .diff_file_reference import eval_legacy_config_ref, has_legacy_config_ref
+from .errors import ConfigurationError, InvalidValueError
+
+logger = getLogger("bandersnatch")
+
+_default_master_url = "https://pypi.org"
+_default_root_uri = "https://files.pythonhosted.org"
+
+
+@attrs.define(kw_only=True)
+class MirrorOptions:
+    """Class with attributes for all the options that may appear in the
+    '[mirror]' section of a config file.
+    """
+
+    directory: PurePath = attrs.field(converter=PurePath)
+
+    storage_backend_name: str = attrs.field(
+        default="filesystem",
+        alias="storage_backend",
+        validator=validate_not_empty,
+    )
+
+    master_url: str = attrs.field(default=_default_master_url, alias="master")
+    proxy_url: str | None = attrs.field(default=None, alias="proxy")
+
+    download_mirror_url: str | None = attrs.field(default=None, alias="download_mirror")
+    download_mirror_no_fallback: bool = False
+
+    save_release_files: bool = attrs.field(default=True, alias="release_files")
+    save_json: bool = attrs.field(default=False, alias="json")
+
+    # type-ignores on converters for the following enums b/c MyPy's plugin for attrs
+    # doesn't handle using arbitrary functions as converters
+    simple_format: SimpleFormat = attrs.field(
+        default=SimpleFormat.ALL,
+        converter=only_if_str(get_format_value),  # type: ignore
+    )
+
+    compare_method: ComparisonMethod = attrs.field(
+        default=ComparisonMethod.HASH,
+        converter=only_if_str(get_comparison_value),  # type: ignore
+    )
+
+    digest_name: SimpleDigest = attrs.field(
+        default=SimpleDigest.SHA256,
+        converter=only_if_str(get_digest_value),  # type: ignore
+    )
+
+    # this gets a non-empty default value in post-init if save_release_files is False
+    root_uri: str = ""
+
+    hash_index: bool = False
+
+    keep_index_versions: int = attrs.field(default=0, validator=attrs.validators.ge(0))
+
+    diff_file: PurePath | None = attrs.field(
+        default=None, converter=attrs.converters.optional(PurePath)
+    )
+    diff_append_epoch: bool = False
+
+    stop_on_error: bool = False
+    timeout: float = attrs.field(default=10.0, validator=attrs.validators.gt(0))
+    global_timeout: float = attrs.field(
+        default=1800.0, validator=attrs.validators.gt(0)
+    )
+
+    workers: int = attrs.field(
+        default=3, validator=[attrs.validators.gt(0), attrs.validators.le(10)]
+    )
+
+    verifiers: int = attrs.field(
+        default=3, validator=[attrs.validators.gt(0), attrs.validators.le(10)]
+    )
+
+    log_config: PurePath | None = attrs.field(
+        default=None, converter=attrs.converters.optional(PurePath)
+    )
+
+    cleanup: bool = attrs.field(default=False, metadata={"deprecated": True})
+
+    # Called after the attrs class is constructed; doing cross-field validation here
+    def __attrs_post_init__(self) -> None:
+        # set default for root_uri if release-files is disabled
+        if not self.save_release_files and not self.root_uri:
+            logger.warning(
+                (
+                    "Inconsistent config: 'root_uri' should be set when "
+                    "'release-files' is disabled. Please set 'root-uri' in the "
+                    "[mirror] section of your config file. Using default value '%s'"
+                ),
+                _default_root_uri,
+            )
+            self.root_uri = _default_root_uri
+
+    @classmethod
+    def from_config_parser(cls, source: ConfigParser) -> "MirrorOptions":
+        if "mirror" not in source:
+            raise ConfigurationError("Config file missing required section '[mirror]'")
+
+        model_kwargs: dict[str, Any] = {}
+
+        for option in attrs.fields(cls):
+            option_name, option_value = get_name_value_for_option(
+                source, "mirror", option
+            )
+
+            if option_name == "diff_file" and isinstance(option_value, str):
+                option_value = _check_legacy_reference(source, option_value)
+
+            if option_value is not None:
+                model_kwargs[option_name] = option_value
+
+        try:
+            instance = cls(**model_kwargs)
+        except ValueError as err:
+            raise InvalidValueError.for_section("mirror", str(err)) from err
+        except TypeError as err:
+            raise ConfigurationError.for_section("mirror", str(err)) from err
+
+        return instance
+
+
+def _check_legacy_reference(config: ConfigParser, value: str) -> str | None:
+    if not has_legacy_config_ref(value):
+        return value
+
+    logger.warning(
+        "Found section reference using '{{ }}' in 'diff-file' path. "
+        "Use ConfigParser's built-in extended interpolation instead, "
+        "for example '${mirror:directory}/new-files'"
+    )
+    try:
+        return eval_legacy_config_ref(config, value)
+    except (ValueError, NoSectionError, NoOptionError) as ref_err:
+        # NOTE: raise here would be a breaking change; previous impl. logged and
+        # fell back to a default. Create exception anyway for consistent error messages.
+        exc = InvalidValueError.for_option("mirror", "diff-file", str(ref_err))
+        logger.error(str(exc))
+        return None

--- a/src/bandersnatch/configuration.py
+++ b/src/bandersnatch/configuration.py
@@ -6,7 +6,7 @@ import configparser
 import importlib.resources
 import logging
 from pathlib import Path
-from typing import Any, NamedTuple
+from typing import NamedTuple
 
 from .config.diff_file_reference import eval_legacy_config_ref, has_legacy_config_ref
 from .simple import SimpleDigest, SimpleFormat, get_digest_value, get_format_value
@@ -29,25 +29,13 @@ class SetConfigValues(NamedTuple):
     simple_format: SimpleFormat
 
 
-class Singleton(type):  # pragma: no cover
-    _instances: dict["Singleton", type] = {}
-
-    def __call__(cls, *args: Any, **kwargs: Any) -> type:
-        if cls not in cls._instances:
-            cls._instances[cls] = super().__call__(*args, **kwargs)
-        return cls._instances[cls]
-
-
-class BandersnatchConfig(metaclass=Singleton):
+class BandersnatchConfig:
     # Ensure we only show the deprecations once
     SHOWN_DEPRECATIONS = False
 
     def __init__(self, config_file: str | None = None) -> None:
         """
-        Bandersnatch configuration class singleton
-
-        This class is a singleton that parses the configuration once at the
-        start time.
+        Bandersnatch configuration management class.
 
         Parameters
         ==========

--- a/src/bandersnatch/configuration.py
+++ b/src/bandersnatch/configuration.py
@@ -8,6 +8,7 @@ import logging
 from pathlib import Path
 from typing import Any, NamedTuple
 
+from .config.diff_file_reference import eval_legacy_config_ref, has_legacy_config_ref
 from .simple import SimpleDigest, SimpleFormat, get_digest_value, get_format_value
 
 logger = logging.getLogger("bandersnatch")
@@ -101,20 +102,17 @@ def validate_config_values(  # noqa: C901
         diff_file_path = config.get("mirror", "diff-file")
     except configparser.NoOptionError:
         diff_file_path = ""
-    if "{{" in diff_file_path and "}}" in diff_file_path:
-        diff_file_path = diff_file_path.replace("{{", "").replace("}}", "")
-        diff_ref_section, _, diff_ref_key = diff_file_path.partition("_")
+
+    if diff_file_path and has_legacy_config_ref(diff_file_path):
         try:
-            diff_file_path = config.get(diff_ref_section, diff_ref_key)
-        except (configparser.NoOptionError, configparser.NoSectionError):
+            diff_file_path = eval_legacy_config_ref(config, diff_file_path)
+        except ValueError as err:
             logger.error(
-                "Invalid section reference in `diff-file` key. "
-                "Please correct this error. Saving diff files in"
-                " base mirror directory."
+                "Invalid section reference in `diff-file` key: %s. Saving diff files in base mirror directory.",
+                str(err),
             )
-            diff_file_path = str(
-                Path(config.get("mirror", "directory")) / "mirrored-files"
-            )
+            mirror_dir = config.get("mirror", "directory")
+            diff_file_path = (Path(mirror_dir) / "mirrored-files").as_posix()
 
     try:
         diff_append_epoch = config.getboolean("mirror", "diff-append-epoch")

--- a/src/bandersnatch/delete.py
+++ b/src/bandersnatch/delete.py
@@ -14,14 +14,15 @@ from urllib.parse import urlparse
 from packaging.utils import canonicalize_name
 
 from .master import Master
-from .storage import storage_backend_plugins
+from .storage import Storage, storage_backend_plugins
 from .verify import get_latest_json
 
 logger = logging.getLogger(__name__)
 
 
-async def delete_path(blob_path: Path, dry_run: bool = False) -> int:
-    storage_backend = next(iter(storage_backend_plugins()))
+async def delete_path(
+    blob_path: Path, storage_backend: Storage, dry_run: bool = False
+) -> int:
     if dry_run:
         logger.info(f" rm {blob_path}")
         return 0
@@ -131,7 +132,9 @@ async def delete_packages(config: ConfigParser, args: Namespace, master: Master)
                 for blob in blobs:
                     url_parts = urlparse(blob["url"])
                     blob_path = web_base_path / url_parts.path[1:]
-                    delete_coros.append(delete_path(blob_path, args.dry_run))
+                    delete_coros.append(
+                        delete_path(blob_path, storage_backend, args.dry_run)
+                    )
 
         # Attempt to delete json, normal simple path + hash simple path
         hash_index_enabled = config.getboolean("mirror", "hash-index")
@@ -160,7 +163,9 @@ async def delete_packages(config: ConfigParser, args: Namespace, master: Master)
             if not package_path:
                 continue
 
-            delete_coros.append(delete_path(package_path, args.dry_run))
+            delete_coros.append(
+                delete_path(package_path, storage_backend, args.dry_run)
+            )
 
     if args.dry_run:
         logger.info("-- bandersnatch delete DRY RUN --")

--- a/src/bandersnatch/filter.py
+++ b/src/bandersnatch/filter.py
@@ -3,11 +3,10 @@ Blocklist management
 """
 
 from collections import defaultdict
+from configparser import ConfigParser
 from typing import TYPE_CHECKING, Any
 
 import pkg_resources
-
-from .configuration import BandersnatchConfig
 
 if TYPE_CHECKING:
     from configparser import SectionProxy
@@ -36,8 +35,8 @@ class Filter:
     name = "filter"
     deprecated_name: str = ""
 
-    def __init__(self, *args: Any, **kwargs: Any) -> None:
-        self.configuration = BandersnatchConfig().config
+    def __init__(self, *args: Any, config: ConfigParser, **kwargs: Any) -> None:
+        self.configuration = config
         if (
             "plugins" not in self.configuration
             or "enabled" not in self.configuration["plugins"]
@@ -152,11 +151,11 @@ class LoadedFilters:
         RELEASE_FILE_PLUGIN_RESOURCE,
     ]
 
-    def __init__(self, load_all: bool = False) -> None:
+    def __init__(self, config: ConfigParser, load_all: bool = False) -> None:
         """
         Loads and stores all of specified filters from the config file
         """
-        self.config = BandersnatchConfig().config
+        self.config = config
         self.loaded_filter_plugins: dict[str, list["Filter"]] = defaultdict(list)
         self.enabled_plugins = self._load_enabled()
         if load_all:
@@ -189,7 +188,7 @@ class LoadedFilters:
             plugins = set()
             for entry_point in pkg_resources.iter_entry_points(group=group):
                 plugin_class = entry_point.load()
-                plugin_instance = plugin_class()
+                plugin_instance = plugin_class(config=self.config)
                 if (
                     "all" in self.enabled_plugins
                     or plugin_instance.name in self.enabled_plugins

--- a/src/bandersnatch/main.py
+++ b/src/bandersnatch/main.py
@@ -165,7 +165,7 @@ async def async_main(args: argparse.Namespace, config: ConfigParser) -> int:
         )
 
     if args.force_check:
-        storage_plugin = next(iter(storage_backend_plugins()))
+        storage_plugin = next(iter(storage_backend_plugins(config)))
         status_file = (
             storage_plugin.PATH_BACKEND(config.get("mirror", "directory")) / "status"
         )

--- a/src/bandersnatch/mirror.py
+++ b/src/bandersnatch/mirror.py
@@ -6,11 +6,11 @@ import logging
 import os
 import sys
 import time
-from collections.abc import Awaitable
+from collections.abc import Awaitable, Callable
 from json import dump
 from pathlib import Path, WindowsPath
 from threading import RLock
-from typing import Any
+from typing import Any, TypeVar
 from urllib.parse import unquote, urlparse
 
 from filelock import Timeout
@@ -22,7 +22,7 @@ from .filter import LoadedFilters
 from .master import Master
 from .package import Package
 from .simple import SimpleAPI, SimpleFormat, SimpleFormats
-from .storage import storage_backend_plugins
+from .storage import Storage, storage_backend_plugins
 
 LOG_PLUGINS = True
 logger = logging.getLogger(__name__)
@@ -188,7 +188,6 @@ class BandersnatchMirror(Mirror):
         digest_name: str | None = None,
         root_uri: str | None = None,
         keep_index_versions: int = 0,
-        diff_file: Path | str | None = None,
         diff_append_epoch: bool = False,
         diff_full_path: Path | str | None = None,
         flock_timeout: int = 1,
@@ -230,7 +229,6 @@ class BandersnatchMirror(Mirror):
         # PyPI mirror, which requires serving packages from
         # https://files.pythonhosted.org
         self.root_uri = root_uri or ""
-        self.diff_file = diff_file
         self.diff_append_epoch = diff_append_epoch
         self.diff_full_path = diff_full_path
         self.keep_index_versions = keep_index_versions
@@ -913,6 +911,44 @@ class BandersnatchMirror(Mirror):
         return path
 
 
+_T = TypeVar("_T")
+
+
+async def _run_in_storage_executor(
+    storage_plugin: Storage, func: Callable[..., _T], *args: Any
+) -> _T:
+    return await storage_plugin.loop.run_in_executor(
+        storage_plugin.executor, func, *args
+    )
+
+
+async def _setup_diff_file(
+    storage_plugin: Storage, configured_path: str, append_epoch: bool
+) -> Path:
+    # use the storage backend to convert an abstract path to a concrete one
+    concrete_path = storage_plugin.PATH_BACKEND(configured_path)
+
+    # create parent directories if needed
+    await _run_in_storage_executor(
+        storage_plugin, lambda: concrete_path.parent.mkdir(exist_ok=True, parents=True)
+    )
+
+    # adjust the file/directory name if timestamps are enabled
+    if append_epoch:
+        epoch = int(time.time())
+        concrete_path = concrete_path.with_name(f"{concrete_path.name}-{epoch}")
+
+    # if the path is directory, adjust to write to a file inside it
+    if await _run_in_storage_executor(storage_plugin, concrete_path.is_dir):
+        concrete_path = concrete_path / "mirrored-files"
+
+    # if there is an existing file there then delete it
+    if await _run_in_storage_executor(storage_plugin, concrete_path.is_file):
+        concrete_path.unlink()
+
+    return concrete_path
+
+
 async def mirror(
     config: configparser.ConfigParser,
     specific_packages: list[str] | None = None,
@@ -928,28 +964,13 @@ async def mirror(
         )
     )
 
-    diff_file = storage_plugin.PATH_BACKEND(config_values.diff_file_path)
-    diff_full_path: Path | str
-    if diff_file:
-        diff_file.parent.mkdir(exist_ok=True, parents=True)
-        if config_values.diff_append_epoch:
-            diff_full_path = diff_file.with_name(f"{diff_file.name}-{int(time.time())}")
-        else:
-            diff_full_path = diff_file
-    else:
-        diff_full_path = ""
-
-    if diff_full_path:
-        if isinstance(diff_full_path, str):
-            diff_full_path = storage_plugin.PATH_BACKEND(diff_full_path)
-        if await storage_plugin.loop.run_in_executor(
-            storage_plugin.executor, diff_full_path.is_file
-        ):
-            diff_full_path.unlink()
-        elif await storage_plugin.loop.run_in_executor(
-            storage_plugin.executor, diff_full_path.is_dir
-        ):
-            diff_full_path = diff_full_path / "mirrored-files"
+    diff_full_path: Path | None = None
+    if config_values.diff_file_path:
+        diff_full_path = await _setup_diff_file(
+            storage_plugin,
+            config_values.diff_file_path,
+            config_values.diff_append_epoch,
+        )
 
     mirror_url = config.get("mirror", "master")
     timeout = config.getfloat("mirror", "timeout")
@@ -975,9 +996,8 @@ async def mirror(
             keep_index_versions=config.getint(
                 "mirror", "keep_index_versions", fallback=0
             ),
-            diff_file=diff_file,
             diff_append_epoch=config_values.diff_append_epoch,
-            diff_full_path=diff_full_path if diff_full_path else None,
+            diff_full_path=diff_full_path,
             cleanup=config_values.cleanup,
             release_files_save=config_values.release_files_save,
             download_mirror=config_values.download_mirror,
@@ -997,14 +1017,13 @@ async def mirror(
         loggable_changes = [str(chg) for chg in package_changes]
         logger.debug(f"{package_name} added: {loggable_changes}")
 
-    if mirror.diff_full_path:
-        logger.info(f"Writing diff file to {mirror.diff_full_path}")
+    if diff_full_path:
+        logger.info(f"Writing diff file to '{diff_full_path}'")
         diff_text = f"{os.linesep}".join(
             [str(chg.absolute()) for chg in mirror.diff_file_list]
         )
-        diff_file = mirror.storage_backend.PATH_BACKEND(mirror.diff_full_path)
-        await storage_plugin.loop.run_in_executor(
-            storage_plugin.executor, diff_file.write_text, diff_text
+        await _run_in_storage_executor(
+            storage_plugin, diff_full_path.write_text, diff_text
         )
 
     return 0

--- a/src/bandersnatch/mirror.py
+++ b/src/bandersnatch/mirror.py
@@ -1,5 +1,4 @@
 import asyncio
-import configparser
 import datetime
 import hashlib
 import logging
@@ -8,20 +7,23 @@ import sys
 import time
 from collections.abc import Awaitable, Callable
 from json import dump
-from pathlib import Path, WindowsPath
+from pathlib import Path, PurePath
 from threading import RLock
 from typing import Any, TypeVar
 from urllib.parse import unquote, urlparse
 
 from filelock import Timeout
 
+from bandersnatch.config.errors import ConfigurationError
+
 from . import utils
-from .configuration import validate_config_values
+from .config import BandersnatchConfig, MirrorOptions
+from .config.comparison_method import ComparisonMethod
 from .errors import PackageNotFound
 from .filter import LoadedFilters
 from .master import Master
 from .package import Package
-from .simple import SimpleAPI, SimpleFormat, SimpleFormats
+from .simple import SimpleAPI, SimpleDigest, SimpleFormat, SimpleFormats
 from .storage import Storage, storage_backend_plugins
 
 LOG_PLUGINS = True
@@ -178,7 +180,7 @@ class BandersnatchMirror(Mirror):
 
     def __init__(
         self,
-        homedir: Path,
+        homedir: PurePath,
         master: Master,
         storage_backend: Storage,
         filters: LoadedFilters,
@@ -186,20 +188,20 @@ class BandersnatchMirror(Mirror):
         workers: int = 3,
         hash_index: bool = False,
         json_save: bool = False,
-        digest_name: str | None = None,
-        root_uri: str | None = None,
+        digest_name: SimpleDigest = SimpleDigest.SHA256,
+        root_uri: str = "",
         keep_index_versions: int = 0,
         diff_append_epoch: bool = False,
-        diff_full_path: Path | str | None = None,
+        diff_full_path: Path | None = None,
         flock_timeout: int = 1,
         diff_file_list: list[Path] | None = None,
         *,
         cleanup: bool = False,
         release_files_save: bool = True,
-        compare_method: str | None = None,
+        compare_method: ComparisonMethod = ComparisonMethod.HASH,
         download_mirror: str | None = None,
         download_mirror_no_fallback: bool | None = False,
-        simple_format: SimpleFormat | str = "ALL",
+        simple_format: SimpleFormat = SimpleFormat.ALL,
     ) -> None:
         super().__init__(master=master, filters=filters, workers=workers)
         self.cleanup = cleanup
@@ -207,10 +209,7 @@ class BandersnatchMirror(Mirror):
         self.storage_backend = storage_backend
         self.stop_on_error = stop_on_error
         self.loop = asyncio.get_event_loop()
-        if isinstance(homedir, WindowsPath):
-            self.homedir = self.storage_backend.PATH_BACKEND(homedir.as_posix())
-        else:
-            self.homedir = self.storage_backend.PATH_BACKEND(str(homedir))
+        self.homedir = self.storage_backend.PATH_BACKEND(homedir.as_posix())
         self.lockfile_path = self.homedir / ".lock"
         self.master = master
 
@@ -226,12 +225,12 @@ class BandersnatchMirror(Mirror):
         # This is generally not necessary, but was added for the official internal
         # PyPI mirror, which requires serving packages from
         # https://files.pythonhosted.org
-        self.root_uri = root_uri or ""
+        self.root_uri = root_uri
         self.diff_append_epoch = diff_append_epoch
         self.diff_full_path = diff_full_path
         self.keep_index_versions = keep_index_versions
-        self.digest_name = digest_name if digest_name else "sha256"
-        self.compare_method = compare_method if compare_method else "hash"
+        self.digest_name = digest_name
+        self.compare_method = compare_method
         self.download_mirror = download_mirror
         self.download_mirror_no_fallback = download_mirror_no_fallback
         self.workers = workers
@@ -921,7 +920,7 @@ async def _run_in_storage_executor(
 
 
 async def _setup_diff_file(
-    storage_plugin: Storage, configured_path: str, append_epoch: bool
+    storage_plugin: Storage, configured_path: PurePath, append_epoch: bool
 ) -> Path:
     # use the storage backend to convert an abstract path to a concrete one
     concrete_path = storage_plugin.PATH_BACKEND(configured_path)
@@ -948,61 +947,63 @@ async def _setup_diff_file(
 
 
 async def mirror(
-    config: configparser.ConfigParser,
+    config: BandersnatchConfig,
     specific_packages: list[str] | None = None,
     sync_simple_index: bool = True,
 ) -> int:
-    config_values = validate_config_values(config)
+    try:
+        mirror_options = config.get_validated(MirrorOptions)
+    except ConfigurationError as err:
+        logger.error("Configuration error: %s", str(err))
+        logger.debug("Configuration error: exception info:", exc_info=err)
+        return 1
 
     storage_plugin = next(
         iter(
             storage_backend_plugins(
                 config=config,
-                backend=config_values.storage_backend_name,
+                backend=mirror_options.storage_backend_name,
                 clear_cache=True,
             )
         )
     )
 
     diff_full_path: Path | None = None
-    if config_values.diff_file_path:
+    if mirror_options.diff_file:
         diff_full_path = await _setup_diff_file(
             storage_plugin,
-            config_values.diff_file_path,
-            config_values.diff_append_epoch,
+            mirror_options.diff_file,
+            mirror_options.diff_append_epoch,
         )
-
-    mirror_url = config.get("mirror", "master")
-    timeout = config.getfloat("mirror", "timeout")
-    global_timeout = config.getfloat("mirror", "global-timeout", fallback=None)
-    proxy = config.get("mirror", "proxy", fallback=None)
-    homedir = Path(config.get("mirror", "directory"))
 
     # Always reference those classes here with the fully qualified name to
     # allow them being patched by mock libraries!
-    async with Master(mirror_url, timeout, global_timeout, proxy) as master:
+    async with Master(
+        mirror_options.master_url,
+        mirror_options.timeout,
+        mirror_options.global_timeout,
+        mirror_options.proxy_url,
+    ) as master:
         mirror = BandersnatchMirror(
-            homedir,
+            mirror_options.directory,
             master,
             storage_plugin,
             LoadedFilters(config, load_all=True),
-            stop_on_error=config.getboolean("mirror", "stop-on-error"),
-            workers=config.getint("mirror", "workers"),
-            hash_index=config.getboolean("mirror", "hash-index"),
-            json_save=config_values.json_save,
-            root_uri=config_values.root_uri,
-            digest_name=config_values.digest_name,
-            compare_method=config_values.compare_method,
-            keep_index_versions=config.getint(
-                "mirror", "keep_index_versions", fallback=0
-            ),
-            diff_append_epoch=config_values.diff_append_epoch,
+            stop_on_error=mirror_options.stop_on_error,
+            workers=mirror_options.workers,
+            hash_index=mirror_options.hash_index,
+            json_save=mirror_options.save_json,
+            root_uri=mirror_options.root_uri,
+            digest_name=mirror_options.digest_name,
+            compare_method=mirror_options.compare_method,
+            keep_index_versions=mirror_options.keep_index_versions,
+            diff_append_epoch=mirror_options.diff_append_epoch,
             diff_full_path=diff_full_path,
-            cleanup=config_values.cleanup,
-            release_files_save=config_values.release_files_save,
-            download_mirror=config_values.download_mirror,
-            download_mirror_no_fallback=config_values.download_mirror_no_fallback,
-            simple_format=config_values.simple_format,
+            cleanup=mirror_options.cleanup,
+            release_files_save=mirror_options.save_release_files,
+            download_mirror=mirror_options.download_mirror_url,
+            download_mirror_no_fallback=mirror_options.download_mirror_no_fallback,
+            simple_format=mirror_options.simple_format,
         )
         changed_packages = await mirror.synchronize(
             specific_packages, sync_simple_index=sync_simple_index

--- a/src/bandersnatch/mirror.py
+++ b/src/bandersnatch/mirror.py
@@ -38,9 +38,9 @@ class Mirror:
     # of it when starting to sync.
     now: datetime.datetime | None = None
 
-    def __init__(self, master: Master, workers: int = 3):
+    def __init__(self, master: Master, filters: LoadedFilters, workers: int = 3):
         self.master = master
-        self.filters = LoadedFilters(load_all=True)
+        self.filters = filters
         self.workers = workers
         if self.workers > 10:
             raise ValueError("Downloading with more than 10 workers is not allowed")
@@ -181,6 +181,7 @@ class BandersnatchMirror(Mirror):
         homedir: Path,
         master: Master,
         storage_backend: Storage,
+        filters: LoadedFilters,
         stop_on_error: bool = False,
         workers: int = 3,
         hash_index: bool = False,
@@ -200,7 +201,7 @@ class BandersnatchMirror(Mirror):
         download_mirror_no_fallback: bool | None = False,
         simple_format: SimpleFormat | str = "ALL",
     ) -> None:
-        super().__init__(master=master, workers=workers)
+        super().__init__(master=master, filters=filters, workers=workers)
         self.cleanup = cleanup
 
         self.storage_backend = storage_backend
@@ -983,7 +984,8 @@ async def mirror(
         mirror = BandersnatchMirror(
             homedir,
             master,
-            storage_backend=storage_plugin,
+            storage_plugin,
+            LoadedFilters(config, load_all=True),
             stop_on_error=config.getboolean("mirror", "stop-on-error"),
             workers=config.getint("mirror", "workers"),
             hash_index=config.getboolean("mirror", "hash-index"),

--- a/src/bandersnatch/mirror.py
+++ b/src/bandersnatch/mirror.py
@@ -36,7 +36,7 @@ class Mirror:
     # We are required to leave a 'last changed' timestamp. I'd rather err
     # on the side of giving a timestamp that is too old so we keep track
     # of it when starting to sync.
-    now = None
+    now: datetime.datetime | None = None
 
     def __init__(self, master: Master, workers: int = 3):
         self.master = master
@@ -180,7 +180,7 @@ class BandersnatchMirror(Mirror):
         self,
         homedir: Path,
         master: Master,
-        storage_backend: str | None = None,
+        storage_backend: Storage,
         stop_on_error: bool = False,
         workers: int = 3,
         hash_index: bool = False,
@@ -203,10 +203,7 @@ class BandersnatchMirror(Mirror):
         super().__init__(master=master, workers=workers)
         self.cleanup = cleanup
 
-        if storage_backend:
-            self.storage_backend = next(iter(storage_backend_plugins(storage_backend)))
-        else:
-            self.storage_backend = next(iter(storage_backend_plugins()))
+        self.storage_backend = storage_backend
         self.stop_on_error = stop_on_error
         self.loop = asyncio.get_event_loop()
         if isinstance(homedir, WindowsPath):
@@ -959,7 +956,9 @@ async def mirror(
     storage_plugin = next(
         iter(
             storage_backend_plugins(
-                config_values.storage_backend_name, config=config, clear_cache=True
+                config=config,
+                backend=config_values.storage_backend_name,
+                clear_cache=True,
             )
         )
     )
@@ -976,7 +975,6 @@ async def mirror(
     timeout = config.getfloat("mirror", "timeout")
     global_timeout = config.getfloat("mirror", "global-timeout", fallback=None)
     proxy = config.get("mirror", "proxy", fallback=None)
-    storage_backend = config_values.storage_backend_name
     homedir = Path(config.get("mirror", "directory"))
 
     # Always reference those classes here with the fully qualified name to
@@ -985,7 +983,7 @@ async def mirror(
         mirror = BandersnatchMirror(
             homedir,
             master,
-            storage_backend=storage_backend,
+            storage_backend=storage_plugin,
             stop_on_error=config.getboolean("mirror", "stop-on-error"),
             workers=config.getint("mirror", "workers"),
             hash_index=config.getboolean("mirror", "hash-index"),

--- a/src/bandersnatch/tests/conftest.py
+++ b/src/bandersnatch/tests/conftest.py
@@ -14,6 +14,7 @@ from _pytest.fixtures import FixtureRequest
 from _pytest.monkeypatch import MonkeyPatch
 from s3path import PureS3Path, S3Path, _s3_accessor, register_configuration_parameter
 
+from bandersnatch.filter import LoadedFilters
 from bandersnatch.storage import Storage
 
 if TYPE_CHECKING:
@@ -122,6 +123,12 @@ def local_storage(tmp_path: Path, local_storage_factory: StorageFactory) -> Stor
 
 
 @pytest.fixture
+def empty_filters() -> LoadedFilters:
+    cfg = ConfigParser()
+    return LoadedFilters(cfg, load_all=True)
+
+
+@pytest.fixture
 def master(package_json: dict[str, Any]) -> "Master":
     from bandersnatch.master import Master
 
@@ -164,12 +171,15 @@ def mirror(
     tmp_path: Path,
     master: "Master",
     monkeypatch: MonkeyPatch,
+    empty_filters: LoadedFilters,
     local_storage_factory: StorageFactory,
 ) -> "BandersnatchMirror":
     monkeypatch.chdir(tmp_path)
     from bandersnatch.mirror import BandersnatchMirror
 
-    return BandersnatchMirror(tmp_path, master, local_storage_factory(tmp_path))
+    return BandersnatchMirror(
+        tmp_path, master, local_storage_factory(tmp_path), empty_filters
+    )
 
 
 @pytest.fixture
@@ -177,13 +187,18 @@ def mirror_hash_index(
     tmp_path: Path,
     master: "Master",
     monkeypatch: MonkeyPatch,
+    empty_filters: LoadedFilters,
     local_storage_factory: StorageFactory,
 ) -> "BandersnatchMirror":
     monkeypatch.chdir(tmp_path)
     from bandersnatch.mirror import BandersnatchMirror
 
     return BandersnatchMirror(
-        tmp_path, master, local_storage_factory(tmp_path), hash_index=True
+        tmp_path,
+        master,
+        local_storage_factory(tmp_path),
+        empty_filters,
+        hash_index=True,
     )
 
 

--- a/src/bandersnatch/tests/mock_config.py
+++ b/src/bandersnatch/tests/mock_config.py
@@ -1,4 +1,4 @@
-from bandersnatch.configuration import BandersnatchConfig
+from bandersnatch.config import BandersnatchConfig
 
 
 def mock_config(contents: str, filename: str = "test.conf") -> BandersnatchConfig:
@@ -6,10 +6,7 @@ def mock_config(contents: str, filename: str = "test.conf") -> BandersnatchConfi
     Creates a config file with contents and loads them into a
     BandersnatchConfig instance.
     """
-    with open(filename, "w") as fd:
-        fd.write(contents)
 
     instance = BandersnatchConfig()
-    instance.config_file = filename
-    instance.load_configuration()
+    instance.read_string(contents)
     return instance

--- a/src/bandersnatch/tests/plugins/test_allowlist_name.py
+++ b/src/bandersnatch/tests/plugins/test_allowlist_name.py
@@ -6,10 +6,9 @@ from unittest import TestCase
 
 import bandersnatch.filter
 import bandersnatch.storage
-from bandersnatch.master import Master
-from bandersnatch.mirror import BandersnatchMirror
 from bandersnatch.package import Package
 from bandersnatch.tests.mock_config import mock_config
+from bandersnatch.tests.plugins.util import make_test_mirror
 
 
 class TestAllowListProject(TestCase):
@@ -79,7 +78,7 @@ packages =
 """
         )
 
-        mirror = BandersnatchMirror(Path("."), Master(url="https://foo.bar.com"))
+        mirror = make_test_mirror()
         mirror.packages_to_sync = {"foo": ""}
         mirror._filter_packages()
 
@@ -102,7 +101,7 @@ packages =
 """
         )
 
-        mirror = BandersnatchMirror(Path("."), Master(url="https://foo.bar.com"))
+        mirror = make_test_mirror()
         mirror.packages_to_sync = {"foo": "", "foo2": ""}
         mirror._filter_packages()
 
@@ -126,7 +125,7 @@ packages =
 """
         )
 
-        mirror = BandersnatchMirror(Path("."), Master(url="https://foo.bar.com"))
+        mirror = make_test_mirror()
         mirror.packages_to_sync = {"foo": "", "foo2": ""}
         mirror._filter_packages()
 
@@ -150,7 +149,7 @@ packages =
     bar~=3.0,<=1.5
 """
         )
-        mirror = BandersnatchMirror(Path("."), Master(url="https://foo.bar.com"))
+        mirror = make_test_mirror()
         mirror.packages_to_sync = {
             "foo": "",
             "bar": "",
@@ -177,7 +176,7 @@ packages =
 #    bar
 """
         )
-        mirror = BandersnatchMirror(Path("."), Master(url="https://foo.bar.com"))
+        mirror = make_test_mirror()
         mirror.packages_to_sync = {
             "foo": "",
             "bar": "",
@@ -251,7 +250,7 @@ packages =
 """
         )
 
-        mirror = BandersnatchMirror(Path("."), Master(url="https://foo.bar.com"))
+        mirror = make_test_mirror()
         pkg = Package("foo", 1)
         pkg._metadata = {
             "info": {"name": "foo"},
@@ -278,7 +277,7 @@ packages =
 """
         )
 
-        mirror = BandersnatchMirror(Path("."), Master(url="https://foo.bar.com"))
+        mirror = make_test_mirror()
         pkg = Package("foo", 1)
         pkg._metadata = {
             "info": {"name": "foo"},
@@ -305,7 +304,7 @@ packages =
 """
         )
 
-        mirror = BandersnatchMirror(Path("."), Master(url="https://foo.bar.com"))
+        mirror = make_test_mirror()
         pkg = Package("foo", 1)
         pkg._metadata = {
             "info": {"name": "foo"},
@@ -339,7 +338,7 @@ packages =
 """
         )
 
-        mirror = BandersnatchMirror(Path("."), Master(url="https://foo.bar.com"))
+        mirror = make_test_mirror()
         pkg = Package("foo", 1)
         pkg._metadata = {
             "info": {"name": "foo"},
@@ -429,7 +428,7 @@ requirements =
 """
         )
 
-        mirror = BandersnatchMirror(Path("."), Master(url="https://foo.bar.com"))
+        mirror = make_test_mirror()
         pkg = Package("foo", 1)
         pkg._metadata = {
             "info": {"name": "foo"},
@@ -467,7 +466,7 @@ requirements =
 """
         )
 
-        mirror = BandersnatchMirror(Path("."), Master(url="https://foo.bar.com"))
+        mirror = make_test_mirror()
         pkg = Package("foo", 1)
         pkg._metadata = {
             "info": {"name": "foo"},
@@ -504,7 +503,7 @@ requirements =
 """
         )
 
-        mirror = BandersnatchMirror(Path("."), Master(url="https://foo.bar.com"))
+        mirror = make_test_mirror()
 
         mirror.packages_to_sync = {
             "foo": "",
@@ -540,7 +539,7 @@ requirements =
 """
         )
 
-        mirror = BandersnatchMirror(Path("."), Master(url="https://foo.bar.com"))
+        mirror = make_test_mirror()
 
         mirror.packages_to_sync = {
             "foo": "",
@@ -592,7 +591,7 @@ requirements =
 """
         )
 
-        mirror = BandersnatchMirror(Path("."), Master(url="https://foo.bar.com"))
+        mirror = make_test_mirror()
 
         mirror.packages_to_sync = {
             "foo": "",
@@ -635,7 +634,7 @@ requirements =
 """
         )
 
-        mirror = BandersnatchMirror(Path("."), Master(url="https://foo.bar.com"))
+        mirror = make_test_mirror()
 
         mirror.packages_to_sync = {
             "foo": "",

--- a/src/bandersnatch/tests/plugins/test_allowlist_name.py
+++ b/src/bandersnatch/tests/plugins/test_allowlist_name.py
@@ -41,7 +41,7 @@ enabled =
 """
         )
 
-        plugins = bandersnatch.filter.LoadedFilters(bc.config).filter_project_plugins()
+        plugins = bandersnatch.filter.LoadedFilters(bc).filter_project_plugins()
         names = [plugin.name for plugin in plugins]
         self.assertListEqual(names, ["allowlist_project"])
         self.assertEqual(len(plugins), 1)
@@ -57,7 +57,7 @@ workers = 2
 """
         )
 
-        plugins = bandersnatch.filter.LoadedFilters(bc.config).filter_project_plugins()
+        plugins = bandersnatch.filter.LoadedFilters(bc).filter_project_plugins()
         names = [plugin.name for plugin in plugins]
         self.assertNotIn("allowlist_project", names)
 
@@ -101,7 +101,7 @@ packages =
 """
         )
 
-        mirror = make_test_mirror(config=bc.config)
+        mirror = make_test_mirror(config=bc)
         mirror.packages_to_sync = {"foo": "", "foo2": ""}
         mirror._filter_packages()
 
@@ -125,7 +125,7 @@ packages =
 """
         )
 
-        mirror = make_test_mirror(config=bc.config)
+        mirror = make_test_mirror(config=bc)
         mirror.packages_to_sync = {"foo": "", "foo2": ""}
         mirror._filter_packages()
 
@@ -149,7 +149,7 @@ packages =
     bar~=3.0,<=1.5
 """
         )
-        mirror = make_test_mirror(config=bc.config)
+        mirror = make_test_mirror(config=bc)
         mirror.packages_to_sync = {
             "foo": "",
             "bar": "",
@@ -176,7 +176,7 @@ packages =
 #    bar
 """
         )
-        mirror = make_test_mirror(config=bc.config)
+        mirror = make_test_mirror(config=bc)
         mirror.packages_to_sync = {
             "foo": "",
             "bar": "",
@@ -212,7 +212,7 @@ enabled =
 """
         )
 
-        plugins = bandersnatch.filter.LoadedFilters(bc.config).filter_release_plugins()
+        plugins = bandersnatch.filter.LoadedFilters(bc).filter_release_plugins()
         names = [plugin.name for plugin in plugins]
         self.assertListEqual(names, ["allowlist_release"])
         self.assertEqual(len(plugins), 1)
@@ -230,7 +230,7 @@ enabled =
 """
         )
 
-        plugins = bandersnatch.filter.LoadedFilters(bc.config).filter_release_plugins()
+        plugins = bandersnatch.filter.LoadedFilters(bc).filter_release_plugins()
         names = [plugin.name for plugin in plugins]
         self.assertNotIn("allowlist_release", names)
 
@@ -250,7 +250,7 @@ packages =
 """
         )
 
-        mirror = make_test_mirror(config=bc.config)
+        mirror = make_test_mirror(config=bc)
         pkg = Package("foo", 1)
         pkg._metadata = {
             "info": {"name": "foo"},
@@ -277,7 +277,7 @@ packages =
 """
         )
 
-        mirror = make_test_mirror(config=bc.config)
+        mirror = make_test_mirror(config=bc)
         pkg = Package("foo", 1)
         pkg._metadata = {
             "info": {"name": "foo"},
@@ -304,7 +304,7 @@ packages =
 """
         )
 
-        mirror = make_test_mirror(config=bc.config)
+        mirror = make_test_mirror(config=bc)
         pkg = Package("foo", 1)
         pkg._metadata = {
             "info": {"name": "foo"},
@@ -338,7 +338,7 @@ packages =
 """
         )
 
-        mirror = make_test_mirror(config=bc.config)
+        mirror = make_test_mirror(config=bc)
         pkg = Package("foo", 1)
         pkg._metadata = {
             "info": {"name": "foo"},
@@ -379,7 +379,7 @@ enabled =
 """
         )
 
-        plugins = bandersnatch.filter.LoadedFilters(bc.config).filter_release_plugins()
+        plugins = bandersnatch.filter.LoadedFilters(bc).filter_release_plugins()
         names = [plugin.name for plugin in plugins]
         self.assertListEqual(names, ["project_requirements_pinned"])
         self.assertEqual(len(plugins), 1)
@@ -397,7 +397,7 @@ enabled =
 """
         )
 
-        plugins = bandersnatch.filter.LoadedFilters(bc.config).filter_release_plugins()
+        plugins = bandersnatch.filter.LoadedFilters(bc).filter_release_plugins()
         names = [plugin.name for plugin in plugins]
         self.assertNotIn("project_requirements", names)
 
@@ -428,7 +428,7 @@ requirements =
 """
         )
 
-        mirror = make_test_mirror(config=bc.config)
+        mirror = make_test_mirror(config=bc)
         pkg = Package("foo", 1)
         pkg._metadata = {
             "info": {"name": "foo"},
@@ -466,7 +466,7 @@ requirements =
 """
         )
 
-        mirror = make_test_mirror(config=bc.config)
+        mirror = make_test_mirror(config=bc)
         pkg = Package("foo", 1)
         pkg._metadata = {
             "info": {"name": "foo"},
@@ -503,7 +503,7 @@ requirements =
 """
         )
 
-        mirror = make_test_mirror(config=bc.config)
+        mirror = make_test_mirror(config=bc)
 
         mirror.packages_to_sync = {
             "foo": "",
@@ -539,7 +539,7 @@ requirements =
 """
         )
 
-        mirror = make_test_mirror(config=bc.config)
+        mirror = make_test_mirror(config=bc)
 
         mirror.packages_to_sync = {
             "foo": "",
@@ -591,7 +591,7 @@ requirements =
 """
         )
 
-        mirror = make_test_mirror(config=bc.config)
+        mirror = make_test_mirror(config=bc)
 
         mirror.packages_to_sync = {
             "foo": "",
@@ -634,7 +634,7 @@ requirements =
 """
         )
 
-        mirror = make_test_mirror(config=bc.config)
+        mirror = make_test_mirror(config=bc)
 
         mirror.packages_to_sync = {
             "foo": "",

--- a/src/bandersnatch/tests/plugins/test_blocklist_name.py
+++ b/src/bandersnatch/tests/plugins/test_blocklist_name.py
@@ -37,7 +37,7 @@ enabled =
 """
         )
 
-        plugins = bandersnatch.filter.LoadedFilters(bc.config).filter_project_plugins()
+        plugins = bandersnatch.filter.LoadedFilters(bc).filter_project_plugins()
         names = [plugin.name for plugin in plugins]
         self.assertListEqual(names, ["blocklist_project"])
         self.assertEqual(len(plugins), 1)
@@ -51,7 +51,7 @@ enabled =
 """
         )
 
-        plugins = bandersnatch.filter.LoadedFilters(bc.config).filter_project_plugins()
+        plugins = bandersnatch.filter.LoadedFilters(bc).filter_project_plugins()
         names = [plugin.name for plugin in plugins]
         self.assertNotIn("blocklist_project", names)
 
@@ -62,7 +62,7 @@ enabled =
 """
         )
 
-        plugins = bandersnatch.filter.LoadedFilters(bc.config).filter_project_plugins()
+        plugins = bandersnatch.filter.LoadedFilters(bc).filter_project_plugins()
         names = [plugin.name for plugin in plugins]
         self.assertNotIn("blocklist_project", names)
 
@@ -78,7 +78,7 @@ packages =
 """
         )
 
-        mirror = make_test_mirror(config=bc.config)
+        mirror = make_test_mirror(config=bc)
         mirror.packages_to_sync = {"foo": ""}
         mirror._filter_packages()
 
@@ -95,7 +95,7 @@ packages =
         """
         )
 
-        mirror = make_test_mirror(config=bc.config)
+        mirror = make_test_mirror(config=bc)
         mirror.packages_to_sync = {"foo2": ""}
         mirror._filter_packages()
 
@@ -117,7 +117,7 @@ packages =
 """
         )
 
-        mirror = make_test_mirror(config=bc.config)
+        mirror = make_test_mirror(config=bc)
         mirror.packages_to_sync = {"foo": "", "foo2": ""}
         mirror._filter_packages()
 
@@ -141,7 +141,7 @@ packages =
     snu
 """
         )
-        mirror = make_test_mirror(config=bc.config)
+        mirror = make_test_mirror(config=bc)
         mirror.packages_to_sync = {
             "foo": "",
             "foo2": "",
@@ -182,7 +182,7 @@ enabled =
 """
         )
 
-        plugins = bandersnatch.filter.LoadedFilters(bc.config).filter_release_plugins()
+        plugins = bandersnatch.filter.LoadedFilters(bc).filter_release_plugins()
         names = [plugin.name for plugin in plugins]
         self.assertListEqual(names, ["blocklist_release"])
         self.assertEqual(len(plugins), 1)
@@ -196,7 +196,7 @@ enabled =
 """
         )
 
-        plugins = bandersnatch.filter.LoadedFilters(bc.config).filter_release_plugins()
+        plugins = bandersnatch.filter.LoadedFilters(bc).filter_release_plugins()
         names = [plugin.name for plugin in plugins]
         self.assertNotIn("blocklist_release", names)
 
@@ -212,7 +212,7 @@ packages =
 """
         )
 
-        mirror = make_test_mirror(config=bc.config)
+        mirror = make_test_mirror(config=bc)
         pkg = Package("foo", 1)
         pkg._metadata = {
             "info": {"name": "foo"},
@@ -235,7 +235,7 @@ packages =
 """
         )
 
-        mirror = make_test_mirror(config=bc.config)
+        mirror = make_test_mirror(config=bc)
         pkg = Package("foo", 1)
         pkg._metadata = {
             "info": {"name": "foo"},
@@ -265,7 +265,7 @@ packages =
 """
         )
 
-        mirror = make_test_mirror(config=bc.config)
+        mirror = make_test_mirror(config=bc)
         pkg = Package("foo", 1)
         pkg._metadata = {
             "info": {"name": "foo"},

--- a/src/bandersnatch/tests/plugins/test_blocklist_name.py
+++ b/src/bandersnatch/tests/plugins/test_blocklist_name.py
@@ -29,7 +29,7 @@ class TestBlockListProject(TestCase):
             self.tempdir = None
 
     def test__plugin__loads__explicitly_enabled(self) -> None:
-        mock_config(
+        bc = mock_config(
             """\
 [plugins]
 enabled =
@@ -37,13 +37,13 @@ enabled =
 """
         )
 
-        plugins = bandersnatch.filter.LoadedFilters().filter_project_plugins()
+        plugins = bandersnatch.filter.LoadedFilters(bc.config).filter_project_plugins()
         names = [plugin.name for plugin in plugins]
         self.assertListEqual(names, ["blocklist_project"])
         self.assertEqual(len(plugins), 1)
 
     def test__plugin__doesnt_load__explicitly__disabled(self) -> None:
-        mock_config(
+        bc = mock_config(
             """\
 [plugins]
 enabled =
@@ -51,23 +51,23 @@ enabled =
 """
         )
 
-        plugins = bandersnatch.filter.LoadedFilters().filter_project_plugins()
+        plugins = bandersnatch.filter.LoadedFilters(bc.config).filter_project_plugins()
         names = [plugin.name for plugin in plugins]
         self.assertNotIn("blocklist_project", names)
 
     def test__plugin__loads__default(self) -> None:
-        mock_config(
+        bc = mock_config(
             """\
 [blocklist]
 """
         )
 
-        plugins = bandersnatch.filter.LoadedFilters().filter_project_plugins()
+        plugins = bandersnatch.filter.LoadedFilters(bc.config).filter_project_plugins()
         names = [plugin.name for plugin in plugins]
         self.assertNotIn("blocklist_project", names)
 
     def test__filter__matches__package(self) -> None:
-        mock_config(
+        bc = mock_config(
             """\
 [plugins]
 enabled =
@@ -78,14 +78,14 @@ packages =
 """
         )
 
-        mirror = make_test_mirror()
+        mirror = make_test_mirror(config=bc.config)
         mirror.packages_to_sync = {"foo": ""}
         mirror._filter_packages()
 
         self.assertNotIn("foo", mirror.packages_to_sync.keys())
 
     def test__filter__nomatch_package(self) -> None:
-        mock_config(
+        bc = mock_config(
             """\
         [blocklist]
         plugins =
@@ -95,14 +95,14 @@ packages =
         """
         )
 
-        mirror = make_test_mirror()
+        mirror = make_test_mirror(config=bc.config)
         mirror.packages_to_sync = {"foo2": ""}
         mirror._filter_packages()
 
         self.assertIn("foo2", mirror.packages_to_sync.keys())
 
     def test__filter__name_only(self) -> None:
-        mock_config(
+        bc = mock_config(
             """\
 [mirror]
 storage-backend = filesystem
@@ -117,7 +117,7 @@ packages =
 """
         )
 
-        mirror = make_test_mirror()
+        mirror = make_test_mirror(config=bc.config)
         mirror.packages_to_sync = {"foo": "", "foo2": ""}
         mirror._filter_packages()
 
@@ -125,7 +125,7 @@ packages =
         self.assertIn("foo2", mirror.packages_to_sync.keys())
 
     def test__filter__varying__specifiers(self) -> None:
-        mock_config(
+        bc = mock_config(
             """\
 [mirror]
 storage-backend = filesystem
@@ -141,7 +141,7 @@ packages =
     snu
 """
         )
-        mirror = make_test_mirror()
+        mirror = make_test_mirror(config=bc.config)
         mirror.packages_to_sync = {
             "foo": "",
             "foo2": "",
@@ -174,7 +174,7 @@ class TestBlockListRelease(TestCase):
             self.tempdir = None
 
     def test__plugin__loads__explicitly_enabled(self) -> None:
-        mock_config(
+        bc = mock_config(
             """\
 [plugins]
 enabled =
@@ -182,13 +182,13 @@ enabled =
 """
         )
 
-        plugins = bandersnatch.filter.LoadedFilters().filter_release_plugins()
+        plugins = bandersnatch.filter.LoadedFilters(bc.config).filter_release_plugins()
         names = [plugin.name for plugin in plugins]
         self.assertListEqual(names, ["blocklist_release"])
         self.assertEqual(len(plugins), 1)
 
     def test__plugin__doesnt_load__explicitly__disabled(self) -> None:
-        mock_config(
+        bc = mock_config(
             """\
 [plugins]
 enabled =
@@ -196,12 +196,12 @@ enabled =
 """
         )
 
-        plugins = bandersnatch.filter.LoadedFilters().filter_release_plugins()
+        plugins = bandersnatch.filter.LoadedFilters(bc.config).filter_release_plugins()
         names = [plugin.name for plugin in plugins]
         self.assertNotIn("blocklist_release", names)
 
     def test__filter__matches__release(self) -> None:
-        mock_config(
+        bc = mock_config(
             """\
 [plugins]
 enabled =
@@ -212,7 +212,7 @@ packages =
 """
         )
 
-        mirror = make_test_mirror()
+        mirror = make_test_mirror(config=bc.config)
         pkg = Package("foo", 1)
         pkg._metadata = {
             "info": {"name": "foo"},
@@ -224,7 +224,7 @@ packages =
         self.assertEqual(pkg.releases, {"1.2.1": {}})
 
     def test__dont__filter__prereleases(self) -> None:
-        mock_config(
+        bc = mock_config(
             """\
 [plugins]
 enabled =
@@ -235,7 +235,7 @@ packages =
 """
         )
 
-        mirror = make_test_mirror()
+        mirror = make_test_mirror(config=bc.config)
         pkg = Package("foo", 1)
         pkg._metadata = {
             "info": {"name": "foo"},
@@ -254,7 +254,7 @@ packages =
         self.assertEqual(pkg.releases, {"1.2.1": {}, "1.2.2alpha3": {}, "1.2.3rc1": {}})
 
     def test__casing__no__affect(self) -> None:
-        mock_config(
+        bc = mock_config(
             """\
 [plugins]
 enabled =
@@ -265,7 +265,7 @@ packages =
 """
         )
 
-        mirror = make_test_mirror()
+        mirror = make_test_mirror(config=bc.config)
         pkg = Package("foo", 1)
         pkg._metadata = {
             "info": {"name": "foo"},

--- a/src/bandersnatch/tests/plugins/test_blocklist_name.py
+++ b/src/bandersnatch/tests/plugins/test_blocklist_name.py
@@ -1,13 +1,11 @@
 import os
-from pathlib import Path
 from tempfile import TemporaryDirectory
 from unittest import TestCase
 
 import bandersnatch.filter
-from bandersnatch.master import Master
-from bandersnatch.mirror import BandersnatchMirror
 from bandersnatch.package import Package
 from bandersnatch.tests.mock_config import mock_config
+from bandersnatch.tests.plugins.util import make_test_mirror
 
 
 class TestBlockListProject(TestCase):
@@ -80,7 +78,7 @@ packages =
 """
         )
 
-        mirror = BandersnatchMirror(Path("."), Master(url="https://foo.bar.com"))
+        mirror = make_test_mirror()
         mirror.packages_to_sync = {"foo": ""}
         mirror._filter_packages()
 
@@ -97,7 +95,7 @@ packages =
         """
         )
 
-        mirror = BandersnatchMirror(Path("."), Master(url="https://foo.bar.com"))
+        mirror = make_test_mirror()
         mirror.packages_to_sync = {"foo2": ""}
         mirror._filter_packages()
 
@@ -119,7 +117,7 @@ packages =
 """
         )
 
-        mirror = BandersnatchMirror(Path("."), Master(url="https://foo.bar.com"))
+        mirror = make_test_mirror()
         mirror.packages_to_sync = {"foo": "", "foo2": ""}
         mirror._filter_packages()
 
@@ -143,7 +141,7 @@ packages =
     snu
 """
         )
-        mirror = BandersnatchMirror(Path("."), Master(url="https://foo.bar.com"))
+        mirror = make_test_mirror()
         mirror.packages_to_sync = {
             "foo": "",
             "foo2": "",
@@ -214,7 +212,7 @@ packages =
 """
         )
 
-        mirror = BandersnatchMirror(Path("."), Master(url="https://foo.bar.com"))
+        mirror = make_test_mirror()
         pkg = Package("foo", 1)
         pkg._metadata = {
             "info": {"name": "foo"},
@@ -237,7 +235,7 @@ packages =
 """
         )
 
-        mirror = BandersnatchMirror(Path("."), Master(url="https://foo.bar.com"))
+        mirror = make_test_mirror()
         pkg = Package("foo", 1)
         pkg._metadata = {
             "info": {"name": "foo"},
@@ -267,7 +265,7 @@ packages =
 """
         )
 
-        mirror = BandersnatchMirror(Path("."), Master(url="https://foo.bar.com"))
+        mirror = make_test_mirror()
         pkg = Package("foo", 1)
         pkg._metadata = {
             "info": {"name": "foo"},

--- a/src/bandersnatch/tests/plugins/test_filename.py
+++ b/src/bandersnatch/tests/plugins/test_filename.py
@@ -45,9 +45,11 @@ platforms =
 """
 
     def test_plugin_compiles_patterns(self) -> None:
-        mock_config(self.config_contents)
+        bc = mock_config(self.config_contents)
 
-        plugins = bandersnatch.filter.LoadedFilters().filter_release_file_plugins()
+        plugins = bandersnatch.filter.LoadedFilters(
+            bc.config
+        ).filter_release_file_plugins()
 
         assert any(
             type(plugin) is filename_name.ExcludePlatformFilter for plugin in plugins
@@ -60,9 +62,9 @@ platforms =
         freebsd and macos packages while only dropping linux-armv7l from
         linux packages
         """
-        mock_config(self.config_contents)
+        bc = mock_config(self.config_contents)
 
-        mirror = make_test_mirror()
+        mirror = make_test_mirror(config=bc.config)
         pkg = Package("foobar", 1)
         pkg._metadata = {
             "info": {"name": "foobar", "version": "1.0"},

--- a/src/bandersnatch/tests/plugins/test_filename.py
+++ b/src/bandersnatch/tests/plugins/test_filename.py
@@ -47,9 +47,7 @@ platforms =
     def test_plugin_compiles_patterns(self) -> None:
         bc = mock_config(self.config_contents)
 
-        plugins = bandersnatch.filter.LoadedFilters(
-            bc.config
-        ).filter_release_file_plugins()
+        plugins = bandersnatch.filter.LoadedFilters(bc).filter_release_file_plugins()
 
         assert any(
             type(plugin) is filename_name.ExcludePlatformFilter for plugin in plugins
@@ -64,7 +62,7 @@ platforms =
         """
         bc = mock_config(self.config_contents)
 
-        mirror = make_test_mirror(config=bc.config)
+        mirror = make_test_mirror(config=bc)
         pkg = Package("foobar", 1)
         pkg._metadata = {
             "info": {"name": "foobar", "version": "1.0"},

--- a/src/bandersnatch/tests/plugins/test_filename.py
+++ b/src/bandersnatch/tests/plugins/test_filename.py
@@ -1,13 +1,11 @@
 import os
-from pathlib import Path
 from tempfile import TemporaryDirectory
 from unittest import TestCase
 
 import bandersnatch.filter
-from bandersnatch.master import Master
-from bandersnatch.mirror import BandersnatchMirror
 from bandersnatch.package import Package
 from bandersnatch.tests.mock_config import mock_config
+from bandersnatch.tests.plugins.util import make_test_mirror
 from bandersnatch_filter_plugins import filename_name
 
 
@@ -64,7 +62,7 @@ platforms =
         """
         mock_config(self.config_contents)
 
-        mirror = BandersnatchMirror(Path("."), Master(url="https://foo.bar.com"))
+        mirror = make_test_mirror()
         pkg = Package("foobar", 1)
         pkg._metadata = {
             "info": {"name": "foobar", "version": "1.0"},

--- a/src/bandersnatch/tests/plugins/test_latest_release.py
+++ b/src/bandersnatch/tests/plugins/test_latest_release.py
@@ -1,13 +1,11 @@
 import os
-from pathlib import Path
 from tempfile import TemporaryDirectory
 from unittest import TestCase
 
 import bandersnatch.filter
-from bandersnatch.master import Master
-from bandersnatch.mirror import BandersnatchMirror
 from bandersnatch.package import Package
 from bandersnatch.tests.mock_config import mock_config
+from bandersnatch.tests.plugins.util import make_test_mirror
 from bandersnatch_filter_plugins import latest_name
 
 
@@ -56,7 +54,7 @@ keep = 2
     def test_latest_releases_keep_latest(self) -> None:
         mock_config(self.config_contents)
 
-        mirror = BandersnatchMirror(Path("."), Master(url="https://foo.bar.com"))
+        mirror = make_test_mirror()
         pkg = Package("foo", 1)
         pkg._metadata = {
             "info": {"name": "foo", "version": "2.0.0"},
@@ -77,7 +75,7 @@ keep = 2
     def test_latest_releases_keep_latest_time(self) -> None:
         mock_config(self.config_contents + "\nsort_by = time")
 
-        mirror = BandersnatchMirror(Path("."), Master(url="https://foo.bar.com"))
+        mirror = make_test_mirror()
         pkg = Package("foo", 1)
         pkg._metadata = {
             "info": {"name": "foo", "version": "2.0.0"},
@@ -102,7 +100,7 @@ keep = 2
     def test_latest_releases_keep_stable(self) -> None:
         mock_config(self.config_contents)
 
-        mirror = BandersnatchMirror(Path("."), Master(url="https://foo.bar.com"))
+        mirror = make_test_mirror()
         pkg = Package("foo", 1)
         pkg._metadata = {
             "info": {"name": "foo", "version": "2.0.0"},  # stable version
@@ -129,7 +127,7 @@ keep = 2
         """
         mock_config(self.config_contents)
 
-        mirror = BandersnatchMirror(Path("."), Master(url="https://foo.bar.com"))
+        mirror = make_test_mirror()
         pkg1 = Package("foo", 1)
         pkg1._metadata = {
             "info": {"name": "foo", "version": "2.0.0"},
@@ -190,7 +188,7 @@ enabled =
     def test_latest_releases_uninitialized(self) -> None:
         mock_config(self.config_contents)
 
-        mirror = BandersnatchMirror(Path("."), Master(url="https://foo.bar.com"))
+        mirror = make_test_mirror()
         pkg = Package("foo", 1)
         pkg._metadata = {
             "info": {"name": "foo", "version": "2.0.0"},

--- a/src/bandersnatch/tests/plugins/test_latest_release.py
+++ b/src/bandersnatch/tests/plugins/test_latest_release.py
@@ -39,7 +39,7 @@ keep = 2
     def test_plugin_compiles_patterns(self) -> None:
         bc = mock_config(self.config_contents)
 
-        plugins = bandersnatch.filter.LoadedFilters(bc.config).filter_release_plugins()
+        plugins = bandersnatch.filter.LoadedFilters(bc).filter_release_plugins()
 
         assert any(
             type(plugin) is latest_name.LatestReleaseFilter for plugin in plugins
@@ -54,7 +54,7 @@ keep = 2
     def test_latest_releases_keep_latest(self) -> None:
         bc = mock_config(self.config_contents)
 
-        mirror = make_test_mirror(config=bc.config)
+        mirror = make_test_mirror(config=bc)
         pkg = Package("foo", 1)
         pkg._metadata = {
             "info": {"name": "foo", "version": "2.0.0"},
@@ -75,7 +75,7 @@ keep = 2
     def test_latest_releases_keep_latest_time(self) -> None:
         bc = mock_config(self.config_contents + "\nsort_by = time")
 
-        mirror = make_test_mirror(config=bc.config)
+        mirror = make_test_mirror(config=bc)
         pkg = Package("foo", 1)
         pkg._metadata = {
             "info": {"name": "foo", "version": "2.0.0"},
@@ -100,7 +100,7 @@ keep = 2
     def test_latest_releases_keep_stable(self) -> None:
         bc = mock_config(self.config_contents)
 
-        mirror = make_test_mirror(config=bc.config)
+        mirror = make_test_mirror(config=bc)
         pkg = Package("foo", 1)
         pkg._metadata = {
             "info": {"name": "foo", "version": "2.0.0"},  # stable version
@@ -127,7 +127,7 @@ keep = 2
         """
         bc = mock_config(self.config_contents)
 
-        mirror = make_test_mirror(config=bc.config)
+        mirror = make_test_mirror(config=bc)
         pkg1 = Package("foo", 1)
         pkg1._metadata = {
             "info": {"name": "foo", "version": "2.0.0"},
@@ -173,7 +173,7 @@ enabled =
     def test_plugin_compiles_patterns(self) -> None:
         bc = mock_config(self.config_contents)
 
-        plugins = bandersnatch.filter.LoadedFilters(bc.config).filter_release_plugins()
+        plugins = bandersnatch.filter.LoadedFilters(bc).filter_release_plugins()
 
         assert any(
             type(plugin) is latest_name.LatestReleaseFilter for plugin in plugins

--- a/src/bandersnatch/tests/plugins/test_latest_release.py
+++ b/src/bandersnatch/tests/plugins/test_latest_release.py
@@ -37,9 +37,9 @@ keep = 2
 """
 
     def test_plugin_compiles_patterns(self) -> None:
-        mock_config(self.config_contents)
+        bc = mock_config(self.config_contents)
 
-        plugins = bandersnatch.filter.LoadedFilters().filter_release_plugins()
+        plugins = bandersnatch.filter.LoadedFilters(bc.config).filter_release_plugins()
 
         assert any(
             type(plugin) is latest_name.LatestReleaseFilter for plugin in plugins
@@ -52,9 +52,9 @@ keep = 2
         assert plugin.keep == 2
 
     def test_latest_releases_keep_latest(self) -> None:
-        mock_config(self.config_contents)
+        bc = mock_config(self.config_contents)
 
-        mirror = make_test_mirror()
+        mirror = make_test_mirror(config=bc.config)
         pkg = Package("foo", 1)
         pkg._metadata = {
             "info": {"name": "foo", "version": "2.0.0"},
@@ -73,9 +73,9 @@ keep = 2
         assert pkg.releases == {"1.1.3": {}, "2.0.0": {}}
 
     def test_latest_releases_keep_latest_time(self) -> None:
-        mock_config(self.config_contents + "\nsort_by = time")
+        bc = mock_config(self.config_contents + "\nsort_by = time")
 
-        mirror = make_test_mirror()
+        mirror = make_test_mirror(config=bc.config)
         pkg = Package("foo", 1)
         pkg._metadata = {
             "info": {"name": "foo", "version": "2.0.0"},
@@ -98,9 +98,9 @@ keep = 2
         }
 
     def test_latest_releases_keep_stable(self) -> None:
-        mock_config(self.config_contents)
+        bc = mock_config(self.config_contents)
 
-        mirror = make_test_mirror()
+        mirror = make_test_mirror(config=bc.config)
         pkg = Package("foo", 1)
         pkg._metadata = {
             "info": {"name": "foo", "version": "2.0.0"},  # stable version
@@ -125,9 +125,9 @@ keep = 2
         Tests the filter multiple times to ensure no state is preserved and
         thus is reusable between packages
         """
-        mock_config(self.config_contents)
+        bc = mock_config(self.config_contents)
 
-        mirror = make_test_mirror()
+        mirror = make_test_mirror(config=bc.config)
         pkg1 = Package("foo", 1)
         pkg1._metadata = {
             "info": {"name": "foo", "version": "2.0.0"},
@@ -171,9 +171,9 @@ enabled =
 """
 
     def test_plugin_compiles_patterns(self) -> None:
-        mock_config(self.config_contents)
+        bc = mock_config(self.config_contents)
 
-        plugins = bandersnatch.filter.LoadedFilters().filter_release_plugins()
+        plugins = bandersnatch.filter.LoadedFilters(bc.config).filter_release_plugins()
 
         assert any(
             type(plugin) is latest_name.LatestReleaseFilter for plugin in plugins

--- a/src/bandersnatch/tests/plugins/test_metadata_plugins.py
+++ b/src/bandersnatch/tests/plugins/test_metadata_plugins.py
@@ -38,7 +38,7 @@ max_package_size = 1G
 """
         )
 
-        plugins = bandersnatch.filter.LoadedFilters(bc.config).filter_metadata_plugins()
+        plugins = bandersnatch.filter.LoadedFilters(bc).filter_metadata_plugins()
         names = [plugin.name for plugin in plugins]
         self.assertListEqual(names, ["size_project_metadata"])
         self.assertEqual(len(plugins), 1)
@@ -58,7 +58,7 @@ max_package_size = 2K
 """
         )
 
-        mirror = make_test_mirror(config=bc.config)
+        mirror = make_test_mirror(config=bc)
 
         # Test that under-sized project is allowed
         pkg = Package("foo", 1)
@@ -92,7 +92,7 @@ packages =
 """
         )
 
-        mirror = make_test_mirror(config=bc.config)
+        mirror = make_test_mirror(config=bc)
 
         # Test that under-sized, allowlisted project is allowed
         pkg = Package("foo", 1)

--- a/src/bandersnatch/tests/plugins/test_metadata_plugins.py
+++ b/src/bandersnatch/tests/plugins/test_metadata_plugins.py
@@ -1,14 +1,12 @@
 import os
-from pathlib import Path
 from tempfile import TemporaryDirectory
 from typing import cast
 from unittest import TestCase
 
 import bandersnatch.filter
-from bandersnatch.master import Master
-from bandersnatch.mirror import BandersnatchMirror
 from bandersnatch.package import Package
 from bandersnatch.tests.mock_config import mock_config
+from bandersnatch.tests.plugins.util import make_test_mirror
 from bandersnatch_filter_plugins.metadata_filter import SizeProjectMetadataFilter
 
 
@@ -60,7 +58,7 @@ max_package_size = 2K
 """
         )
 
-        mirror = BandersnatchMirror(Path("."), Master(url="https://foo.bar.com"))
+        mirror = make_test_mirror()
 
         # Test that under-sized project is allowed
         pkg = Package("foo", 1)
@@ -94,7 +92,7 @@ packages =
 """
         )
 
-        mirror = BandersnatchMirror(Path("."), Master(url="https://foo.bar.com"))
+        mirror = make_test_mirror()
 
         # Test that under-sized, allowlisted project is allowed
         pkg = Package("foo", 1)

--- a/src/bandersnatch/tests/plugins/test_metadata_plugins.py
+++ b/src/bandersnatch/tests/plugins/test_metadata_plugins.py
@@ -27,7 +27,7 @@ class TestSizeProjectMetadataFilter(TestCase):
             self.tempdir.cleanup()
 
     def test__size__plugin__loads__and__initializes(self) -> None:
-        mock_config(
+        bc = mock_config(
             """\
 [plugins]
 enabled =
@@ -38,7 +38,7 @@ max_package_size = 1G
 """
         )
 
-        plugins = bandersnatch.filter.LoadedFilters().filter_metadata_plugins()
+        plugins = bandersnatch.filter.LoadedFilters(bc.config).filter_metadata_plugins()
         names = [plugin.name for plugin in plugins]
         self.assertListEqual(names, ["size_project_metadata"])
         self.assertEqual(len(plugins), 1)
@@ -47,7 +47,7 @@ max_package_size = 1G
         self.assertTrue(plugin.initialized)
 
     def test__filter__size__only(self) -> None:
-        mock_config(
+        bc = mock_config(
             """\
 [plugins]
 enabled =
@@ -58,7 +58,7 @@ max_package_size = 2K
 """
         )
 
-        mirror = make_test_mirror()
+        mirror = make_test_mirror(config=bc.config)
 
         # Test that under-sized project is allowed
         pkg = Package("foo", 1)
@@ -77,7 +77,7 @@ max_package_size = 2K
         self.assertFalse(pkg.filter_metadata(mirror.filters.filter_metadata_plugins()))
 
     def test__filter__size__or__allowlist(self) -> None:
-        mock_config(
+        bc = mock_config(
             """\
 [plugins]
 enabled =
@@ -92,7 +92,7 @@ packages =
 """
         )
 
-        mirror = make_test_mirror()
+        mirror = make_test_mirror(config=bc.config)
 
         # Test that under-sized, allowlisted project is allowed
         pkg = Package("foo", 1)

--- a/src/bandersnatch/tests/plugins/test_prerelease_name.py
+++ b/src/bandersnatch/tests/plugins/test_prerelease_name.py
@@ -43,7 +43,7 @@ packages =
     def test_plugin_includes_predefined_patterns(self) -> None:
         bc = mock_config(self.config_contents)
 
-        plugins = bandersnatch.filter.LoadedFilters(bc.config).filter_release_plugins()
+        plugins = bandersnatch.filter.LoadedFilters(bc).filter_release_plugins()
 
         assert any(
             type(plugin) is prerelease_name.PreReleaseFilter for plugin in plugins
@@ -80,10 +80,10 @@ packages =
 
     def test_plugin_filter_all(self) -> None:
         bc = mock_config(self.config_contents)
-        assert self._check_filter("foo", bc.config) is True
-        assert self._check_filter("duckdb", bc.config) is True
+        assert self._check_filter("foo", bc) is True
+        assert self._check_filter("duckdb", bc) is True
 
     def test_plugin_filter_packages(self) -> None:
         bc = mock_config(self.config_contents + self.config_match_package)
-        assert self._check_filter("foo", bc.config) is False
-        assert self._check_filter("duckdb", bc.config) is True
+        assert self._check_filter("foo", bc) is False
+        assert self._check_filter("duckdb", bc) is True

--- a/src/bandersnatch/tests/plugins/test_prerelease_name.py
+++ b/src/bandersnatch/tests/plugins/test_prerelease_name.py
@@ -1,14 +1,12 @@
 import os
 import re
-from pathlib import Path
 from tempfile import TemporaryDirectory
 from unittest import TestCase
 
 import bandersnatch.filter
-from bandersnatch.master import Master
-from bandersnatch.mirror import BandersnatchMirror
 from bandersnatch.package import Package
 from bandersnatch.tests.mock_config import mock_config
+from bandersnatch.tests.plugins.util import make_test_mirror
 from bandersnatch_filter_plugins import prerelease_name
 
 
@@ -60,7 +58,7 @@ packages =
         assert plugin.patterns == expected_patterns
 
     def _check_filter(self, package: str) -> bool:
-        mirror = BandersnatchMirror(Path("."), Master(url="https://foo.bar.com"))
+        mirror = make_test_mirror()
         pkg = Package(package, serial=1)
         pkg._metadata = {
             "info": {"name": package, "version": "1.2.0"},

--- a/src/bandersnatch/tests/plugins/test_regex_name.py
+++ b/src/bandersnatch/tests/plugins/test_regex_name.py
@@ -40,9 +40,9 @@ releases =
 """
 
     def test_plugin_compiles_patterns(self) -> None:
-        mock_config(self.config_contents)
+        bc = mock_config(self.config_contents)
 
-        plugins = bandersnatch.filter.LoadedFilters().filter_release_plugins()
+        plugins = bandersnatch.filter.LoadedFilters(bc.config).filter_release_plugins()
 
         assert any(type(plugin) is regex_name.RegexReleaseFilter for plugin in plugins)
         plugin = next(
@@ -53,9 +53,9 @@ releases =
         assert plugin.patterns == [re.compile(r".+rc\d$"), re.compile(r".+alpha\d$")]
 
     def test_plugin_check_match(self) -> None:
-        mock_config(self.config_contents)
+        bc = mock_config(self.config_contents)
 
-        mirror = make_test_mirror()
+        mirror = make_test_mirror(config=bc.config)
         pkg = Package("foo", 1)
         pkg._metadata = {
             "info": {"name": "foo", "version": "foo-1.2.0"},
@@ -80,9 +80,9 @@ packages =
 """
 
     def test_plugin_compiles_patterns(self) -> None:
-        mock_config(self.config_contents)
+        bc = mock_config(self.config_contents)
 
-        plugins = bandersnatch.filter.LoadedFilters().filter_project_plugins()
+        plugins = bandersnatch.filter.LoadedFilters(bc.config).filter_project_plugins()
 
         assert any(type(plugin) is regex_name.RegexProjectFilter for plugin in plugins)
         plugin = next(
@@ -93,9 +93,9 @@ packages =
         assert plugin.patterns == [re.compile(r".+-evil$"), re.compile(r".+-neutral$")]
 
     def test_plugin_check_match(self) -> None:
-        mock_config(self.config_contents)
+        bc = mock_config(self.config_contents)
 
-        mirror = make_test_mirror()
+        mirror = make_test_mirror(config=bc.config)
         mirror.packages_to_sync = {"foo-good": "", "foo-evil": "", "foo-neutral": ""}
         mirror._filter_packages()
 

--- a/src/bandersnatch/tests/plugins/test_regex_name.py
+++ b/src/bandersnatch/tests/plugins/test_regex_name.py
@@ -1,14 +1,12 @@
 import os
 import re
-from pathlib import Path
 from tempfile import TemporaryDirectory
 from unittest import TestCase
 
 import bandersnatch.filter
-from bandersnatch.master import Master
-from bandersnatch.mirror import BandersnatchMirror
 from bandersnatch.package import Package
 from bandersnatch.tests.mock_config import mock_config
+from bandersnatch.tests.plugins.util import make_test_mirror
 from bandersnatch_filter_plugins import regex_name
 
 
@@ -57,7 +55,7 @@ releases =
     def test_plugin_check_match(self) -> None:
         mock_config(self.config_contents)
 
-        mirror = BandersnatchMirror(Path("."), Master(url="https://foo.bar.com"))
+        mirror = make_test_mirror()
         pkg = Package("foo", 1)
         pkg._metadata = {
             "info": {"name": "foo", "version": "foo-1.2.0"},
@@ -97,7 +95,7 @@ packages =
     def test_plugin_check_match(self) -> None:
         mock_config(self.config_contents)
 
-        mirror = BandersnatchMirror(Path("."), Master(url="https://foo.bar.com"))
+        mirror = make_test_mirror()
         mirror.packages_to_sync = {"foo-good": "", "foo-evil": "", "foo-neutral": ""}
         mirror._filter_packages()
 

--- a/src/bandersnatch/tests/plugins/test_regex_name.py
+++ b/src/bandersnatch/tests/plugins/test_regex_name.py
@@ -42,7 +42,7 @@ releases =
     def test_plugin_compiles_patterns(self) -> None:
         bc = mock_config(self.config_contents)
 
-        plugins = bandersnatch.filter.LoadedFilters(bc.config).filter_release_plugins()
+        plugins = bandersnatch.filter.LoadedFilters(bc).filter_release_plugins()
 
         assert any(type(plugin) is regex_name.RegexReleaseFilter for plugin in plugins)
         plugin = next(
@@ -55,7 +55,7 @@ releases =
     def test_plugin_check_match(self) -> None:
         bc = mock_config(self.config_contents)
 
-        mirror = make_test_mirror(config=bc.config)
+        mirror = make_test_mirror(config=bc)
         pkg = Package("foo", 1)
         pkg._metadata = {
             "info": {"name": "foo", "version": "foo-1.2.0"},
@@ -82,7 +82,7 @@ packages =
     def test_plugin_compiles_patterns(self) -> None:
         bc = mock_config(self.config_contents)
 
-        plugins = bandersnatch.filter.LoadedFilters(bc.config).filter_project_plugins()
+        plugins = bandersnatch.filter.LoadedFilters(bc).filter_project_plugins()
 
         assert any(type(plugin) is regex_name.RegexProjectFilter for plugin in plugins)
         plugin = next(
@@ -95,7 +95,7 @@ packages =
     def test_plugin_check_match(self) -> None:
         bc = mock_config(self.config_contents)
 
-        mirror = make_test_mirror(config=bc.config)
+        mirror = make_test_mirror(config=bc)
         mirror.packages_to_sync = {"foo-good": "", "foo-evil": "", "foo-neutral": ""}
         mirror._filter_packages()
 

--- a/src/bandersnatch/tests/plugins/test_storage_plugin_s3.py
+++ b/src/bandersnatch/tests/plugins/test_storage_plugin_s3.py
@@ -144,7 +144,7 @@ def test_scandir(s3_mock: S3Path) -> None:
 
 
 def test_plugin_init(s3_mock: S3Path) -> None:
-    config_loader = mock_config(
+    config = mock_config(
         """
 [mirror]
 directory = /tmp/pypi
@@ -167,14 +167,14 @@ endpoint_url = http://localhost:9090
 signature_version = s3v4
 """
     )
-    backend = s3.S3Storage(config=config_loader.config)
+    backend = s3.S3Storage(config=config)
     backend.initialize_plugin()
 
     path = s3.S3Path("/tmp/pypi")
     resource, _ = path._accessor.configuration_map.get_configuration(path)
     assert resource.meta.client.meta.endpoint_url == "http://localhost:9090"
 
-    config_loader = mock_config(
+    config = mock_config(
         """
 [mirror]
 directory = /tmp/pypi
@@ -193,7 +193,7 @@ compare-method = hash
 endpoint_url = http://localhost:9090
 """
     )
-    backend = s3.S3Storage(config=config_loader.config)
+    backend = s3.S3Storage(config=config)
     backend.initialize_plugin()
 
     path = s3.S3Path("/tmp/pypi")

--- a/src/bandersnatch/tests/plugins/test_storage_plugin_s3.py
+++ b/src/bandersnatch/tests/plugins/test_storage_plugin_s3.py
@@ -1,3 +1,4 @@
+from configparser import ConfigParser
 from datetime import datetime
 
 from s3path import S3Path
@@ -5,16 +6,26 @@ from s3path import S3Path
 from bandersnatch.tests.mock_config import mock_config
 from bandersnatch_storage_plugins import s3
 
+_empty_cfg = ConfigParser()
+
+
+def s3_backend(bucket: S3Path) -> s3.S3Storage:
+    config = ConfigParser()
+    config.read_dict(
+        {"mirror": {"storage-backend": "s3", "directory": bucket.as_posix()}}
+    )
+    return s3.S3Storage(config=config)
+
 
 def test_rewrite(s3_mock: S3Path) -> None:
-    backend = s3.S3Storage()
+    backend = s3.S3Storage(config=_empty_cfg)
     with backend.rewrite(f"/{s3_mock.bucket}/test") as fp:
         fp.write("testcontent\n")
     assert s3.S3Path("/test-bucket/test").read_text() == "testcontent\n"
 
 
 def test_update_safe(s3_mock: S3Path) -> None:
-    backend = s3.S3Storage()
+    backend = s3.S3Storage(config=_empty_cfg)
     with backend.update_safe(
         f"/{s3_mock.bucket}/todo", mode="w+", encoding="utf-8"
     ) as fp:
@@ -46,7 +57,7 @@ def test_path_glob(s3_mock: S3Path) -> None:
 
 
 def test_lock(s3_mock: S3Path) -> None:
-    backend = s3.S3Storage()
+    backend = s3.S3Storage(config=_empty_cfg)
     s3lock = backend.get_lock(f"/{s3_mock.bucket}/.lock")
     with s3lock.acquire(timeout=30):
         assert s3lock.is_locked is True
@@ -54,7 +65,7 @@ def test_lock(s3_mock: S3Path) -> None:
 
 
 def test_compare_files(s3_mock: S3Path) -> None:
-    backend = s3.S3Storage()
+    backend = s3.S3Storage(config=_empty_cfg)
     backend.write_file(f"/{s3_mock.bucket}/file1", "test")
     backend.write_file(f"/{s3_mock.bucket}/file2", "test")
     assert (
@@ -64,14 +75,14 @@ def test_compare_files(s3_mock: S3Path) -> None:
 
 
 def test_read_write_file(s3_mock: S3Path) -> None:
-    backend = s3.S3Storage()
+    backend = s3.S3Storage(config=_empty_cfg)
     backend.write_file(f"/{s3_mock.bucket}/file1", "test")
 
     assert backend.read_file(f"/{s3_mock.bucket}/file1", text=True) == "test"
 
 
 def test_delete_file(s3_mock: S3Path) -> None:
-    backend = s3.S3Storage()
+    backend = s3.S3Storage(config=_empty_cfg)
     sample_file = backend.PATH_BACKEND(f"/{s3_mock.bucket}/file1")
     sample_file.touch()
     assert sample_file.exists() is True
@@ -81,7 +92,7 @@ def test_delete_file(s3_mock: S3Path) -> None:
 
 
 def test_delete_path(s3_mock: S3Path) -> None:
-    backend = s3.S3Storage()
+    backend = s3.S3Storage(config=_empty_cfg)
     backend.PATH_BACKEND(f"/{s3_mock.bucket}/folder1/file1").touch()
     backend.PATH_BACKEND(f"/{s3_mock.bucket}/folder2/file2").touch()
     backend.PATH_BACKEND(f"/{s3_mock.bucket}/folder2/file3").touch()
@@ -114,7 +125,7 @@ def test_delete_path(s3_mock: S3Path) -> None:
 
 
 def test_mkdir_rmdir(s3_mock: S3Path) -> None:
-    backend = s3.S3Storage()
+    backend = s3.S3Storage(config=_empty_cfg)
     backend.mkdir(f"/{s3_mock.bucket}/test_folder")
 
     assert backend.is_dir(f"/{s3_mock.bucket}/test_folder")
@@ -125,7 +136,7 @@ def test_mkdir_rmdir(s3_mock: S3Path) -> None:
 
 
 def test_scandir(s3_mock: S3Path) -> None:
-    backend = s3.S3Storage()
+    backend = s3.S3Storage(config=_empty_cfg)
     backend.mkdir(f"/{s3_mock.bucket}/test_folder")
     backend.mkdir(f"/{s3_mock.bucket}/test_folder/sub_dir")
     backend.write_file(f"/{s3_mock.bucket}/test_folder/sub_file", "test")
@@ -199,7 +210,7 @@ endpoint_url = http://localhost:9090
 
 
 def test_upload_time(s3_mock: S3Path) -> None:
-    backend = s3.S3Storage()
+    backend = s3.S3Storage(config=_empty_cfg)
     backend.PATH_BACKEND(f"/{s3_mock.bucket}/folder1/file1").touch()
 
     assert backend.get_upload_time(f"/{s3_mock.bucket}/folder1/file1").second == 0
@@ -214,13 +225,13 @@ def test_upload_time(s3_mock: S3Path) -> None:
 
 
 def test_file_size(s3_mock: S3Path) -> None:
-    backend = s3.S3Storage()
+    backend = s3.S3Storage(config=_empty_cfg)
     backend.write_file(f"/{s3_mock.bucket}/file1", b"1234")
     assert backend.get_file_size(f"/{s3_mock.bucket}/file1") == 4
 
 
 def test_copy_file(s3_mock: S3Path) -> None:
-    backend = s3.S3Storage()
+    backend = s3.S3Storage(config=_empty_cfg)
     backend.write_file(f"/{s3_mock.bucket}/file1", b"1234")
 
     backend.copy_file(f"/{s3_mock.bucket}/file1", f"/{s3_mock.bucket}/file2")

--- a/src/bandersnatch/tests/plugins/test_storage_plugin_s3.py
+++ b/src/bandersnatch/tests/plugins/test_storage_plugin_s3.py
@@ -9,14 +9,6 @@ from bandersnatch_storage_plugins import s3
 _empty_cfg = ConfigParser()
 
 
-def s3_backend(bucket: S3Path) -> s3.S3Storage:
-    config = ConfigParser()
-    config.read_dict(
-        {"mirror": {"storage-backend": "s3", "directory": bucket.as_posix()}}
-    )
-    return s3.S3Storage(config=config)
-
-
 def test_rewrite(s3_mock: S3Path) -> None:
     backend = s3.S3Storage(config=_empty_cfg)
     with backend.rewrite(f"/{s3_mock.bucket}/test") as fp:

--- a/src/bandersnatch/tests/plugins/test_storage_plugins.py
+++ b/src/bandersnatch/tests/plugins/test_storage_plugins.py
@@ -416,7 +416,7 @@ workers = 3
 
     def setUp_mirror(self) -> None:
         self.master = Master(url="https://foo.bar.com")
-        self.mirror = BandersnatchMirror(self.mirror_path, self.master, self.backend)
+        self.mirror = BandersnatchMirror(self.mirror_path, self.master, self.plugin)
         pkg = Package("foobar", serial=1)
         pkg._metadata = {
             "info": {"name": "foobar", "version": "1.0"},
@@ -425,13 +425,14 @@ workers = 3
         self.pkgs.append(pkg)
 
     def setUp_plugin(self) -> None:
-        self.plugin = next(
-            iter(
-                bandersnatch.storage.storage_backend_plugins(
-                    self.backend, clear_cache=True
+        if self.backend is not None:
+            self.plugin = next(
+                iter(
+                    bandersnatch.storage.storage_backend_plugins(
+                        self.config_data.config, self.backend, clear_cache=True
+                    )
                 )
             )
-        )
 
     def setUp_mirrorDirs(self) -> None:
         pypi_dir = (

--- a/src/bandersnatch/tests/plugins/test_storage_plugins.py
+++ b/src/bandersnatch/tests/plugins/test_storage_plugins.py
@@ -433,7 +433,7 @@ workers = 3
             self.plugin: Storage = next(
                 iter(
                     bandersnatch.storage.storage_backend_plugins(
-                        self.config_data.config, self.backend, clear_cache=True
+                        self.config_data, self.backend, clear_cache=True
                     )
                 )
             )
@@ -619,7 +619,7 @@ web{0}simple{0}index.html""".format(
         self.assertTrue(self.plugin.PATH_BACKEND is self.path_backends[self.backend])
 
     def test_json_paths(self) -> None:
-        config = mock_config(self.config_contents).config
+        config = mock_config(self.config_contents)
         mirror_dir = self.plugin.PATH_BACKEND(config.get("mirror", "directory"))
         packages = {
             "bandersnatch": [

--- a/src/bandersnatch/tests/plugins/test_storage_plugins.py
+++ b/src/bandersnatch/tests/plugins/test_storage_plugins.py
@@ -11,15 +11,17 @@ import sys
 import tempfile
 import unittest
 from collections.abc import Iterator
+from configparser import ConfigParser
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 from unittest import TestCase, mock
 
 import bandersnatch.storage
+from bandersnatch.filter import LoadedFilters
 from bandersnatch.master import Master
 from bandersnatch.mirror import BandersnatchMirror
 from bandersnatch.package import Package
-from bandersnatch.storage import PATH_TYPES
+from bandersnatch.storage import PATH_TYPES, Storage
 from bandersnatch.tests.mock_config import mock_config
 from bandersnatch_storage_plugins import filesystem, swift
 
@@ -416,7 +418,9 @@ workers = 3
 
     def setUp_mirror(self) -> None:
         self.master = Master(url="https://foo.bar.com")
-        self.mirror = BandersnatchMirror(self.mirror_path, self.master, self.plugin)
+        self.mirror = BandersnatchMirror(
+            self.mirror_path, self.master, self.plugin, LoadedFilters(ConfigParser())
+        )
         pkg = Package("foobar", serial=1)
         pkg._metadata = {
             "info": {"name": "foobar", "version": "1.0"},
@@ -426,7 +430,7 @@ workers = 3
 
     def setUp_plugin(self) -> None:
         if self.backend is not None:
-            self.plugin = next(
+            self.plugin: Storage = next(
                 iter(
                     bandersnatch.storage.storage_backend_plugins(
                         self.config_data.config, self.backend, clear_cache=True

--- a/src/bandersnatch/tests/plugins/util.py
+++ b/src/bandersnatch/tests/plugins/util.py
@@ -1,0 +1,27 @@
+from configparser import ConfigParser
+from pathlib import Path
+
+from bandersnatch.master import Master
+from bandersnatch.mirror import BandersnatchMirror
+from bandersnatch.storage import storage_backend_plugins
+
+
+def make_test_mirror(
+    location: Path | None = None, url: str = "https://foo.bar.com"
+) -> BandersnatchMirror:
+    location = location or Path(".")
+    config = ConfigParser()
+    config.read_dict(
+        {
+            "mirror": {
+                "storage-backend": "filesystem",
+                "directory": location.as_posix(),
+                "workers": 2,
+            }
+        }
+    )
+    return BandersnatchMirror(
+        location or Path("."),
+        Master(url=url),
+        next(iter(storage_backend_plugins(config=config))),
+    )

--- a/src/bandersnatch/tests/test_configuration.py
+++ b/src/bandersnatch/tests/test_configuration.py
@@ -9,7 +9,6 @@ from bandersnatch.config.diff_file_reference import eval_legacy_config_ref
 from bandersnatch.configuration import (
     BandersnatchConfig,
     SetConfigValues,
-    Singleton,
     validate_config_values,
 )
 from bandersnatch.simple import SimpleFormat
@@ -27,9 +26,6 @@ class TestBandersnatchConf(TestCase):
         self.cwd = os.getcwd()
         self.tempdir = TemporaryDirectory()
         os.chdir(self.tempdir.name)
-        # Hack to ensure each test gets fresh instance if needed
-        # We have a dedicated test to ensure we're creating a singleton
-        Singleton._instances = {}
 
     def tearDown(self) -> None:
         if self.tempdir:
@@ -37,11 +33,6 @@ class TestBandersnatchConf(TestCase):
             os.chdir(self.cwd)
             self.tempdir.cleanup()
             self.tempdir = None
-
-    def test_is_singleton(self) -> None:
-        instance1 = BandersnatchConfig()
-        instance2 = BandersnatchConfig()
-        self.assertEqual(id(instance1), id(instance2))
 
     def test_single_config__default__all_sections_present(self) -> None:
         config_file = str(importlib.resources.files("bandersnatch") / "unittest.conf")
@@ -118,16 +109,6 @@ class TestBandersnatchConf(TestCase):
         instance.config_file = "test.conf"
         instance.load_configuration()
         self.assertEqual(instance.config["mirror"]["master"], "https://foo.bar.baz")
-
-    def test_multiple_instances_custom_setting_str(self) -> None:
-        with open("test.conf", "w") as testconfig_handle:
-            testconfig_handle.write("[mirror]\nmaster=https://foo.bar.baz\n")
-        instance1 = BandersnatchConfig()
-        instance1.config_file = "test.conf"
-        instance1.load_configuration()
-
-        instance2 = BandersnatchConfig()
-        self.assertEqual(instance2.config["mirror"]["master"], "https://foo.bar.baz")
 
     def test_validate_config_values(self) -> None:
         default_values = SetConfigValues(

--- a/src/bandersnatch/tests/test_configuration.py
+++ b/src/bandersnatch/tests/test_configuration.py
@@ -5,6 +5,7 @@ import unittest
 from tempfile import TemporaryDirectory
 from unittest import TestCase
 
+from bandersnatch.config.diff_file_reference import eval_legacy_config_ref
 from bandersnatch.configuration import (
     BandersnatchConfig,
     SetConfigValues,
@@ -194,6 +195,84 @@ class TestBandersnatchConf(TestCase):
         self.assertEqual(
             default_values, validate_config_values(release_files_false_configparser)
         )
+
+    def test_validate_config_diff_file_reference(self) -> None:
+        diff_file_test_cases = [
+            (
+                {
+                    "mirror": {
+                        "directory": "/test",
+                        "diff-file": r"{{mirror_directory}}",
+                    }
+                },
+                "/test",
+            ),
+            (
+                {
+                    "mirror": {
+                        "directory": "/test",
+                        "diff-file": r"{{ mirror_directory }}",
+                    }
+                },
+                "/test",
+            ),
+            (
+                {
+                    "mirror": {
+                        "directory": "/test",
+                        "diff-file": r"{{ mirror_directory }}/diffs/new-files",
+                    }
+                },
+                "/test/diffs/new-files",
+            ),
+            (
+                {
+                    "strings": {"test": "TESTING"},
+                    "mirror": {"diff-file": r"/var/log/{{ strings_test }}"},
+                },
+                "/var/log/TESTING",
+            ),
+            (
+                {
+                    "strings": {"test": "TESTING"},
+                    "mirror": {"diff-file": r"/var/log/{{ strings_test }}/diffs"},
+                },
+                "/var/log/TESTING/diffs",
+            ),
+        ]
+
+        for cfg_data, expected in diff_file_test_cases:
+            with self.subTest(
+                diff_file=cfg_data["mirror"]["diff-file"],
+                expected=expected,
+                cfg_data=cfg_data,
+            ):
+                cfg = configparser.ConfigParser()
+                cfg.read_dict(cfg_data)
+                config_values = validate_config_values(cfg)
+                self.assertIsInstance(config_values.diff_file_path, str)
+                self.assertEqual(config_values.diff_file_path, expected)
+
+    def test_invalid_diff_file_reference_throws_exception(self) -> None:
+        invalid_diff_file_cases = [
+            (
+                r"{{ missing.underscore }}/foo",
+                "Unable to parse config option reference",
+            ),
+            (r"/var/{{ mirror_woops }}/foo", "No option 'woops' in section: 'mirror'"),
+        ]
+
+        for diff_file_val, expected_error in invalid_diff_file_cases:
+            with self.subTest(diff_file=diff_file_val, expected_error=expected_error):
+                cfg = configparser.ConfigParser()
+                cfg.read_dict({"mirror": {"diff-file": diff_file_val}})
+                self.assertRaisesRegex(
+                    ValueError,
+                    expected_error,
+                    eval_legacy_config_ref,
+                    cfg,
+                    diff_file_val,
+                )
 
 
 if __name__ == "__main__":

--- a/src/bandersnatch/tests/test_configuration.py
+++ b/src/bandersnatch/tests/test_configuration.py
@@ -1,260 +1,94 @@
-import configparser
-import importlib.resources
-import os
-import unittest
-from tempfile import TemporaryDirectory
-from unittest import TestCase
+from pathlib import Path
+from unittest import mock
 
-from bandersnatch.config.diff_file_reference import eval_legacy_config_ref
-from bandersnatch.configuration import (
-    BandersnatchConfig,
-    SetConfigValues,
-    validate_config_values,
+import pytest
+
+from bandersnatch.config import BandersnatchConfig
+
+
+def cfg_from_str(content: str) -> BandersnatchConfig:
+    config = BandersnatchConfig()
+    config.read_string(content)
+    return config
+
+
+def test_validated_options_are_reused() -> None:
+    # leaking implementation detail: get_validated assumes its argument is a class and caches initialized objects by the class's __qualname__.
+    # Mock/MagicMock raise an AttributeError for __qualname__ (and __name__) unless you specifically set the attribute.
+    MockOptionsType = mock.Mock(__qualname__="MockOptionsType")
+
+    config = BandersnatchConfig()
+    options1 = config.get_validated(MockOptionsType)  # type: ignore
+    options2 = config.get_validated(MockOptionsType)  # type: ignore
+
+    # the factory method should only be called once, the first time 'get_validated' is called
+    MockOptionsType.from_config_parser.assert_called_once_with(config)
+    # both calls to 'get_validated' should return the same object b/c the second call returns the cached object
+    assert options1 is options2
+
+
+def test_validated_option_types_are_distinct() -> None:
+    MockOptionsTypeA = mock.Mock(__qualname__="MockOptionsTypeA")
+    MockOptionsTypeB = mock.Mock(__qualname__="MockOptionsTypeB")
+
+    config = BandersnatchConfig()
+    options_a = config.get_validated(MockOptionsTypeA)  # type: ignore
+    options_b = config.get_validated(MockOptionsTypeB)  # type: ignore
+
+    assert options_a is not options_b
+
+
+@pytest.mark.parametrize(
+    "option_name",
+    ["test_option_name", "test-option-name", "Test-Option-Name", "TEST_OPTION_NAME"],
 )
-from bandersnatch.simple import SimpleFormat
-
-
-class TestBandersnatchConf(TestCase):
+def test_option_names_are_normalized(option_name: str) -> None:
+    content = f"""\
+    [test]
+    {option_name} = expected value
     """
-    Tests for the BandersnatchConf singleton class
+    config = cfg_from_str(content)
+    assert config.get("test", "test_option_name") == "expected value"
+
+
+def test_supports_extended_interpolation() -> None:
+    content = """\
+    [paths]
+    root = /opt/stuff
+
+    [test]
+    option_a = ${paths:root}
+    option_b = ${option_a}/example.txt
     """
-
-    tempdir = None
-    cwd = None
-
-    def setUp(self) -> None:
-        self.cwd = os.getcwd()
-        self.tempdir = TemporaryDirectory()
-        os.chdir(self.tempdir.name)
-
-    def tearDown(self) -> None:
-        if self.tempdir:
-            assert self.cwd
-            os.chdir(self.cwd)
-            self.tempdir.cleanup()
-            self.tempdir = None
-
-    def test_single_config__default__all_sections_present(self) -> None:
-        config_file = str(importlib.resources.files("bandersnatch") / "unittest.conf")
-        instance = BandersnatchConfig(str(config_file))
-        # All default values should at least be present and be the write types
-        for section in ["mirror", "plugins", "blocklist"]:
-            self.assertIn(section, instance.config.sections())
-
-    def test_single_config__default__mirror__setting_attributes(self) -> None:
-        instance = BandersnatchConfig()
-        options = [option for option in instance.config["mirror"]]
-        options.sort()
-        self.assertListEqual(
-            options,
-            [
-                "cleanup",
-                "compare-method",
-                "directory",
-                "global-timeout",
-                "hash-index",
-                "json",
-                "master",
-                "release-files",
-                "simple-format",
-                "stop-on-error",
-                "storage-backend",
-                "timeout",
-                "verifiers",
-                "workers",
-            ],
-        )
-
-    def test_single_config__default__mirror__setting__types(self) -> None:
-        """
-        Make sure all default mirror settings will cast to the correct types
-        """
-        instance = BandersnatchConfig()
-        for option, option_type in [
-            ("directory", str),
-            ("hash-index", bool),
-            ("json", bool),
-            ("master", str),
-            ("stop-on-error", bool),
-            ("storage-backend", str),
-            ("timeout", int),
-            ("global-timeout", int),
-            ("workers", int),
-            ("compare-method", str),
-        ]:
-            self.assertIsInstance(
-                option_type(instance.config["mirror"].get(option)), option_type
-            )
-
-    def test_single_config_custom_setting_boolean(self) -> None:
-        with open("test.conf", "w") as testconfig_handle:
-            testconfig_handle.write("[mirror]\nhash-index=false\n")
-        instance = BandersnatchConfig()
-        instance.config_file = "test.conf"
-        instance.load_configuration()
-        self.assertFalse(instance.config["mirror"].getboolean("hash-index"))
-
-    def test_single_config_custom_setting_int(self) -> None:
-        with open("test.conf", "w") as testconfig_handle:
-            testconfig_handle.write("[mirror]\ntimeout=999\n")
-        instance = BandersnatchConfig()
-        instance.config_file = "test.conf"
-        instance.load_configuration()
-        self.assertEqual(int(instance.config["mirror"]["timeout"]), 999)
-
-    def test_single_config_custom_setting_str(self) -> None:
-        with open("test.conf", "w") as testconfig_handle:
-            testconfig_handle.write("[mirror]\nmaster=https://foo.bar.baz\n")
-        instance = BandersnatchConfig()
-        instance.config_file = "test.conf"
-        instance.load_configuration()
-        self.assertEqual(instance.config["mirror"]["master"], "https://foo.bar.baz")
-
-    def test_validate_config_values(self) -> None:
-        default_values = SetConfigValues(
-            False,
-            "",
-            "",
-            False,
-            "sha256",
-            "filesystem",
-            False,
-            True,
-            "hash",
-            "",
-            False,
-            SimpleFormat.ALL,
-        )
-        no_options_configparser = configparser.ConfigParser()
-        no_options_configparser["mirror"] = {}
-        self.assertEqual(
-            default_values, validate_config_values(no_options_configparser)
-        )
-
-    def test_validate_config_values_release_files_false_sets_root_uri(self) -> None:
-        default_values = SetConfigValues(
-            False,
-            "https://files.pythonhosted.org",
-            "",
-            False,
-            "sha256",
-            "filesystem",
-            False,
-            False,
-            "hash",
-            "",
-            False,
-            SimpleFormat.ALL,
-        )
-        release_files_false_configparser = configparser.ConfigParser()
-        release_files_false_configparser["mirror"] = {"release-files": "false"}
-        self.assertEqual(
-            default_values, validate_config_values(release_files_false_configparser)
-        )
-
-    def test_validate_config_values_download_mirror_false_sets_no_fallback(
-        self,
-    ) -> None:
-        default_values = SetConfigValues(
-            False,
-            "",
-            "",
-            False,
-            "sha256",
-            "filesystem",
-            False,
-            True,
-            "hash",
-            "",
-            False,
-            SimpleFormat.ALL,
-        )
-        release_files_false_configparser = configparser.ConfigParser()
-        release_files_false_configparser["mirror"] = {
-            "download-mirror-no-fallback": "true",
-        }
-        self.assertEqual(
-            default_values, validate_config_values(release_files_false_configparser)
-        )
-
-    def test_validate_config_diff_file_reference(self) -> None:
-        diff_file_test_cases = [
-            (
-                {
-                    "mirror": {
-                        "directory": "/test",
-                        "diff-file": r"{{mirror_directory}}",
-                    }
-                },
-                "/test",
-            ),
-            (
-                {
-                    "mirror": {
-                        "directory": "/test",
-                        "diff-file": r"{{ mirror_directory }}",
-                    }
-                },
-                "/test",
-            ),
-            (
-                {
-                    "mirror": {
-                        "directory": "/test",
-                        "diff-file": r"{{ mirror_directory }}/diffs/new-files",
-                    }
-                },
-                "/test/diffs/new-files",
-            ),
-            (
-                {
-                    "strings": {"test": "TESTING"},
-                    "mirror": {"diff-file": r"/var/log/{{ strings_test }}"},
-                },
-                "/var/log/TESTING",
-            ),
-            (
-                {
-                    "strings": {"test": "TESTING"},
-                    "mirror": {"diff-file": r"/var/log/{{ strings_test }}/diffs"},
-                },
-                "/var/log/TESTING/diffs",
-            ),
-        ]
-
-        for cfg_data, expected in diff_file_test_cases:
-            with self.subTest(
-                diff_file=cfg_data["mirror"]["diff-file"],
-                expected=expected,
-                cfg_data=cfg_data,
-            ):
-                cfg = configparser.ConfigParser()
-                cfg.read_dict(cfg_data)
-                config_values = validate_config_values(cfg)
-                self.assertIsInstance(config_values.diff_file_path, str)
-                self.assertEqual(config_values.diff_file_path, expected)
-
-    def test_invalid_diff_file_reference_throws_exception(self) -> None:
-        invalid_diff_file_cases = [
-            (
-                r"{{ missing.underscore }}/foo",
-                "Unable to parse config option reference",
-            ),
-            (r"/var/{{ mirror_woops }}/foo", "No option 'woops' in section: 'mirror'"),
-        ]
-
-        for diff_file_val, expected_error in invalid_diff_file_cases:
-            with self.subTest(diff_file=diff_file_val, expected_error=expected_error):
-                cfg = configparser.ConfigParser()
-                cfg.read_dict({"mirror": {"diff-file": diff_file_val}})
-                self.assertRaisesRegex(
-                    ValueError,
-                    expected_error,
-                    eval_legacy_config_ref,
-                    cfg,
-                    diff_file_val,
-                )
+    config = cfg_from_str(content)
+    assert config.get("test", "option_a") == "/opt/stuff"
+    assert config.get("test", "option_b") == "/opt/stuff/example.txt"
 
 
-if __name__ == "__main__":
-    unittest.main()
+def test_can_read_from_path(tmp_path: Path) -> None:
+    content = """\
+    [A]
+    one = one fish
+    two = two fish
+    [B]
+    three = red fish, blue fish
+    """
+    tmp_file = tmp_path / "test.cfg"
+    tmp_file.write_text(content)
+
+    config1 = BandersnatchConfig()
+    config1.read_path(tmp_file)
+
+    config2 = BandersnatchConfig()
+    with tmp_file.open() as cfg_file:
+        config2.read_file(cfg_file)
+
+    assert config1.sections() == config2.sections()
+    assert config1.items("A") == config2.items("A")
+
+
+def test_reading_missing_path_raises(tmp_path: Path) -> None:
+    no_file = tmp_path / "test.cfg"
+    config = BandersnatchConfig()
+    with pytest.raises(IOError):
+        config.read_path(no_file)

--- a/src/bandersnatch/tests/test_delete.py
+++ b/src/bandersnatch/tests/test_delete.py
@@ -1,5 +1,6 @@
 import os
 from argparse import Namespace
+from collections.abc import Callable
 from configparser import ConfigParser
 from json import loads
 from pathlib import Path
@@ -14,6 +15,7 @@ from pytest import MonkeyPatch
 from bandersnatch.delete import delete_packages, delete_path, delete_simple_page
 from bandersnatch.master import Master
 from bandersnatch.mirror import BandersnatchMirror
+from bandersnatch.storage import Storage
 from bandersnatch.utils import find
 
 EXPECTED_WEB_BEFORE_DELETION = """\
@@ -76,24 +78,25 @@ def _fake_config() -> ConfigParser:
 
 
 @pytest.mark.asyncio
-async def test_delete_path() -> None:
+async def test_delete_path(local_storage_factory: Callable[[Path], Storage]) -> None:
     with TemporaryDirectory() as td:
         td_path = Path(td)
+        storage_backend = local_storage_factory(td_path)
         fake_path = td_path / "unittest-file.tgz"
         with patch("bandersnatch.delete.logger.info") as mock_log:
-            assert await delete_path(fake_path, True) == 0
+            assert await delete_path(fake_path, storage_backend, True) == 0
             assert mock_log.call_count == 1
 
         with patch("bandersnatch.delete.logger.debug") as mock_log:
-            assert await delete_path(fake_path, False) == 0
+            assert await delete_path(fake_path, storage_backend, False) == 0
             assert mock_log.call_count == 1
 
         fake_path.touch()
         # Remove file
-        assert await delete_path(fake_path, False) == 0
+        assert await delete_path(fake_path, storage_backend, False) == 0
         # File should be gone - We should log that via debug
         with patch("bandersnatch.delete.logger.debug") as mock_log:
-            assert await delete_path(fake_path, False) == 0
+            assert await delete_path(fake_path, storage_backend, False) == 0
             assert mock_log.call_count == 1
 
 

--- a/src/bandersnatch/tests/test_filter.py
+++ b/src/bandersnatch/tests/test_filter.py
@@ -5,7 +5,7 @@ from configparser import ConfigParser
 from tempfile import TemporaryDirectory
 from unittest import TestCase
 
-from bandersnatch.configuration import BandersnatchConfig
+from bandersnatch.config import BandersnatchConfig
 from bandersnatch.tests.mock_config import mock_config
 
 from bandersnatch.filter import (  # isort:skip
@@ -51,7 +51,7 @@ enabled = all
             "allowlist_project",
         ]
 
-        plugins = LoadedFilters(bc.config).filter_project_plugins()
+        plugins = LoadedFilters(bc).filter_project_plugins()
         names = [plugin.name for plugin in plugins]
         for name in builtin_plugin_names:
             self.assertIn(name, names)
@@ -70,7 +70,7 @@ enabled = all
             "latest_release",
         ]
 
-        plugins = LoadedFilters(bc.config).filter_release_plugins()
+        plugins = LoadedFilters(bc).filter_release_plugins()
         names = [plugin.name for plugin in plugins]
         for name in builtin_plugin_names:
             self.assertIn(name, names)
@@ -83,10 +83,10 @@ enabled =
 """
         )
 
-        plugins = LoadedFilters(bc.config).filter_release_plugins()
+        plugins = LoadedFilters(bc).filter_release_plugins()
         self.assertEqual(len(plugins), 0)
 
-        plugins = LoadedFilters(bc.config).filter_project_plugins()
+        plugins = LoadedFilters(bc).filter_project_plugins()
         self.assertEqual(len(plugins), 0)
 
     def test__filter_base_clases(self) -> None:
@@ -125,12 +125,10 @@ enabled =
         self.assertFalse(error)
 
     def test_deprecated_keys(self) -> None:
-        with open("test.conf", "w") as f:
-            f.write("[allowlist]\npackages=foo\n[blocklist]\npackages=bar\n")
         instance = BandersnatchConfig()
-        instance.config_file = "test.conf"
-        instance.load_configuration()
-        plugin = Filter(config=instance.config)
+        instance.read_string("[allowlist]\npackages=foo\n[blocklist]\npackages=bar\n")
+
+        plugin = Filter(config=instance)
         assert plugin.allowlist.name == "allowlist"
         assert plugin.blocklist.name == "blocklist"
 
@@ -155,8 +153,7 @@ packages =
         )
 
         plugins = {
-            plugin.name: plugin
-            for plugin in LoadedFilters(bc.config).filter_project_plugins()
+            plugin.name: plugin for plugin in LoadedFilters(bc).filter_project_plugins()
         }
 
         self.assertTrue(plugins["blocklist_project"].check_match(name="sampleproject"))

--- a/src/bandersnatch/tests/test_main.py
+++ b/src/bandersnatch/tests/test_main.py
@@ -90,7 +90,6 @@ def test_main_reads_config_values(mirror_mock: mock.MagicMock, tmpdir: Path) -> 
         "keep_index_versions": 0,
         "release_files_save": True,
         "storage_backend": "filesystem",
-        "diff_file": diff_file,
         "diff_append_epoch": False,
         "diff_full_path": diff_file,
         "cleanup": False,

--- a/src/bandersnatch/tests/test_main.py
+++ b/src/bandersnatch/tests/test_main.py
@@ -76,19 +76,7 @@ def test_main_reads_config_values(mirror_mock: mock.MagicMock, tmpdir: Path) -> 
     sys.argv = ["bandersnatch", "-c", str(config_path), "mirror"]
     assert config_path.exists()
     main(asyncio.new_event_loop())
-    (homedir, master), kwargs = mirror_mock.call_args_list[0]
-
-    class MatchStorage:
-        def __init__(self, name: str, path: Path) -> None:
-            self.name = name
-            self.path = path
-
-        def __eq__(self, other: Any) -> bool:
-            return (
-                isinstance(other, bandersnatch.storage.Storage)
-                and other.name == self.name
-                and other.mirror_base_path == self.path
-            )
+    (homedir, master, _storage, _filters), kwargs = mirror_mock.call_args_list[0]
 
     assert Path("/srv/pypi") == homedir
     assert isinstance(master, bandersnatch.master.Master)
@@ -101,7 +89,6 @@ def test_main_reads_config_values(mirror_mock: mock.MagicMock, tmpdir: Path) -> 
         "digest_name": "sha256",
         "keep_index_versions": 0,
         "release_files_save": True,
-        "storage_backend": MatchStorage("filesystem", homedir),
         "diff_append_epoch": False,
         "diff_full_path": diff_file,
         "cleanup": False,

--- a/src/bandersnatch/tests/test_main.py
+++ b/src/bandersnatch/tests/test_main.py
@@ -12,7 +12,6 @@ from _pytest.logging import LogCaptureFixture
 
 import bandersnatch.mirror
 import bandersnatch.storage
-from bandersnatch.configuration import Singleton
 from bandersnatch.main import main
 from bandersnatch.simple import SimpleFormat
 
@@ -22,11 +21,6 @@ if TYPE_CHECKING:
 
 async def empty_dict(*args: Any, **kwargs: Any) -> dict:
     return {}
-
-
-def setup() -> None:
-    """simple setup function to clear Singleton._instances before each test"""
-    Singleton._instances = {}
 
 
 def test_main_help(capfd: CaptureFixture) -> None:
@@ -102,7 +96,6 @@ def test_main_reads_config_values(mirror_mock: mock.MagicMock, tmpdir: Path) -> 
 def test_main_reads_custom_config_values(
     mirror_mock: "BandersnatchMirror", logging_mock: mock.MagicMock, customconfig: Path
 ) -> None:
-    setup()
     conffile = str(customconfig / "bandersnatch.conf")
     sys.argv = ["bandersnatch", "-c", conffile, "mirror"]
     main(asyncio.new_event_loop())
@@ -113,7 +106,6 @@ def test_main_reads_custom_config_values(
 def test_main_throws_exception_on_unsupported_digest_name(
     customconfig: Path,
 ) -> None:
-    setup()
     conffile = str(customconfig / "bandersnatch.conf")
     parser = configparser.ConfigParser()
     parser.read(conffile)

--- a/src/bandersnatch/tests/test_main.py
+++ b/src/bandersnatch/tests/test_main.py
@@ -78,6 +78,18 @@ def test_main_reads_config_values(mirror_mock: mock.MagicMock, tmpdir: Path) -> 
     main(asyncio.new_event_loop())
     (homedir, master), kwargs = mirror_mock.call_args_list[0]
 
+    class MatchStorage:
+        def __init__(self, name: str, path: Path) -> None:
+            self.name = name
+            self.path = path
+
+        def __eq__(self, other: Any) -> bool:
+            return (
+                isinstance(other, bandersnatch.storage.Storage)
+                and other.name == self.name
+                and other.mirror_base_path == self.path
+            )
+
     assert Path("/srv/pypi") == homedir
     assert isinstance(master, bandersnatch.master.Master)
     assert {
@@ -89,7 +101,7 @@ def test_main_reads_config_values(mirror_mock: mock.MagicMock, tmpdir: Path) -> 
         "digest_name": "sha256",
         "keep_index_versions": 0,
         "release_files_save": True,
-        "storage_backend": "filesystem",
+        "storage_backend": MatchStorage("filesystem", homedir),
         "diff_append_epoch": False,
         "diff_full_path": diff_file,
         "cleanup": False,

--- a/src/bandersnatch/tests/test_mirror.py
+++ b/src/bandersnatch/tests/test_mirror.py
@@ -12,7 +12,7 @@ import pytest
 from freezegun import freeze_time
 
 from bandersnatch import utils
-from bandersnatch.configuration import BandersnatchConfig, Singleton
+from bandersnatch.configuration import BandersnatchConfig
 from bandersnatch.filter import LoadedFilters
 from bandersnatch.master import Master
 from bandersnatch.mirror import BandersnatchMirror
@@ -155,7 +155,6 @@ enabled =
 packages =
     example1
 """
-    Singleton._instances = {}
     with open("test.conf", "w") as testconfig_handle:
         testconfig_handle.write(test_configuration)
     bc = BandersnatchConfig("test.conf")
@@ -182,11 +181,12 @@ enable =
 packages =
     example3>2.0.0
 """
-    Singleton._instances = {}
     with open("test.conf", "w") as testconfig_handle:
         testconfig_handle.write(test_configuration)
-    BandersnatchConfig("test.conf")
-    m = BandersnatchMirror(tmp_path, mock.Mock(), local_storage, empty_filters)
+    bc = BandersnatchConfig("test.conf")
+    m = BandersnatchMirror(
+        tmp_path, mock.Mock(), local_storage, LoadedFilters(config=bc.config)
+    )
     m.packages_to_sync = {"example1": "", "example3": ""}
     m._filter_packages()
     assert "example3" in m.packages_to_sync.keys()

--- a/src/bandersnatch/tests/test_mirror_options.py
+++ b/src/bandersnatch/tests/test_mirror_options.py
@@ -1,0 +1,228 @@
+from collections.abc import Iterable
+from contextlib import nullcontext
+from pathlib import PurePath
+from typing import Any
+
+import pytest
+
+from bandersnatch.config import (
+    BandersnatchConfig,
+    ConfigurationError,
+    InvalidValueError,
+    MirrorOptions,
+    MissingOptionError,
+)
+from bandersnatch.config.diff_file_reference import eval_legacy_config_ref
+
+
+def config_with(content: dict[str, Any] | None = None) -> BandersnatchConfig:
+    base = {"mirror": {"directory": "/test"}}
+    config = BandersnatchConfig()
+    config.read_dict(base)
+    if content:
+        config.read_dict(content)
+    return config
+
+
+def test_empty_config_raises() -> None:
+    config = BandersnatchConfig()
+    with pytest.raises(ConfigurationError, match="missing required section"):
+        _ = config.get_validated(MirrorOptions)
+
+
+def test_empty_section_raises() -> None:
+    config = BandersnatchConfig()
+    config.read_dict({"mirror": {}})
+    with pytest.raises(MissingOptionError, match="missing required option"):
+        _ = config.get_validated(MirrorOptions)
+
+
+def test_minimal_mirror_options_are_valid() -> None:
+    config = config_with()
+    expected_options = MirrorOptions(directory=PurePath("/test"))
+    validated_options = config.get_validated(MirrorOptions)
+    assert validated_options == expected_options
+
+
+@pytest.mark.parametrize(
+    ("cfg_data", "expected"),
+    [
+        (
+            {
+                "mirror": {
+                    "diff-file": r"{{mirror_directory}}",
+                }
+            },
+            "/test",
+        ),
+        (
+            {
+                "mirror": {
+                    "diff-file": r"{{ mirror_directory }}",
+                }
+            },
+            "/test",
+        ),
+        (
+            {
+                "mirror": {
+                    "diff-file": r"{{ mirror_directory }}/diffs/new-files",
+                }
+            },
+            "/test/diffs/new-files",
+        ),
+        (
+            {
+                "strings": {"test": "TESTING"},
+                "mirror": {
+                    "diff-file": r"/var/log/{{ strings_test }}",
+                },
+            },
+            "/var/log/TESTING",
+        ),
+        (
+            {
+                "strings": {"test": "TESTING"},
+                "mirror": {
+                    "diff-file": r"/var/log/{{ strings_test }}/diffs",
+                },
+            },
+            "/var/log/TESTING/diffs",
+        ),
+    ],
+)
+def test_legacy_diff_file_ref_resolves(cfg_data: dict, expected: str) -> None:
+    config = config_with(cfg_data)
+    mirror_opts = config.get_validated(MirrorOptions)
+    assert mirror_opts.diff_file == PurePath(expected)
+
+
+@pytest.mark.parametrize(
+    ("option_value", "expected_message"),
+    [
+        (
+            r"{{ missing.underscore }}/foo",
+            "Unable to parse config option reference",
+        ),
+        (r"/var/{{ mirror_woops }}/foo", "No option 'woops' in section: 'mirror'"),
+    ],
+)
+def test_invalid_legacy_diff_file_ref_raises(
+    option_value: str, expected_message: str
+) -> None:
+    config = config_with({"mirror": {"diff-file": option_value}})
+    with pytest.raises(ValueError, match=expected_message):
+        _ = eval_legacy_config_ref(config, option_value)
+
+
+@pytest.mark.parametrize(
+    ("release_files_option", "expected_root_uri"),
+    [
+        ("", ""),
+        ("true", ""),
+        ("false", "https://files.pythonhosted.org"),
+    ],
+)
+def test_release_files_off_sets_default_root_uri(
+    release_files_option: str,
+    expected_root_uri: str,
+) -> None:
+    cfg_data = (
+        {"mirror": {"release-files": release_files_option}}
+        if release_files_option
+        else {}
+    )
+    config = config_with(cfg_data)
+    mirror_opts = config.get_validated(MirrorOptions)
+    assert mirror_opts.root_uri == expected_root_uri
+
+
+def _permutate_case(*texts: str) -> Iterable[str]:
+    for t in texts:
+        yield t
+        yield t.upper()
+        yield t.capitalize()
+
+
+@pytest.mark.parametrize(
+    ("config_value", "expected"),
+    [
+        *((v, True) for v in _permutate_case("on", "yes", "true")),
+        *((v, False) for v in _permutate_case("no", "off", "false")),
+    ],
+)
+def test_friendly_boolean_is_valid(config_value: str, expected: bool) -> None:
+    content = {"mirror": {"diff-append-epoch": config_value}}
+    config = config_with(content)
+    mirror_opts = config.get_validated(MirrorOptions)
+    assert mirror_opts.diff_append_epoch == expected
+
+
+@pytest.mark.parametrize(
+    ("timeout_value", "expected_timeout"),
+    [
+        ("-1", pytest.raises(InvalidValueError)),
+        ("0", pytest.raises(InvalidValueError)),
+        ("1.9", nullcontext(1.9)),
+        ("1000.0", nullcontext(1000.0)),
+    ],
+)
+def test_non_positive_timeouts_are_rejected(
+    timeout_value: str, expected_timeout: Any
+) -> None:
+    content = {"mirror": {"timeout": timeout_value}}
+    config = config_with(content)
+    with expected_timeout as e:
+        mirror_opts = config.get_validated(MirrorOptions)
+        assert mirror_opts.timeout == pytest.approx(e)
+
+
+@pytest.mark.parametrize(
+    ("workers_value", "expected_workers"),
+    [
+        ("-1", pytest.raises(InvalidValueError)),
+        ("0", pytest.raises(InvalidValueError)),
+        ("1", nullcontext(1)),
+        ("10", nullcontext(10)),
+        ("11", pytest.raises(InvalidValueError)),
+    ],
+)
+def test_out_of_range_worker_counts_are_rejected(
+    workers_value: str, expected_workers: Any
+) -> None:
+    content = {"mirror": {"workers": workers_value}}
+    config = config_with(content)
+    with expected_workers as e:
+        mirror_opts = config.get_validated(MirrorOptions)
+        assert mirror_opts.workers == e
+
+
+_int_convert_error_pattern = r"can't convert option .+ to expected type 'int'"
+
+
+@pytest.mark.parametrize(
+    ("workers_value", "expected_workers"),
+    [
+        ("1", nullcontext(1)),
+        ("01", nullcontext(1)),
+        ("0_1", nullcontext(1)),
+        ("1_", pytest.raises(InvalidValueError, match=_int_convert_error_pattern)),
+        (
+            "fooey",
+            pytest.raises(InvalidValueError, match=_int_convert_error_pattern),
+        ),
+        (
+            "no",
+            pytest.raises(InvalidValueError, match=_int_convert_error_pattern),
+        ),
+    ],
+)
+def test_integer_option_string_conversion(
+    workers_value: str,
+    expected_workers: Any,
+) -> None:
+    content = {"mirror": {"workers": workers_value}}
+    config = config_with(content)
+    with expected_workers as e:
+        mirror_opts = config.get_validated(MirrorOptions)
+        assert mirror_opts.workers == e

--- a/src/bandersnatch/tests/test_simple.py
+++ b/src/bandersnatch/tests/test_simple.py
@@ -6,7 +6,7 @@ from tempfile import TemporaryDirectory
 import pytest
 
 from bandersnatch import utils
-from bandersnatch.configuration import validate_config_values
+from bandersnatch.config import BandersnatchConfig, MirrorOptions
 from bandersnatch.package import Package
 from bandersnatch.simple import (
     InvalidDigestFormat,
@@ -46,11 +46,12 @@ def test_digest_valid(local_storage: Storage) -> None:
 
 
 def test_digest_config_default(local_storage: Storage) -> None:
-    c = ConfigParser()
-    c.add_section("mirror")
-    config = validate_config_values(c)
+    c = BandersnatchConfig()
+    c.read_dict({"mirror": {"directory": "/"}})
+
+    config = c.get_validated(MirrorOptions)
     s = SimpleAPI(local_storage, "ALL", [], config.digest_name, False, None)
-    assert config.digest_name.upper() in [v.name for v in SimpleDigest]
+    assert config.digest_name in [v for v in SimpleDigest]
     assert s.digest_name == SimpleDigest.SHA256
 
 

--- a/src/bandersnatch/tests/test_simple.py
+++ b/src/bandersnatch/tests/test_simple.py
@@ -25,37 +25,39 @@ from bandersnatch.tests.test_simple_fixtures import (
 from bandersnatch_storage_plugins.filesystem import FilesystemStorage
 
 
-def test_format_invalid() -> None:
+def test_format_invalid(local_storage: Storage) -> None:
     with pytest.raises(InvalidSimpleFormat):
-        SimpleAPI(Storage(), "l33t", [], "sha256", False, None)
+        SimpleAPI(local_storage, "l33t", [], "sha256", False, None)
 
 
-def test_format_valid() -> None:
-    s = SimpleAPI(Storage(), "ALL", [], "sha256", False, None)
+def test_format_valid(local_storage: Storage) -> None:
+    s = SimpleAPI(local_storage, "ALL", [], "sha256", False, None)
     assert s.format == SimpleFormat.ALL
 
 
-def test_digest_invalid() -> None:
+def test_digest_invalid(local_storage: Storage) -> None:
     with pytest.raises(InvalidDigestFormat):
-        SimpleAPI(Storage(), "ALL", [], "digest", False, None)
+        SimpleAPI(local_storage, "ALL", [], "digest", False, None)
 
 
-def test_digest_valid() -> None:
-    s = SimpleAPI(Storage(), "ALL", [], "md5", False, None)
+def test_digest_valid(local_storage: Storage) -> None:
+    s = SimpleAPI(local_storage, "ALL", [], "md5", False, None)
     assert s.digest_name == SimpleDigest.MD5
 
 
-def test_digest_config_default() -> None:
+def test_digest_config_default(local_storage: Storage) -> None:
     c = ConfigParser()
     c.add_section("mirror")
     config = validate_config_values(c)
-    s = SimpleAPI(Storage(), "ALL", [], config.digest_name, False, None)
+    s = SimpleAPI(local_storage, "ALL", [], config.digest_name, False, None)
     assert config.digest_name.upper() in [v.name for v in SimpleDigest]
     assert s.digest_name == SimpleDigest.SHA256
 
 
-def test_json_package_page() -> None:
-    s = SimpleAPI(Storage(), SimpleFormat.JSON, [], SimpleDigest.SHA256, False, None)
+def test_json_package_page(local_storage: Storage) -> None:
+    s = SimpleAPI(
+        local_storage, SimpleFormat.JSON, [], SimpleDigest.SHA256, False, None
+    )
     p = Package("69")
     p._metadata = SIXTYNINE_METADATA
     assert EXPECTED_SIMPLE_SIXTYNINE_JSON_1_1 == s.generate_json_simple_page(p)

--- a/src/bandersnatch/verify.py
+++ b/src/bandersnatch/verify.py
@@ -155,7 +155,7 @@ async def verify(
         return
 
     # apply releases filter plugins like class Package
-    for plugin in LoadedFilters().filter_release_plugins() or []:
+    for plugin in LoadedFilters(config).filter_release_plugins() or []:
         plugin.filter(pkg)
 
     deferred_exception = None


### PR DESCRIPTION
## Goals

- Consolidate options from the `mirror` section into a type-annotated class
  - This expands on the existing `SetConfigValues` named tuple
  - Probably dataclass or attrs (I <3 attrs)
- Consolidate reading and validation of mirror options into the configuration module
  - Currently some options are read in `validate_config_values` and some in the `mirror` subcommand itself, we can move these into a single place
  - Similarly with validation, some validation is performed e.g. inside the Mirror/Master classes, we can validate configuration at the program boundary so internal classes can assume configuration is valid
- Define default values for all mirror options that are supposed to have one in a single location (#990)
  - Defaults should not have to be provided where an option is read, since this leads to defaults being set for some subcommands but not others 
- Change BandersnatchConfig into a regular class instead of a singleton
  - The config object is already being passed as a parameter from main to async_main to subcommands
  - " " " " " " " to the storage plugin initializers
  - The config object is not being passed to filter plugin initializers, but there is a clear place to do so
  - If the config object is injected as a parameter everywhere it is used, then a Singleton metaclass is unnecessary and all the unit tests become a bit simpler
- (If needed) support old and new config implementations to coexist and be used simultaneously so modules can be migrated over time
- Fix #1674 while we're in here

## In Progress

- [ ] A `MirrorConfig` attrs class
  - I've got most of an implementation for this, but intend to capture some design notes regarding the approach I ended up taking
- [ ] Update subcommands to to read values from validated class fields instead of directly from a `ConfigParser` instance
- [ ] ...

## Completed

- [x] Fix evaluation of custom option reference syntax in diff-file
- [x] Fix a diff file being written unconditionally 
- [x] Change storage plugin init to require an external ConfigParser instance 
- [x] Change filter plugin init to require " " " "