### PR TITLE
Move to s3path 0.5.5

### DIFF
--- a/requirements_s3.txt
+++ b/requirements_s3.txt
@@ -2,7 +2,7 @@ boto3==1.34.54
 botocore==1.34.54
 jmespath==1.0.1
 python-dateutil==2.9.0.post0
-s3path==0.5.0
+s3path==0.5.5
 s3transfer==0.10.1
 six==1.16.0
 smart-open==6.4.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -86,7 +86,7 @@ uvloop =
     uvloop
 
 s3 =
-    s3path>=0.4.0
+    s3path>=0.5.5
 
 [isort]
 atomic = true

--- a/src/bandersnatch/tests/conftest.py
+++ b/src/bandersnatch/tests/conftest.py
@@ -10,7 +10,7 @@ import pytest
 from _pytest.capture import CaptureFixture
 from _pytest.fixtures import FixtureRequest
 from _pytest.monkeypatch import MonkeyPatch
-from s3path import PureS3Path, S3Path, _s3_accessor, register_configuration_parameter
+from s3path import PureS3Path, S3Path, accessor, register_configuration_parameter
 
 if TYPE_CHECKING:
     from bandersnatch.master import Master
@@ -180,10 +180,10 @@ def logging_mock(request: FixtureRequest) -> mock.MagicMock:
 @pytest.fixture()
 def reset_configuration_cache() -> Iterator[None]:
     try:
-        _s3_accessor.configuration_map.get_configuration.cache_clear()
+        accessor.configuration_map.get_configuration.cache_clear()
         yield
     finally:
-        _s3_accessor.configuration_map.get_configuration.cache_clear()
+        accessor.configuration_map.get_configuration.cache_clear()
 
 
 @pytest.fixture()

--- a/src/bandersnatch/tests/plugins/test_storage_plugin_s3.py
+++ b/src/bandersnatch/tests/plugins/test_storage_plugin_s3.py
@@ -130,11 +130,14 @@ def test_scandir(s3_mock: S3Path) -> None:
     backend.mkdir(f"/{s3_mock.bucket}/test_folder")
     backend.mkdir(f"/{s3_mock.bucket}/test_folder/sub_dir")
     backend.write_file(f"/{s3_mock.bucket}/test_folder/sub_file", "test")
-    for ent in backend.scandir(f"/{s3_mock.bucket}/test_folder"):
+    for ent in S3Path(f"/{s3_mock.bucket}/test_folder").iterdir():
         if ent.name == "sub_dir":
             assert ent.is_dir()
         elif ent.name == "sub_file":
             assert ent.is_file()
+        # we now make .s3keep files to pass params so is expected
+        elif ent.name == ".s3keep":
+            continue
         # no symlink for S3
         else:
             raise ValueError(f"unexpected dir entry {str(ent.name)}")

--- a/src/bandersnatch_storage_plugins/s3.py
+++ b/src/bandersnatch_storage_plugins/s3.py
@@ -10,7 +10,7 @@ import pathlib
 import tempfile
 from collections.abc import Generator, Iterator
 from fnmatch import fnmatch
-from typing import IO, Any, TYPE_CHECKING
+from typing import IO, TYPE_CHECKING, Any
 
 import boto3
 import filelock

--- a/src/bandersnatch_storage_plugins/s3.py
+++ b/src/bandersnatch_storage_plugins/s3.py
@@ -10,7 +10,7 @@ import pathlib
 import tempfile
 from collections.abc import Generator, Iterator
 from fnmatch import fnmatch
-from typing import IO, Any
+from typing import IO, Any, TYPE_CHECKING
 
 import boto3
 import filelock
@@ -19,15 +19,10 @@ from s3path import PureS3Path
 from s3path import S3Path as _S3Path
 from s3path import register_configuration_parameter
 
+if TYPE_CHECKING:
+    from s3path.accessor import _S3DirEntry
+
 from bandersnatch.storage import PATH_TYPES, StoragePlugin
-
-try:
-    # For backwards compatibility
-    from s3path import S3DirEntry as _S3DirEntry
-except ImportError:
-    # for s3path>=0.5.0;
-    from s3path import _S3DirEntry
-
 
 logger = logging.getLogger("bandersnatch")
 
@@ -362,7 +357,7 @@ class S3Storage(StoragePlugin):
         """Read entries from the provided directory"""
         if not isinstance(path, self.PATH_BACKEND):
             path = self.PATH_BACKEND(path)
-        for p in path._accessor.scandir(path):
+        for p in path.iterdir():
             if p.name == self.PATH_BACKEND.keep_file:
                 continue
             yield p


### PR DESCRIPTION
- s/_s3_accessor/accessor/
- Move _S3DirEntry behind TYPE_CHECKING
  - Remove backwards compatability
- Move scandir to use `S3Path.iterdir()`
  - Again drop backward compatibility

Test:
- Keep tests with minio passing