### PR TITLE
Update docker images to 3.12

### DIFF
--- a/.github/workflows/docker_upload.yml
+++ b/.github/workflows/docker_upload.yml
@@ -35,13 +35,13 @@ jobs:
       - name: Build and push filesystem image
         uses: docker/build-push-action@v5
         env:
-          PY_VERSION: '3.11'
+          PY_VERSION: '3.12'
         with:
           build-args: PY_VERSION
           context: .
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: pypa/bandersnatch:latest,pypa/bandersnatch:${{ env.GIT_TAG }},pypa/bandersnatch:3,pypa/bandersnatch:3.11
+          tags: pypa/bandersnatch:latest,pypa/bandersnatch:${{ env.GIT_TAG }},pypa/bandersnatch:3,pypa/bandersnatch:3.12
 
       - name: Filesystem Image digest
         run: echo ${{ steps.docker_build.outputs.digest }}
@@ -49,7 +49,7 @@ jobs:
       - name: Build and push s3 image
         uses: docker/build-push-action@v5
         env:
-          PY_VERSION: '3.11'
+          PY_VERSION: '3.12'
           WITH_S3: yes
         with:
           build-args: |
@@ -58,24 +58,7 @@ jobs:
           context: .
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: pypa/bandersnatch:s3-latest,pypa/bandersnatch:s3-${{ env.GIT_TAG }},pypa/bandersnatch:s3-3,pypa/bandersnatch:s3-3.11
+          tags: pypa/bandersnatch:s3-latest,pypa/bandersnatch:s3-${{ env.GIT_TAG }},pypa/bandersnatch:s3-3,pypa/bandersnatch:s3-3.12
 
       - name: S3 Image digest
-        run: echo ${{ steps.docker_build.outputs.digest }}
-
-      - name: Build and push swift image
-        uses: docker/build-push-action@v5
-        env:
-          PY_VERSION: '3.11'
-          WITH_SWIFT: yes
-        with:
-          build-args: |
-            PY_VERSION
-            WITH_SWIFT
-          context: .
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: pypa/bandersnatch:swift-latest,pypa/bandersnatch:swift-${{ env.GIT_TAG }},pypa/bandersnatch:swift-3,pypa/bandersnatch:swift-3.11
-
-      - name: Swift Image digest
         run: echo ${{ steps.docker_build.outputs.digest }}

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,10 +1,12 @@
-# Unreleased
+# Unreleased - 6.6.0
 
 ## New Features
 
 - Add arbitrary configuration option for S3 Storage Backend Boto3 calls (PR #1697)
 - Added HTTPS support in Docker Compose + Enabled bind-mount volume for Nginx config + add documentation in README.md (PR #1653)
 - Initial support for python 3.12 (PR #1728)
+- Move Docker images to 3.12 (PR #1733)
+  - Removing swift builds due to lack or assistance - Happy to bring back if you're willing to help maintian
 
 ## Documentation
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,28 +1,21 @@
-ARG PY_VERSION=3.11
+ARG PY_VERSION=3.12
 
 FROM python:${PY_VERSION} as base
 
 FROM base as builder
 ARG PY_VERSION
 ARG WITH_S3
-ARG WITH_SWIFT
 
 RUN mkdir /install
 WORKDIR /install
 RUN pip install --target="/install" --upgrade pip setuptools wheel
 ADD requirements_s3.txt /install
-ADD requirements_swift.txt /install
 ADD requirements.txt /install
 RUN if [ ! -z "$WITH_S3" ] \
      ; then \
      pip install --target="/install" \
         -r requirements.txt \
         -r requirements_s3.txt \
-     ; elif [ ! -z "$WITH_SWIFT" ] \
-     ; then \
-     pip install --target="/install" \
-        -r requirements.txt \
-        -r requirements_swift.txt \
      ; else \
      pip install --target="/install" \
         -r requirements.txt \
@@ -36,7 +29,6 @@ ENV LC_ALL C.UTF-8
 
 ARG PY_VERSION
 ARG WITH_S3
-ARG WITH_SWIFT
 
 COPY --from=builder /install /usr/local/lib/python${PY_VERSION}/site-packages
 RUN mkdir /bandersnatch && mkdir /conf && chmod 777 /conf
@@ -49,9 +41,6 @@ COPY src /bandersnatch/src
 RUN if [ ! -z "$WITH_S3" ] \
      ; then \
      pip --no-cache-dir install /bandersnatch/[s3] \
-     ; elif [ ! -z "$WITH_SWIFT" ] \
-     ; then \
-     pip --no-cache-dir install /bandersnatch/[swift] \
      ; else \
      pip --no-cache-dir install /bandersnatch/ \
      ; fi


### PR DESCRIPTION
- Use 3.12 for filesystem + s3 docker images
- Due to lack of support / tests dropping building swift
  - If someone is using, happy to bring back if support / maintanence is helped with

Test:
- Build on my laptop from root of bandersnatch repo
  - `docker build --tag bandersnatch_312 .`