### PR TITLE
Add inital support for 3.12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.10", "3.11"]
+        python-version: ["3.11", "3.12"]
         os: [macOS-latest, windows-latest]
 
     steps:

--- a/.github/workflows/ci_ubuntu.yml
+++ b/.github/workflows/ci_ubuntu.yml
@@ -18,7 +18,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.10", "3.11"]
+        python-version: ["3.11", "3.12"]
         os: [ubuntu-latest]
 
     steps:

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@
 
 - Add arbitrary configuration option for S3 Storage Backend Boto3 calls (PR #1697)
 - Added HTTPS support in Docker Compose + Enabled bind-mount volume for Nginx config + add documentation in README.md (PR #1653)
+- Initial support for python 3.12 (PR #1728)
 
 ## Documentation
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,6 +5,7 @@ classifiers =
     Programming Language :: Python :: 3 :: Only
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
+    Programming Language :: Python :: 3.12
 description = Mirroring tool that implements the client (mirror) side of PEP 381
 long_description = file:README.md
 long_description_content_type = text/markdown
@@ -15,7 +16,7 @@ project_urls =
     Source Code = https://github.com/pypa/bandersnatch
     Change Log = https://github.com/pypa/bandersnatch/blob/master/CHANGES.md
 url = https://github.com/pypa/bandersnatch/
-version = 6.5.0
+version = 6.6.0dev0
 
 [options]
 install_requires =
@@ -29,7 +30,7 @@ install_requires =
 package_dir =
     =src
 packages = find:
-python_requires = >=3.10
+python_requires = >=3.11
 
 [options.packages.find]
 where=src

--- a/src/bandersnatch/__init__.py
+++ b/src/bandersnatch/__init__.py
@@ -20,9 +20,9 @@ class _VersionInfo(NamedTuple):
 
 __version_info__ = _VersionInfo(
     major=6,
-    minor=5,
+    minor=6,
     micro=0,
-    releaselevel="",
+    releaselevel="dev0",
     serial=0,  # Not currently in use with Bandersnatch versioning
 )
 __version__ = __version_info__.version_str

--- a/src/bandersnatch/tests/plugins/test_storage_plugin_s3.py
+++ b/src/bandersnatch/tests/plugins/test_storage_plugin_s3.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 
 import pytest
-from s3path import S3Path
+from s3path import S3Path, configuration_map
 
 from bandersnatch.tests.mock_config import mock_config
 from bandersnatch_storage_plugins import s3
@@ -172,7 +172,7 @@ signature_version = s3v4
     backend.initialize_plugin()
 
     path = s3.S3Path("/tmp/pypi")
-    resource, _ = path._accessor.configuration_map.get_configuration(path)
+    resource, _ = configuration_map.get_configuration(path)
     assert resource.meta.client.meta.endpoint_url == "http://localhost:9090"
 
     config_loader = mock_config(
@@ -198,7 +198,7 @@ endpoint_url = http://localhost:9090
     backend.initialize_plugin()
 
     path = s3.S3Path("/tmp/pypi")
-    resource, _ = path._accessor.configuration_map.get_configuration(path)
+    resource, _ = configuration_map.get_configuration(path)
     assert resource.meta.client.meta.endpoint_url == "http://localhost:9090"
 
 

--- a/src/bandersnatch_storage_plugins/s3.py
+++ b/src/bandersnatch_storage_plugins/s3.py
@@ -7,6 +7,7 @@ import hashlib
 import logging
 import os
 import pathlib
+import sys
 import tempfile
 from collections.abc import Generator, Iterator
 from fnmatch import fnmatch
@@ -18,6 +19,9 @@ from botocore.client import Config
 from s3path import PureS3Path
 from s3path import S3Path as _S3Path
 from s3path import configuration_map, register_configuration_parameter
+
+if sys.version_info >= (3, 12):
+    from s3path.accessor import _generate_prefix
 
 if TYPE_CHECKING:
     from s3path.accessor import _S3DirEntry
@@ -40,9 +44,14 @@ class S3Path(_S3Path):
         resource, _ = configuration_map.get_configuration(self)
         bucket = resource.Bucket(bucket_name)
 
+        if sys.version_info >= (3, 12):
+            prefix = _generate_prefix(self)
+        else:
+            prefix = self._accessor.generate_prefix(self)
+
         kwargs = {
             "Bucket": bucket_name,
-            "Prefix": self._accessor.generate_prefix(self),
+            "Prefix": prefix,
             "Delimiter": "",
         }
         continuation_token = None


### PR DESCRIPTION
- Move to version 6.6.0dev0
- Make CI pass for 3.12
  - Drop support for swift unless someone speaks up and wants to help support it - This will cause a temporary coverage reduction
  - Move python_requires + GitHub actions to >= 3.11 only
- Leave swift for one more release + document deprecating support due to no one to help maintain
- Fix remaining s3path 3.12 fun
  - Move to 3.12 private _generate_prefix until we workout correct way
  - Move last missed uses of private configuration_map

Test:
- Run `/tmp/tb_312/bin/pre-commit run -a`
- Run tox in py312
  - `/tmp/tb_312/bin/tox`