### PR TITLE
Finish py3.13 support and move docker to 3.13

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.11", "3.12"]
+        python-version: ["3.11", "3.12", "3.13"]
         os: [macOS-latest, windows-latest]
 
     steps:

--- a/.github/workflows/ci_ubuntu.yml
+++ b/.github/workflows/ci_ubuntu.yml
@@ -18,7 +18,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.11", "3.12"]
+        python-version: ["3.11", "3.12", "3.13"]
         os: [ubuntu-latest]
 
     steps:

--- a/.github/workflows/docker_upload.yml
+++ b/.github/workflows/docker_upload.yml
@@ -35,13 +35,13 @@ jobs:
       - name: Build and push filesystem image
         uses: docker/build-push-action@v6
         env:
-          PY_VERSION: '3.12'
+          PY_VERSION: '3.13'
         with:
           build-args: PY_VERSION
           context: .
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: pypa/bandersnatch:latest,pypa/bandersnatch:${{ env.GIT_TAG }},pypa/bandersnatch:3,pypa/bandersnatch:3.12
+          tags: pypa/bandersnatch:latest,pypa/bandersnatch:${{ env.GIT_TAG }},pypa/bandersnatch:3,pypa/bandersnatch:3.13
 
       - name: Filesystem Image digest
         run: echo ${{ steps.docker_build.outputs.digest }}
@@ -49,7 +49,7 @@ jobs:
       - name: Build and push s3 image
         uses: docker/build-push-action@v6
         env:
-          PY_VERSION: '3.12'
+          PY_VERSION: '3.13'
           WITH_S3: yes
         with:
           build-args: |
@@ -58,7 +58,7 @@ jobs:
           context: .
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: pypa/bandersnatch:s3-latest,pypa/bandersnatch:s3-${{ env.GIT_TAG }},pypa/bandersnatch:s3-3,pypa/bandersnatch:s3-3.12
+          tags: pypa/bandersnatch:s3-latest,pypa/bandersnatch:s3-${{ env.GIT_TAG }},pypa/bandersnatch:s3-3,pypa/bandersnatch:s3-3.13
 
       - name: S3 Image digest
         run: echo ${{ steps.docker_build.outputs.digest }}

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+# 6.7.0 (Unreleased)
+
+## New Features
+
+- Declare support for python 3.13 `PR #1848`
+
 # 6.6.0
 
 ## New Features

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
-ARG PY_VERSION=3.12
+ARG PY_VERSION=3.13
 
-FROM python:${PY_VERSION} as base
+FROM python:${PY_VERSION} AS base
 
-FROM base as builder
+FROM base AS builder
 ARG PY_VERSION
 ARG WITH_S3
 
@@ -24,8 +24,8 @@ RUN if [ ! -z "$WITH_S3" ] \
 
 
 FROM python:${PY_VERSION}-slim
-ENV LANG C.UTF-8
-ENV LC_ALL C.UTF-8
+ENV LANG=C.UTF-8
+ENV LC_ALL=C.UTF-8
 
 ARG PY_VERSION
 ARG WITH_S3

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,9 +3,9 @@ author = Christian Theune
 author_email = ct@flyingcircus.io
 classifiers =
     Programming Language :: Python :: 3 :: Only
-    Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
     Programming Language :: Python :: 3.12
+    Programming Language :: Python :: 3.13
 description = Mirroring tool that implements the client (mirror) side of PEP 381
 long_description = file:README.md
 long_description_content_type = text/markdown
@@ -16,7 +16,7 @@ project_urls =
     Source Code = https://github.com/pypa/bandersnatch
     Change Log = https://github.com/pypa/bandersnatch/blob/master/CHANGES.md
 url = https://github.com/pypa/bandersnatch/
-version = 6.6.0
+version = 6.7.0.dev0
 
 [options]
 install_requires =

