### PR TITLE
Move all use of s3path's configuration_map to public API

### DIFF
--- a/requirements_s3.txt
+++ b/requirements_s3.txt
@@ -2,7 +2,7 @@ boto3==1.34.54
 botocore==1.34.54
 jmespath==1.0.1
 python-dateutil==2.9.0.post0
-s3path==0.5.6
+s3path==0.5.7
 s3transfer==0.10.1
 six==1.16.0
 smart-open==7.0.4

--- a/src/bandersnatch/tests/conftest.py
+++ b/src/bandersnatch/tests/conftest.py
@@ -10,8 +10,13 @@ import pytest
 from _pytest.capture import CaptureFixture
 from _pytest.fixtures import FixtureRequest
 from _pytest.monkeypatch import MonkeyPatch
-from s3path import PureS3Path, S3Path, accessor, register_configuration_parameter
-from s3path.accessor import configuration_map
+from s3path import (
+    PureS3Path,
+    S3Path,
+    accessor,
+    configuration_map,
+    register_configuration_parameter,
+)
 
 if TYPE_CHECKING:
     from bandersnatch.master import Master

--- a/src/bandersnatch/tests/conftest.py
+++ b/src/bandersnatch/tests/conftest.py
@@ -11,6 +11,7 @@ from _pytest.capture import CaptureFixture
 from _pytest.fixtures import FixtureRequest
 from _pytest.monkeypatch import MonkeyPatch
 from s3path import PureS3Path, S3Path, accessor, register_configuration_parameter
+from s3path.accessor import configuration_map
 
 if TYPE_CHECKING:
     from bandersnatch.master import Master
@@ -202,7 +203,7 @@ def s3_mock(reset_configuration_cache: None) -> S3Path:
     new_bucket = S3Path("/test-bucket")
     new_bucket.mkdir(exist_ok=True)
     yield new_bucket
-    resource, _ = new_bucket._accessor.configuration_map.get_configuration(new_bucket)
+    resource, _ = configuration_map.get_configuration(new_bucket)
     bucket = resource.Bucket(new_bucket.bucket)
     for key in bucket.objects.all():
         key.delete()

--- a/src/bandersnatch_storage_plugins/s3.py
+++ b/src/bandersnatch_storage_plugins/s3.py
@@ -17,8 +17,7 @@ import filelock
 from botocore.client import Config
 from s3path import PureS3Path
 from s3path import S3Path as _S3Path
-from s3path import register_configuration_parameter
-from s3path.accessor import configuration_map
+from s3path import configuration_map, register_configuration_parameter
 
 if TYPE_CHECKING:
     from s3path.accessor import _S3DirEntry


### PR DESCRIPTION
- Move use uses of s3path configuration_map to import from accessor and use directly

Tests:
- See tests stay passing in GitHub actions
  - I can not get them to pass locally ...