### PR TITLE
Fix diff-file being created when not configured

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,7 @@
 ## Big Fixes
 
 - Fix config file value interpolation for the `diff-file` option `PR #1715`
+- Fix diff-file being created when the option wasn't set `PR #1716`
 
 # 6.5.0
 

--- a/src/bandersnatch/mirror.py
+++ b/src/bandersnatch/mirror.py
@@ -6,11 +6,11 @@ import logging
 import os
 import sys
 import time
-from collections.abc import Awaitable
+from collections.abc import Awaitable, Callable
 from json import dump
 from pathlib import Path, WindowsPath
 from threading import RLock
-from typing import Any
+from typing import Any, TypeVar
 from urllib.parse import unquote, urlparse
 
 from filelock import Timeout
@@ -22,7 +22,7 @@ from .filter import LoadedFilters
 from .master import Master
 from .package import Package
 from .simple import SimpleAPI, SimpleFormat, SimpleFormats
-from .storage import storage_backend_plugins
+from .storage import Storage, storage_backend_plugins
 
 LOG_PLUGINS = True
 logger = logging.getLogger(__name__)
@@ -911,6 +911,42 @@ class BandersnatchMirror(Mirror):
         return path
 
 
+_T = TypeVar("_T")
+
+
+async def _setup_diff_file(
+    storage_plugin: Storage, configured_path: str, append_epoch: bool
+) -> Path:
+    # save some typing. maybe a method to add to Storage?
+    async def storage_plugin_exec(fn: Callable[..., _T], *args: Any) -> _T:
+        return await storage_plugin.loop.run_in_executor(
+            storage_plugin.executor, fn, *args
+        )
+
+    # use the storage backend to convert an abstract path to a concrete one
+    concrete_path = storage_plugin.PATH_BACKEND(configured_path)
+
+    # create parent directories if needed
+    await storage_plugin_exec(
+        lambda: concrete_path.parent.mkdir(exist_ok=True, parents=True)
+    )
+
+    # adjust the file/directory name if timestamps are enabled
+    if append_epoch:
+        epoch = int(time.time())
+        concrete_path = concrete_path.with_name(f"{concrete_path.name}-{epoch}")
+
+    # if the path is directory, adjust to write to a file inside it
+    if await storage_plugin_exec(concrete_path.is_dir):
+        concrete_path = concrete_path / "mirrored-files"
+
+    # if there is an existing file there then delete it
+    if await storage_plugin_exec(concrete_path.is_file):
+        concrete_path.unlink()
+
+    return concrete_path
+
+
 async def mirror(
     config: configparser.ConfigParser,
     specific_packages: list[str] | None = None,
@@ -926,28 +962,13 @@ async def mirror(
         )
     )
 
-    diff_file = storage_plugin.PATH_BACKEND(config_values.diff_file_path)
-    diff_full_path: Path | str
-    if diff_file:
-        diff_file.parent.mkdir(exist_ok=True, parents=True)
-        if config_values.diff_append_epoch:
-            diff_full_path = diff_file.with_name(f"{diff_file.name}-{int(time.time())}")
-        else:
-            diff_full_path = diff_file
-    else:
-        diff_full_path = ""
-
-    if diff_full_path:
-        if isinstance(diff_full_path, str):
-            diff_full_path = storage_plugin.PATH_BACKEND(diff_full_path)
-        if await storage_plugin.loop.run_in_executor(
-            storage_plugin.executor, diff_full_path.is_file
-        ):
-            diff_full_path.unlink()
-        elif await storage_plugin.loop.run_in_executor(
-            storage_plugin.executor, diff_full_path.is_dir
-        ):
-            diff_full_path = diff_full_path / "mirrored-files"
+    diff_full_path: Path | None = None
+    if config_values.diff_file_path:
+        diff_full_path = await _setup_diff_file(
+            storage_plugin,
+            config_values.diff_file_path,
+            config_values.diff_append_epoch,
+        )
 
     mirror_url = config.get("mirror", "master")
     timeout = config.getfloat("mirror", "timeout")
@@ -974,7 +995,7 @@ async def mirror(
                 "mirror", "keep_index_versions", fallback=0
             ),
             diff_append_epoch=config_values.diff_append_epoch,
-            diff_full_path=diff_full_path if diff_full_path else None,
+            diff_full_path=diff_full_path,
             cleanup=config_values.cleanup,
             release_files_save=config_values.release_files_save,
             download_mirror=config_values.download_mirror,
