### PR TITLE
Upgrade test dependencies pytest and pytest-asyncio 

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -2,6 +2,7 @@
 log_cli_level = DEBUG
 log_level = DEBUG
 asyncio_mode=strict
+asyncio_default_fixture_loop_scope = function
 
 testpaths = src
 python_files = test.py test_*.py

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,13 +1,13 @@
-async-timeout>=4.0.0a3
+async-timeout==5.0.1
 black==24.4.2
 coverage==7.6.4
 flake8==7.1.1
 flake8-bugbear==24.8.19
 freezegun==1.5.1
 mypy==1.11.2
-pre-commit==4.0.0
-pytest==7.4.4
-pytest-asyncio==0.23.8
+pre_commit==4.0.0
+pytest==8.3.4
+pytest-asyncio==0.24.0
 pytest-timeout==2.3.1
 setuptools==72.2.0
 tox==4.18.0

--- a/src/bandersnatch/tests/conftest.py
+++ b/src/bandersnatch/tests/conftest.py
@@ -1,6 +1,7 @@
 # flake8: noqa
 import os
 import unittest.mock as mock
+from asyncio import AbstractEventLoop
 from collections.abc import Iterator
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Dict
@@ -96,8 +97,11 @@ def package_json() -> dict[str, Any]:
     }
 
 
+# This requests the 'event_loop' fixture from pytest-asyncio because the initializer for
+# 'Master' uses `asyncio.get_event_loop()`, and in some contexts a loop won't already
+# exist when the fixture is initialized.
 @pytest.fixture
-def master(package_json: dict[str, Any]) -> "Master":
+def master(package_json: dict[str, Any], event_loop: AbstractEventLoop) -> "Master":
     from bandersnatch.master import Master
 
     class FakeReader:

--- a/src/bandersnatch/tests/plugins/test_allowlist_name.py
+++ b/src/bandersnatch/tests/plugins/test_allowlist_name.py
@@ -4,12 +4,16 @@ from pathlib import Path
 from tempfile import TemporaryDirectory
 from unittest import TestCase
 
+import pytest
+
 import bandersnatch.filter
 import bandersnatch.storage
 from bandersnatch.master import Master
 from bandersnatch.mirror import BandersnatchMirror
 from bandersnatch.package import Package
 from bandersnatch.tests.mock_config import mock_config
+
+pytestmark = pytest.mark.asyncio(loop_scope="class")
 
 
 class TestAllowListProject(TestCase):

--- a/src/bandersnatch/tests/plugins/test_blocklist_name.py
+++ b/src/bandersnatch/tests/plugins/test_blocklist_name.py
@@ -3,11 +3,15 @@ from pathlib import Path
 from tempfile import TemporaryDirectory
 from unittest import TestCase
 
+import pytest
+
 import bandersnatch.filter
 from bandersnatch.master import Master
 from bandersnatch.mirror import BandersnatchMirror
 from bandersnatch.package import Package
 from bandersnatch.tests.mock_config import mock_config
+
+pytestmark = pytest.mark.asyncio(loop_scope="class")
 
 
 class TestBlockListProject(TestCase):

--- a/src/bandersnatch/tests/plugins/test_filename.py
+++ b/src/bandersnatch/tests/plugins/test_filename.py
@@ -3,12 +3,16 @@ from pathlib import Path
 from tempfile import TemporaryDirectory
 from unittest import TestCase
 
+import pytest
+
 import bandersnatch.filter
 from bandersnatch.master import Master
 from bandersnatch.mirror import BandersnatchMirror
 from bandersnatch.package import Package
 from bandersnatch.tests.mock_config import mock_config
 from bandersnatch_filter_plugins import filename_name
+
+pytestmark = pytest.mark.asyncio(loop_scope="class")
 
 
 class BasePluginTestCase(TestCase):

--- a/src/bandersnatch/tests/plugins/test_latest_release.py
+++ b/src/bandersnatch/tests/plugins/test_latest_release.py
@@ -3,12 +3,16 @@ from pathlib import Path
 from tempfile import TemporaryDirectory
 from unittest import TestCase
 
+import pytest
+
 import bandersnatch.filter
 from bandersnatch.master import Master
 from bandersnatch.mirror import BandersnatchMirror
 from bandersnatch.package import Package
 from bandersnatch.tests.mock_config import mock_config
 from bandersnatch_filter_plugins import latest_name
