### PR TITLE
Accommodations for running tests in containers that don't match the host OS

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -2,7 +2,11 @@
 log_cli_level = DEBUG
 log_level = DEBUG
 asyncio_mode=strict
+
+testpaths = src
+python_files = test.py test_*.py
 norecursedirs = src/bandersnatch_docker_compose
+pythonpath = .
 
 markers =
     s3: mark tests that require an S3/MinIO bucket

--- a/src/bandersnatch/tests/conftest.py
+++ b/src/bandersnatch/tests/conftest.py
@@ -196,13 +196,14 @@ def reset_configuration_cache() -> Iterator[None]:
 def s3_mock(reset_configuration_cache: None) -> S3Path:
     if os.environ.get("os") != "ubuntu-latest" and os.environ.get("CI"):
         pytest.skip("Skip s3 test on non-posix server in github action")
+    endpoint = os.environ.get("BANDERSNATCH_S3_ENDPOINT_URL", "http://localhost:9000")
     register_configuration_parameter(
         PureS3Path("/"),
         resource=boto3.resource(
             "s3",
             aws_access_key_id="minioadmin",
             aws_secret_access_key="minioadmin",
-            endpoint_url="http://localhost:9000",
+            endpoint_url=endpoint,
         ),
     )
     new_bucket = S3Path("/test-bucket")

--- a/src/bandersnatch/tests/plugins/test_storage_plugins.py
+++ b/src/bandersnatch/tests/plugins/test_storage_plugins.py
@@ -30,7 +30,7 @@ if sys.version_info < (3, 12):
 if TYPE_CHECKING:
     import swiftclient
 
-
+SAMPLE_FILE_CONTENT = "I am a sample!\n"
 BASE_SAMPLE_FILE = os.path.join(
     os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "sample"
 )
@@ -412,7 +412,9 @@ workers = 3
             target_sample_file = f"{self.container}/{target_sample_file}"
         assert self.tempdir
         self.sample_file = os.path.join(self.tempdir.name, target_sample_file)
-        shutil.copy(BASE_SAMPLE_FILE, self.sample_file)
+        with open(self.sample_file, mode="w") as sample_file:
+            sample_file.write(SAMPLE_FILE_CONTENT)
+
         if self.backend == "swift":
             self.mirror_path = Path(mirror_path)
         else:

--- a/tox.ini
+++ b/tox.ini
@@ -15,6 +15,7 @@ deps =
 passenv =
     os
     CI
+    BANDERSNATCH_*
 
 [testenv:doc_build]
 basepython=python3


### PR DESCRIPTION
I have been working on running the tests within a container to better match the CI environment and more easily test with multiple Python versions. I've kept my Docker/Docker Compose configuration in a sibling folder but needed to make a handful of changes to run the tests successfully.

1. The tests didn't have a way to configure the endpoint URL used for S3 plugin tests, so I added a check for an environment variable to allow overriding `localhost:9000` with something else.
2. There was a newline handling issue with a filesystem storage plugin test that only occurs when `sys.platform` doesn't match the platform the project source files were checked out of source control on. My host is Windows, so a sample file had `\r\n` endings, but when running the test in a Linux container the test expects `\n`.
3. I had problems getting pytest to discover test files, but adding some explicit file discovery settings fixed it.

Each of the above is in its own commit with some additional description in the commit log messages.

Since these changes only modify the development environment I'm not sure if they need a corresponding changelog entry.