--- a/src/bandersnatch/__init__.py
+++ b/src/bandersnatch/__init__.py
@@ -20,9 +20,9 @@ class _VersionInfo(NamedTuple):
 
 __version_info__ = _VersionInfo(
     major=6,
-    minor=6,
+    minor=7,
     micro=0,
-    releaselevel="",
+    releaselevel="dev0",
     serial=0,  # Not currently in use with Bandersnatch versioning
 )
 __version__ = __version_info__.version_str

--- a/src/bandersnatch_filter_plugins/filename_name.py
+++ b/src/bandersnatch_filter_plugins/filename_name.py
@@ -36,6 +36,7 @@ class ExcludePlatformFilter(FilterReleaseFilePlugin):
         "py3.10",
         "py3.11",
         "py3.12",
+        "py3.13",
     ]
 
     _windowsPlatformTypes = [".win32", "-win32", "win_amd64", "win-amd64"]


### PR DESCRIPTION
- Update classifiers
- Add 3.13 to CI
- Move Dockerfile to use 3.13 by default
- Add py3.13 to filter plugin `filename_name.py`

Test:
- Build docker locally
```
cooper@cooper-fedora-MJ0J8MTZ:~/repos/bandersnatch$ docker build -t bandersnatch_test --network host .
[+] Building 1.0s (23/23) FINISHED                                                                       docker:default
 => [internal] load build definition from Dockerfile                                                               0.1s
 => => transferring dockerfile: 1.23kB                                                                             0.0s
 => [internal] load metadata for docker.io/library/python:3.13-slim                                                0.4s
 => [internal] load metadata for docker.io/library/python:3.13                                                     0.5s
 => [internal] load .dockerignore                                                                                  0.1s
 => => transferring context: 290B                                                                                  0.0s
 => [base 1/1] FROM docker.io/library/python:3.13@sha256:cea505b81701dd9e46b8dde96eaa8054c4bd2035dbb660edeb7af947  0.0s
 => [stage-2  1/10] FROM docker.io/library/python:3.13-slim@sha256:1127090f9fff0b8e7c3a1367855ef8a3299472d2c9ed12  0.0s
 => [internal] load build context                                                                                  0.1s
 => => transferring context: 36.67kB                                                                               0.0s
 => CACHED [builder 1/6] RUN mkdir /install                                                                        0.0s
 => CACHED [builder 2/6] WORKDIR /install                                                                          0.0s
 => CACHED [builder 3/6] RUN pip install --target="/install" --upgrade pip setuptools wheel                        0.0s
 => CACHED [builder 4/6] ADD requirements_s3.txt /install                                                          0.0s
 => CACHED [builder 5/6] ADD requirements.txt /install                                                             0.0s
 => CACHED [builder 6/6] RUN if [ ! -z "$WITH_S3" ]      ; then      pip install --target="/install"         -r r  0.0s
 => CACHED [stage-2  2/10] COPY --from=builder /install /usr/local/lib/python3.13/site-packages                    0.0s
 => CACHED [stage-2  3/10] RUN mkdir /bandersnatch && mkdir /conf && chmod 777 /conf                               0.0s
 => CACHED [stage-2  4/10] WORKDIR /bandersnatch                                                                   0.0s
 => CACHED [stage-2  5/10] COPY setup.cfg /bandersnatch                                                            0.0s
 => CACHED [stage-2  6/10] COPY setup.py /bandersnatch                                                             0.0s
 => CACHED [stage-2  7/10] COPY README.md /bandersnatch                                                            0.0s
 => CACHED [stage-2  8/10] COPY LICENSE /bandersnatch                                                              0.0s
 => CACHED [stage-2  9/10] COPY src /bandersnatch/src                                                              0.0s
 => CACHED [stage-2 10/10] RUN if [ ! -z "$WITH_S3" ]      ; then      pip --no-cache-dir install /bandersnatch/[  0.0s
 => exporting to image                                                                                             0.0s
 => => exporting layers                                                                                            0.0s
 => => writing image sha256:6e8a0c36d35f211ab9dea942fd3caaeac2d40285800a9c395335dc12c9657e9c                       0.0s
 => => naming to docker.io/library/bandersnatch_test
```
- Actions on PR