### PR TITLE
Update dependabot.yml to remove `reviewers` option

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,11 +8,9 @@ updates:
     schedule:
       interval: "weekly"
     labels: ["skip news"]
-    reviewers: ["cooperlees"]
 
   - package-ecosystem: "pip"
     directory: "/"
     schedule:
       interval: "weekly"
     labels: ["skip news"]
-    reviewers: ["cooperlees"]

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,7 +8,9 @@
 
 - Support reading HTTP proxy URLs from environment variables, and SOCKS proxy URLs from the 'mirror.proxy' config option `PR #1861`
 
-# 6.6.0
+## CI
+
+- Dependabot `reviewers` configuration option being replaced by code owners `PR #1943`
 
 ## New Features
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,8 @@
 
 - Dependabot `reviewers` configuration option being replaced by code owners `PR #1943`
 
+# 6.6.0
+
 ## New Features
 
 - Add arbitrary configuration option for S3 Storage Backend Boto3 calls `PR #1697`


### PR DESCRIPTION
Dependabot is now posting this comment as a warning:

> The reviewers field in the dependabot.yml file will be removed soon. Please use the code owners file to specify reviewers for Dependabot PRs. For more information, see this [blog post](https://github.blog/changelog/2025-04-29-dependabot-reviewers-configuration-option-being-replaced-by-code-owners/).