+
+pytestmark = pytest.mark.asyncio(loop_scope="class")
 
 
 class BasePluginTestCase(TestCase):

--- a/src/bandersnatch/tests/plugins/test_metadata_plugins.py
+++ b/src/bandersnatch/tests/plugins/test_metadata_plugins.py
@@ -4,12 +4,16 @@ from tempfile import TemporaryDirectory
 from typing import cast
 from unittest import TestCase
 
+import pytest
+
 import bandersnatch.filter
 from bandersnatch.master import Master
 from bandersnatch.mirror import BandersnatchMirror
 from bandersnatch.package import Package
 from bandersnatch.tests.mock_config import mock_config
 from bandersnatch_filter_plugins.metadata_filter import SizeProjectMetadataFilter
+
+pytestmark = pytest.mark.asyncio(loop_scope="class")
 
 
 class TestSizeProjectMetadataFilter(TestCase):

--- a/src/bandersnatch/tests/plugins/test_prerelease_name.py
+++ b/src/bandersnatch/tests/plugins/test_prerelease_name.py
@@ -4,12 +4,16 @@ from pathlib import Path
 from tempfile import TemporaryDirectory
 from unittest import TestCase
 
+import pytest
+
 import bandersnatch.filter
 from bandersnatch.master import Master
 from bandersnatch.mirror import BandersnatchMirror
 from bandersnatch.package import Package
 from bandersnatch.tests.mock_config import mock_config
 from bandersnatch_filter_plugins import prerelease_name
+
+pytestmark = pytest.mark.asyncio(loop_scope="class")
 
 
 class BasePluginTestCase(TestCase):

--- a/src/bandersnatch/tests/plugins/test_regex_name.py
+++ b/src/bandersnatch/tests/plugins/test_regex_name.py
@@ -4,12 +4,16 @@ from pathlib import Path
 from tempfile import TemporaryDirectory
 from unittest import TestCase
 
+import pytest
+
 import bandersnatch.filter
 from bandersnatch.master import Master
 from bandersnatch.mirror import BandersnatchMirror
 from bandersnatch.package import Package
 from bandersnatch.tests.mock_config import mock_config
 from bandersnatch_filter_plugins import regex_name
+
+pytestmark = pytest.mark.asyncio(loop_scope="class")
 
 
 class BasePluginTestCase(TestCase):

--- a/src/bandersnatch/tests/plugins/test_storage_plugins.py
+++ b/src/bandersnatch/tests/plugins/test_storage_plugins.py
@@ -15,6 +15,8 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 from unittest import TestCase, mock
 
+import pytest
+
 import bandersnatch.storage
 from bandersnatch.master import Master
 from bandersnatch.mirror import BandersnatchMirror