@@ -994,14 +1015,13 @@ async def mirror(
         loggable_changes = [str(chg) for chg in package_changes]
         logger.debug(f"{package_name} added: {loggable_changes}")
 
-    if mirror.diff_full_path:
-        logger.info(f"Writing diff file to {mirror.diff_full_path}")
+    if diff_full_path:
+        logger.info(f"Writing diff file to '{diff_full_path}'")
         diff_text = f"{os.linesep}".join(
             [str(chg.absolute()) for chg in mirror.diff_file_list]
         )
-        diff_file = mirror.storage_backend.PATH_BACKEND(mirror.diff_full_path)
         await storage_plugin.loop.run_in_executor(
-            storage_plugin.executor, diff_file.write_text, diff_text
+            storage_plugin.executor, diff_full_path.write_text, diff_text
         )
 
     return 0

--- a/src/bandersnatch/mirror.py
+++ b/src/bandersnatch/mirror.py
@@ -188,7 +188,6 @@ class BandersnatchMirror(Mirror):
         digest_name: str | None = None,
         root_uri: str | None = None,
         keep_index_versions: int = 0,
-        diff_file: Path | str | None = None,
         diff_append_epoch: bool = False,
         diff_full_path: Path | str | None = None,
         flock_timeout: int = 1,
@@ -230,7 +229,6 @@ class BandersnatchMirror(Mirror):
         # PyPI mirror, which requires serving packages from
         # https://files.pythonhosted.org
         self.root_uri = root_uri or ""
-        self.diff_file = diff_file
         self.diff_append_epoch = diff_append_epoch
         self.diff_full_path = diff_full_path
         self.keep_index_versions = keep_index_versions
@@ -975,7 +973,6 @@ async def mirror(
             keep_index_versions=config.getint(
                 "mirror", "keep_index_versions", fallback=0
             ),
-            diff_file=diff_file,
             diff_append_epoch=config_values.diff_append_epoch,
             diff_full_path=diff_full_path if diff_full_path else None,
             cleanup=config_values.cleanup,

--- a/src/bandersnatch/mirror.py
+++ b/src/bandersnatch/mirror.py
@@ -3,7 +3,6 @@ import configparser
 import datetime
 import hashlib
 import logging
-import os
 import sys
 import time
 from collections.abc import Awaitable, Callable
@@ -926,7 +925,7 @@ async def _setup_diff_file(
     # use the storage backend to convert an abstract path to a concrete one
     concrete_path = storage_plugin.PATH_BACKEND(configured_path)
 
-    # create parent directories if needed
+    # create parent directory if needed
     await storage_plugin_exec(
         lambda: concrete_path.parent.mkdir(exist_ok=True, parents=True)
     )
@@ -1017,9 +1016,8 @@ async def mirror(
 
     if diff_full_path:
         logger.info(f"Writing diff file to '{diff_full_path}'")
-        diff_text = f"{os.linesep}".join(
-            [str(chg.absolute()) for chg in mirror.diff_file_list]
-        )
+        # File is written in text mode; universal newlines will translate this to os.linesep
+        diff_text = "\n".join([str(chg.absolute()) for chg in mirror.diff_file_list])
         await storage_plugin.loop.run_in_executor(
             storage_plugin.executor, diff_full_path.write_text, diff_text
         )

--- a/src/bandersnatch/tests/test_main.py
+++ b/src/bandersnatch/tests/test_main.py
@@ -90,7 +90,6 @@ def test_main_reads_config_values(mirror_mock: mock.MagicMock, tmpdir: Path) -> 
         "keep_index_versions": 0,
         "release_files_save": True,
         "storage_backend": "filesystem",
-        "diff_file": diff_file,
         "diff_append_epoch": False,
         "diff_full_path": diff_file,
         "cleanup": False,

--- a/src/bandersnatch/tests/test_mirror.py
+++ b/src/bandersnatch/tests/test_mirror.py
@@ -1,11 +1,13 @@
 import os.path
 import sys
+import time
 import unittest.mock as mock
-from collections.abc import Iterator
+from collections.abc import Awaitable, Callable, Iterator, Mapping
+from configparser import ConfigParser
 from os import sep
 from pathlib import Path
 from tempfile import TemporaryDirectory
-from typing import Any, NoReturn
+from typing import Any, NoReturn, TypeAlias
 
 import pytest
 from freezegun import freeze_time
@@ -14,6 +16,7 @@ from bandersnatch import utils
 from bandersnatch.configuration import BandersnatchConfig, Singleton
 from bandersnatch.master import Master
 from bandersnatch.mirror import BandersnatchMirror
+from bandersnatch.mirror import mirror as mirror_cmd
 from bandersnatch.package import Package
 from bandersnatch.simple import SimpleFormats
 from bandersnatch.tests.test_simple_fixtures import SIXTYNINE_METADATA
@@ -1295,6 +1298,171 @@ def test_write_simple_pages(mirror: BandersnatchMirror) -> None:
         mirror.write_simple_pages(package, json_content)
     # Expect .html, .v1_html and .v1_json ...
     assert 3 == len(mirror.diff_file_list)
+
+
+# Used to patch the `BandersnatchMirror.synchronize` method with a mock that returns a fixed value.
+# This is to test behaviors in the `bandersnatch.mirror.mirror` function without any actual mirroring.
+
+AlteredPackages: TypeAlias = Mapping[str, set[str]]
+
+
+def make_mock_synchronize(
+    retval: AlteredPackages,
+) -> Callable[..., Awaitable[AlteredPackages]]:
+
+    async def mock_synchronize(
+        self: Any,
+        specific_packages: list[str] | None = None,
+        sync_simple_index: bool = True,
+    ) -> AlteredPackages:
+        return retval
+
+    return mock_synchronize
+
+
+# This is a test to check that a diff file is NOT created when 'diff-file' isn't set in
+# configuration. We can't exhaustively assert a negative - the specific behavior being
+# checked here is a diff file being created at "./mirrored-files" when not configured.
+@pytest.mark.asyncio
+async def test_mirror_subcommand_only_creates_diff_file_if_configured(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    # Setup: create a configuration for the 'mirror' subcommand
+    # Mirror section only contains required options and omits 'diff-file'
+    config = ConfigParser()
+    config.read_dict(
+        {
+            "mirror": {
+                "master": "https://pypi.org",
+                "directory": (tmp_path / "mirror").as_posix(),
+                "timeout": 15,
+                "stop-on-error": False,
+                "workers": 1,
+                "hash-index": False,
+                "release-files": True,
+                "json": False,
+            },
+            "plugins": {"enabled": ["allowlist_project"]},
+            "allowlist": {"packages": ["black", "ruff", "autopep8"]},
+        }
+    )
+
+    # Setup: patch 'Mirror.synchronize' with a stub returning fixed data.
+    # Normally it returns 'self.altered_packages', and those are what get written into
+    # the diff file. Non-empty fixed content here means a diff-file should exist and
+    # have content IF it is configured.
+    mock_synchronize = make_mock_synchronize(
+        {
+            "ruff": {"fake/file/path/1", "fake/file/path/2"},
+            "black": {"fake/file/path/3"},
+        }
+    )
+    monkeypatch.setattr(BandersnatchMirror, "synchronize", mock_synchronize)
+
+    # Setup: change the current working directory into tmp_path, because when failing
+    # the test will try to write into './mirrored-files'
+    monkeypatch.chdir(tmp_path)
+
+    # Execute the 'mirror' subcommand. Because 'synchronize' is patched, this is pretty
+    # much running the body of the 'mirror' function, including creating Master and
+    # Mirror instances, but doesn't perform any actual package syncing at all.
+    await mirror_cmd(config=config)
+
+    # An 'info'-level message is always logged after 'synchronize' completes. It should
+    # be consistent with the static data returned from our mock method.
+    expected_message = "2 packages had changes"
+    assert any(
+        m == expected_message for m in caplog.messages
+    ), f"Logged '{expected_message}'"
+
+    # Because BandersnatchMirror's 'bootstrap' runs, this directory should exist;
+    # this is just sanity checking that some disk IO happened...
+    web_folder = tmp_path / "mirror" / "web"
+    assert web_folder.is_dir(), f"The folder '{web_folder}' was created"
+
+    # But there should not be a diff file in the current working directory
+    absent_diff_file = Path.cwd() / "mirrored-files"
+    assert (
+        not absent_diff_file.exists()
+    ), f"there shouldn't be a diff file at {absent_diff_file}"
+
+    # sanity check - we used monkeypatch to change cwd,
+    assert Path.cwd() == tmp_path
+
+
+# This checks the path where the diff-file is created when:
+# 1) `diff-file` points to an existing directory
+# 2) `diff-append-epoch` is enabled
+# One might expect any of:
+# a) `.../{diff-file}/mirrored-files-{timestamp}`
+# b) `.../{diff-file}-{timestamp}/mirrored-files`
+# c) `.../{diff-file}-{timestamp}`
+# The existing behavior is (c). Though this ignores the existing directory, changes to
+# diff-file path handling behavior could break a user's existing automation/scripting.
+@pytest.mark.asyncio
+async def test_mirror_subcommand_diff_file_dir_with_epoch(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+
+    mirror_dir = tmp_path / "mirror"
+    diff_files_dir = mirror_dir / "diff-files-dir"
+
+    # Setup: make sure the 'diff-file' directory is already created
+    diff_files_dir.mkdir(parents=True)
+
+    # Setup: create configuration for 'mirror' subcommand that includes both
+    # `diff-file` and `diff-append-epoch`
+    config = ConfigParser()
+    config.read_dict(
+        {
+            "mirror": {
+                "master": "https://pypi.org",
+                "directory": mirror_dir.as_posix(),
+                "timeout": 15,
+                "stop-on-error": False,
+                "workers": 1,
+                "hash-index": False,
+                "release-files": True,
+                "json": False,
+                "diff-file": diff_files_dir.as_posix(),
+                "diff-append-epoch": True,
+            },
+            "plugins": {"enabled": ["allowlist_project"]},
+            "allowlist": {"packages": ["black", "ruff", "autopep8"]},
+        }
+    )
+
+    # Setup: mock the 'synchronize' method on BandersnatchMirror to return fixed output.
+    # The output of the synchronize method is a mapping from package names to changed
+    # files, so the paths returned here should end up in diff-file.
+    mock_synchronize = make_mock_synchronize(
+        {
+            "black": {"AB/C1/ABC123/black-123-py3-non-any.whl"},
+            "ruff": {
+                "98/7D/987DEF/ruff-123.tar.gz",
+                "98/7D/987DEF/ruff-123-py3-none-any.whl",
+            },
+        }
+    )
+    monkeypatch.setattr(BandersnatchMirror, "synchronize", mock_synchronize)
+
+    # Setup: mock time.time so we can assert against the generated diff-file path
+    fixed_time = time.time()
+    monkeypatch.setattr(time, "time", lambda: fixed_time)
+
+    # Execute: run the 'mirror' subcommand
+    await mirror_cmd(config=config)
+
+    # Expectation: current behavior appends timestamp before checking if the directory exists,
+    # so the generated path will be `{diff-file}-{timestamp}`.
+    expected_diff_file = diff_files_dir.with_name(
+        f"{diff_files_dir.name}-{int(fixed_time)}"
+    )
+    assert expected_diff_file.is_file()
+    lines = expected_diff_file.read_text().splitlines()
+    assert len(lines) > 0
 
 
 if __name__ == "__main__":

--- a/src/bandersnatch/tests/test_mirror.py
+++ b/src/bandersnatch/tests/test_mirror.py
@@ -1462,7 +1462,7 @@ async def test_mirror_subcommand_diff_file_dir_with_epoch(
     )
     assert expected_diff_file.is_file()
     lines = expected_diff_file.read_text().splitlines()
-    assert len(lines) > 0
+    assert len(lines) == 3
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This fixes path handling in the `mirror` subcommand that caused a diff file to be written to the current directory if `diff-file` wasn't set in the configuration file. This is the issue where `Path("")` becomes `Path(".")` and boolean-checks as truthy.

I encountered what might be an unexpected behavior when `diff-file` is set to an existing directory and `diff-append-epoch` is enabled. I've added a unit test to capture the current behavior, but it might be worth changing depending on how you feel about the compatibility break.

Split into 3 commits:

1. Removes a `diff_file` argument and attribute from `BandersnatchMirror`. The initializer accepted both `diff_file` and `diff_full_path`, and `diff_file` doesn't appear to be used anywhere. I went ahead and removed it while I was around then extracted this change into its own commit so it can be accepted/removed on its own.
2. Adds 2 tests for the mirror subcommand: 
    - check whether a diff file is being created when not configured
    - capture the interaction between the `diff-file` and `diff-append-epoch` options when `diff-file` is set to an existing directory

   If you check out this commit, the first test is expected to fail.
3. Changing the path handling in the mirror subcommand for `diff-file`. 