### PR TITLE
Drop `types-pkg_resources`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,7 +31,7 @@ repos:
     hooks:
       - id: mypy
         exclude: (docs/.*)
-        additional_dependencies: ["types-filelock", "types-freezegun", "types-pkg_resources"]
+        additional_dependencies: ["types-filelock", "types-freezegun"]
 
   - repo: https://github.com/PyCQA/flake8
     rev: 7.1.0

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -13,4 +13,3 @@ setuptools==70.2.0
 tox==4.16.0
 types-filelock==3.2.7
 types-freezegun==1.1.10
-types-pkg_resources==0.1.3


### PR DESCRIPTION
This is to resolve an error seen when trying to setup `pre-commit` (see [1] for an example), the most relevant bit of the output:

        An unexpected error has occurred: CalledProcessError: command: ('/pc/clone/LSIlsu0mQy2UjKm46aTi1Q/py_env-python3/bin/python', '-mpip', 'install', '.', 'types-filelock', 'types-freezegun', 'types-pkg_resources')
        return code: 1
        stdout:
            Processing /pc/clone/LSIlsu0mQy2UjKm46aTi1Q
              Preparing metadata (setup.py): started
              Preparing metadata (setup.py): finished with status 'done'
            Collecting types-filelock
              Downloading types_filelock-3.2.7-py3-none-any.whl.metadata (1.4 kB)
            Collecting types-freezegun
              Downloading types_freezegun-1.1.10-py3-none-any.whl.metadata (1.4 kB)
        stderr:
            ERROR: Ignored the following yanked versions: 0.1.0, 0.1.1, 0.1.2, 0.1.3
            ERROR: Could not find a version that satisfies the requirement types-pkg_resources (from versions: none)
            ERROR: No matching distribution found for types-pkg_resources

This is caused by all releases of `types-pkg-resources` having been yanked from `pypi` with a note[2]:

> Use types-setuptools instead

However, instead of doing that we can just drop this dependency, as the last usage of `pkg_resources` was removed with
62a9c7ebae57efef002d5ca335b8b3593fb40c1b

[1] https://results.pre-commit.ci/run/github/133377409/1723480331.7DiDrXbNTeimhjcKTluMag
[2] https://pypi.org/project/types-pkg-resources/