@@ -37,6 +39,10 @@ BASE_SAMPLE_FILE = os.path.join(
 SWIFT_CONTAINER_FILE = os.path.join(
     os.path.dirname(os.path.abspath(__file__)), "swift_container.json"
 )
+
+
+# Swift and FileSystem storage plugins use asyncio.get_event_loop in their initializers
+pytestmark = pytest.mark.asyncio(loop_scope="class")
 
 
 def get_swift_file_attrs(path: Path, base: Path, container: str = "") -> dict[str, Any]:

--- a/src/bandersnatch/tests/test_delete.py
+++ b/src/bandersnatch/tests/test_delete.py
@@ -77,7 +77,12 @@ def _fake_config() -> ConfigParser:
 
 
 @pytest.mark.asyncio
-async def test_delete_path() -> None:
+async def test_delete_path(reset_storage_plugins: None) -> None:
+    # 'delete_path' is one of the few places 'storage_backend_plugins' is used without the 'clear_cache' option.
+    # For interactive use this is not relevant, but when running tests there can be an order-dependent error
+    # caused by 'delete_path' trying to use the event loop from a previous test. The storage plugin initializer
+    # gets the current event loop and saves it in an attribute, but test event loops are scoped, so if a plugin
+    # is created in one event loop scope and used in another the stored loop will be closed.
     BandersnatchConfig().read_dict(_fake_config())
     with TemporaryDirectory() as td:
         td_path = Path(td)

--- a/src/bandersnatch/tests/test_filter.py
+++ b/src/bandersnatch/tests/test_filter.py
@@ -4,6 +4,8 @@ import unittest
 from tempfile import TemporaryDirectory
 from unittest import TestCase
 
+import pytest
+
 from bandersnatch.configuration import BandersnatchConfig
 from bandersnatch.tests.mock_config import mock_config
 
@@ -13,6 +15,8 @@ from bandersnatch.filter import (  # isort:skip
     FilterReleasePlugin,
     LoadedFilters,
 )
+
+pytestmark = pytest.mark.asyncio(loop_scope="class")
 
 
 class TestBandersnatchFilter(TestCase):

--- a/src/bandersnatch/tests/test_main.py
+++ b/src/bandersnatch/tests/test_main.py
@@ -24,9 +24,14 @@ async def empty_dict(*args: Any, **kwargs: Any) -> dict:
     return {}
 
 
-def setup() -> None:
-    """simple setup function to clear Singleton._instances before each test"""
+@pytest.fixture
+def reset_config_singleton() -> None:
+    """Reset the singleton BandersnatchConfig instance"""
     Singleton._instances = {}
+
+
+# Use the above fixture for every test function in the current module
+pytestmark = pytest.mark.usefixtures("reset_config_singleton")
 
 
 def test_main_help(capfd: CaptureFixture) -> None:
@@ -103,7 +108,6 @@ def test_main_reads_config_values(mirror_mock: mock.MagicMock, tmpdir: Path) -> 
 def test_main_reads_custom_config_values(
     mirror_mock: "BandersnatchMirror", logging_mock: mock.MagicMock, customconfig: Path
 ) -> None:
-    setup()
     conffile = str(customconfig / "bandersnatch.conf")
     sys.argv = ["bandersnatch", "-c", conffile, "mirror"]
     main(asyncio.new_event_loop())
@@ -114,7 +118,6 @@ def test_main_reads_custom_config_values(
 def test_main_throws_exception_on_unsupported_digest_name(
     customconfig: Path,
 ) -> None:
-    setup()
     conffile = str(customconfig / "bandersnatch.conf")
     parser = configparser.ConfigParser()
     parser.read(conffile)

--- a/src/bandersnatch/tests/test_master.py
+++ b/src/bandersnatch/tests/test_master.py
@@ -1,4 +1,3 @@
-import asyncio
 import concurrent.futures
 from pathlib import Path
 from tempfile import gettempdir
@@ -74,7 +73,6 @@ async def test_master_doesnt_raise_if_serial_equal(master: Master) -> None:
 @pytest.mark.asyncio
 async def test_master_url_fetch(master: Master) -> None:
     fetch_path = Path(gettempdir()) / "unittest_url_fetch"
-    master.loop = asyncio.get_running_loop()
     with concurrent.futures.ThreadPoolExecutor(max_workers=1) as thread_pool:
         await master.url_fetch("https://unittest.org/asdf", fetch_path, thread_pool)
     assert master.session.get.called


### PR DESCRIPTION
## Dependency Upgrades

This performs the same version changes as #1656 and #1797 in a single merge request, since the associated issues and fixes appear to be related:

- `pytest` => 8.3.4
- `pytest-asyncio` => 0.24.0

This is a major version increment for pytest and a [0ver](https://0ver.org/) minor version increment for pytest-asyncio.

## Unit Test Changes

Locally, I used `pytest-randomly` to shuffle the test execution order. Varying the test order uncovered a number of places where shared state was causing order-dependent failures.

1. Tests that indirectly invoke a call to `get_running_loop`/`get_event_loop` require an event loop to be available even if the test itself and the code under test is not asynchronous. Depending on execution order an event loop was not always active when needed. I added `asyncio` marks to test modules wherever tests were failing because of this (or for 3.12, displaying a `DeprecationWarning` when there was no current event loop).

2. Storage plugin instances store the current event loop as an attribute, and we cache initialized plugins globally. This led to some situations where
    1. An event loop created for one test was accessed in another, and had been closed closed and replaced with a new event loop
    2. A storage plugin for a non-filesystem backend was re-used by a later test where the filesystem backend was expected.
  
   I created fixtures to clear cached storage plugins between test modules. Most problems seemed solved by clearing between modules and I made that an `autouse` fixture. For one function in `test_delete` the scope needed to be narrower and there's a comment inline explaining that case.
