### PR TITLE
 add use-upstream-serial-on-mismatch to avoid sync hung (when  Expected PyPI serial mismatch)

### DIFF
--- a/src/bandersnatch/example.conf
+++ b/src/bandersnatch/example.conf
@@ -59,6 +59,13 @@ simple-format = ALL
 ; "false".
 stop-on-error = false
 
+; Allow upstream serial mismatch: when enabled, if the upstream PyPI serial
+; doesn't match the expected serial, use the upstream serial instead of
+; raising an error. This can help in cases where the local serial gets out
+; of sync with upstream. Value should be "true" or "false".
+; Recommended setting: false for strict consistency, true for resilience
+allow-upstream-serial-mismatch = false
+
 ; The storage backend that will be used to save data and metadata while
 ; mirroring packages. By default, use the filesystem backend. Other options
 ; currently include: 'swift'

--- a/src/bandersnatch/main.py
+++ b/src/bandersnatch/main.py
@@ -152,10 +152,12 @@ def _make_parser() -> argparse.ArgumentParser:
 
 async def async_main(args: argparse.Namespace, config: ConfigParser) -> int:
     if args.op.lower() == "delete":
+        allow_upstream_serial_mismatch = config.getboolean("mirror", "allow-upstream-serial-mismatch", fallback=False)
         async with bandersnatch.master.Master(
             config.get("mirror", "master"),
             config.getfloat("mirror", "timeout"),
             config.getfloat("mirror", "global-timeout", fallback=None),
+            allow_upstream_serial_mismatch=allow_upstream_serial_mismatch,
         ) as master:
             return await bandersnatch.delete.delete_packages(config, args, master)
     elif args.op.lower() == "verify":

--- a/src/bandersnatch/master.py
+++ b/src/bandersnatch/master.py
@@ -40,10 +40,12 @@ class Master:
         global_timeout: float | None = FIVE_HOURS_FLOAT,
         proxy: str | None = None,
         allow_non_https: bool = False,
+        allow_upstream_serial_mismatch: bool = False,
     ) -> None:
         self.url = url
         self.timeout = timeout
         self.global_timeout = global_timeout or FIVE_HOURS_FLOAT
+        self.allow_upstream_serial_mismatch = allow_upstream_serial_mismatch
 
         proxy_url = proxy if proxy else proxy_address_from_env()
         self.proxy_kwargs = get_aiohttp_proxy_kwargs(proxy_url) if proxy_url else {}

--- a/src/bandersnatch/mirror.py
+++ b/src/bandersnatch/mirror.py
@@ -971,6 +971,7 @@ async def mirror(
 
     mirror_url = config.get("mirror", "master")
     allow_non_https = config.getboolean("mirror", "allow-non-https")
+    allow_upstream_serial_mismatch = config.getboolean("mirror", "allow-upstream-serial-mismatch", fallback=False)
     timeout = config.getfloat("mirror", "timeout")
     global_timeout = config.getfloat("mirror", "global-timeout", fallback=None)
     proxy = config.get("mirror", "proxy", fallback=None)
@@ -980,7 +981,7 @@ async def mirror(
     # Always reference those classes here with the fully qualified name to
     # allow them being patched by mock libraries!
     async with Master(
-        mirror_url, timeout, global_timeout, proxy, allow_non_https
+        mirror_url, timeout, global_timeout, proxy, allow_non_https, allow_upstream_serial_mismatch
     ) as master:
         mirror = BandersnatchMirror(
             homedir,


### PR DESCRIPTION
## Description
This PR addresses the recurring issue described in #1633 where sync tasks get stuck due to serial ID mismatches. 

The key change is the introduction of a new configuration option `allow-upstream-serial-mismatch`. When enabled, this option forces the use of the upstream's serial ID during synchronization when a mismatch is detected, preventing the sync process from getting stuck.

## Changes Made
- Added `allow-upstream-serial-mismatch` configuration option (default: False)
- Modified serial ID handling logic to check this configuration when mismatches occur
- Updated relevant synchronization logic to use upstream serial when the option is enabled
- Added validation for the new configuration option

## Motivation and Context
Serial ID mismatches between local and upstream PyPI can cause the sync process to hang indefinitely, as the system struggles to resolve the discrepancy. This change provides an escape hatch for such scenarios, allowing administrators to force synchronization using the upstream's serial ID when needed.

## Testing
- Added unit tests for the new configuration option
- Tested scenarios with both matching and mismatched serial IDs
- Verified that enabling the option allows sync to proceed through previously stuck states
