### PR TITLE
Fix the command execution by runner.py

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,6 +18,7 @@
 - Fix config file value interpolation for the `diff-file` option `PR #1715`
 - Fix diff-file being created when the option wasn't set `PR #1716`
 - Provide default values for most config options in the `[mirror]` section `PR #1740`
+- Fix command execution by `runner.py` - `PR #1753`
 
 ## Deprecation
 

--- a/src/runner.py
+++ b/src/runner.py
@@ -45,11 +45,6 @@ def main() -> int:
     )
     args = parser.parse_args()
 
-    if args.force_check == "true":
-        force_check = "--force-check"
-    else:
-        force_check = ""
-
     print(f"Running bandersnatch every {args.interval}s", file=sys.stderr)
     try:
         while True:
@@ -64,8 +59,11 @@ def main() -> int:
                         "--config",
                         args.config,
                         "mirror",
-                        force_check,
                     ]
+
+                    if args.force_check == "true":
+                        cmd.append("--force-check")
+
                     run(cmd, check=True)
                 except CalledProcessError as cpe:
                     return cpe.returncode


### PR DESCRIPTION
When no `--force-check` option is specified when using the `runner.py` the argument list for running bandersnatch command consists of `''` at the end which breaks the bandersnatch command execution: `bandersnatch: error: unrecognized arguments: `. This commit fixes this by only appending the "--force-check" argument if specified in runner.py call.

Closes #1754