### PR TITLE
Pin python-docs-theme to fix docs build

### DIFF
--- a/.github/workflows/doc_build.yml
+++ b/.github/workflows/doc_build.yml
@@ -6,6 +6,9 @@ on:
       - main
   pull_request:
 
+env:
+  FORCE_COLOR: 1
+
 jobs:
   lint:
     name: html + linkcheck build

--- a/requirements_docs.txt
+++ b/requirements_docs.txt
@@ -9,7 +9,7 @@ xmlrpc2==0.3.1
 sphinx-argparse-cli==1.19.0
 
 git+https://github.com/pypa/pypa-docs-theme.git#egg=pypa-docs-theme
-git+https://github.com/python/python-docs-theme.git#egg=python-docs-theme
+python-docs-theme==2025.2
 
 # This is needed since autodoc imports all bandersnatch packages and modules
 # so imports must not fail or its containing module will NOT be documented.


### PR DESCRIPTION
The CI was installing Python Docs Theme from GitHub:

https://github.com/pypa/bandersnatch/blob/f3e7640eac69ad536ad08d3f9c061ebbe599e285/requirements_docs.txt#L12

And the theme recently dropped Python 3.10 and 3.11: <https://github.com/python/python-docs-theme/pull/234>

But the CI is using 3.11:
<https://github.com/pypa/bandersnatch/blob/f3e7640eac69ad536ad08d3f9c061ebbe599e285/.github/workflows/doc_build.yml#L19>

The quickest fix is to pin `python-docs-theme==2025.2`, which is the most recent release and still supports Python 3.11.

---

There's another error when using Python 3.13 on the CI:

<details>
<summary>Details</summary>


```
WARNING: autodoc: failed to import module 'swift' from module 'bandersnatch_storage_plugins'; the following exception was raised:
looking for now-outdated files... none found
['Traceback (most recent call last):\n', '  File "/home/runner/work/bandersnatch/bandersnatch/.tox/doc_build/lib/python3.13/site-packages/sphinx/ext/autodoc/importer.py", line 175, in import_module\n    module = importlib.import_module(modname)\n', '  File "/opt/hostedtoolcache/Python/3.13.3/x64/lib/python3.13/importlib/__init__.py", line 88, in import_module\n    return _bootstrap._gcd_import(name[level:], package, level)\n           ~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n', '  File "<frozen importlib._bootstrap>", line 1387, in _gcd_import\n', '  File "<frozen importlib._bootstrap>", line 1360, in _find_and_load\n', '  File "<frozen importlib._bootstrap>", line 1331, in _find_and_load_unlocked\n', '  File "<frozen importlib._bootstrap>", line 935, in _load_unlocked\n', '  File "<frozen importlib._bootstrap_external>", line 1026, in exec_module\n', '  File "<frozen importlib._bootstrap>", line 488, in _call_with_frames_removed\n', '  File "/home/runner/work/bandersnatch/bandersnatch/.tox/doc_build/lib/python3.13/site-packages/bandersnatch_storage_plugins/swift.py", line 229, in <module>\n    class SwiftPath(pathlib.Path):\n    ...<229 lines>...\n                    yield from path.iterdir(conn=conn, recurse=recurse)\n', '  File "/home/runner/work/bandersnatch/bandersnatch/.tox/doc_build/lib/python3.13/site-packages/bandersnatch_storage_plugins/swift.py", line 230, in SwiftPath\n    _flavour = getattr(pathlib, "_posix_flavour")  # noqa\n', "AttributeError: module 'pathlib' has no attribute '_posix_flavour'\n", '\nThe above exception was the direct cause of the following exception:\n\n', 'Traceback (most recent call last):\n', '  File "/home/runner/work/bandersnatch/bandersnatch/.tox/doc_build/lib/python3.13/site-packages/sphinx/ext/autodoc/importer.py", line 269, in import_object\n    module = import_module(modname, try_reload=True)\n', '  File "/home/runner/work/bandersnatch/bandersnatch/.tox/doc_build/lib/python3.13/site-packages/sphinx/ext/autodoc/importer.py", line 187, in import_module\n    raise ImportError(exc, traceback.format_exc()) from exc\n', 'ImportError: (AttributeError("module \'pathlib\' has no attribute \'_posix_flavour\'"), \'Traceback (most recent call last):\\n  File "/home/runner/work/bandersnatch/bandersnatch/.tox/doc_build/lib/python3.13/site-packages/sphinx/ext/autodoc/importer.py", line 175, in import_module\\n    module = importlib.import_module(modname)\\n  File "/opt/hostedtoolcache/Python/3.13.3/x64/lib/python3.13/importlib/__init__.py", line 88, in import_module\\n    return _bootstrap._gcd_import(name[level:], package, level)\\n           ~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\\n  File "<frozen importlib._bootstrap>", line 1387, in _gcd_import\\n  File "<frozen importlib._bootstrap>", line 1360, in _find_and_load\\n  File "<frozen importlib._bootstrap>", line 1331, in _find_and_load_unlocked\\n  File "<frozen importlib._bootstrap>", line 935, in _load_unlocked\\n  File "<frozen importlib._bootstrap_external>", line 1026, in exec_module\\n  File "<frozen importlib._bootstrap>", line 488, in _call_with_frames_removed\\n  File "/home/runner/work/bandersnatch/bandersnatch/.tox/doc_build/lib/python3.13/site-packages/bandersnatch_storage_plugins/swift.py", line 229, in <module>\\n    class SwiftPath(pathlib.Path):\\n    ...<229 lines>...\\n                    yield from path.iterdir(conn=conn, recurse=recurse)\\n  File "/home/runner/work/bandersnatch/bandersnatch/.tox/doc_build/lib/python3.13/site-packages/bandersnatch_storage_plugins/swift.py", line 230, in SwiftPath\\n    _flavour = getattr(pathlib, "_posix_flavour")  # noqa\\nAttributeError: module \\\'pathlib\\\' has no attribute \\\'_posix_flavour\\\'\\n\')\n'] [autodoc.import_object]
```

</details>

https://github.com/hugovk/bandersnatch/actions/runs/14668936590/job/41170649424#step:6:51

A longer term fix is to dig into that, but I think this PR is fine for now?