### PR TITLE
Add a GitHub Action for using simple metadata

### DIFF
--- a/.github/workflows/ci_simple_metadata.yml
+++ b/.github/workflows/ci_simple_metadata.yml
@@ -1,0 +1,46 @@
+name: bandersnatch_ci_simple
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: bandersnatch simple metadata CI python ${{ matrix.python-version }} on ${{matrix.os}}
+
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      matrix:
+        python-version: ["3.13"]
+        os: [ubuntu-latest]
+
+    steps:
+    - uses: actions/checkout@v5
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v6
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Install latest pip, setuptools + tox
+      run: |
+        python -m pip install --upgrade pip setuptools tox
+
+    - name: Install base bandersnatch requirements
+      run: |
+        python -m pip install -r requirements.txt
+
+    - name: Run Integration Test
+      env:
+       TOXENV: INTEGRATION
+       METADATA: simple
+      run: |
+        python -m pip install .
+        python test_runner.py

--- a/src/bandersnatch/tests/ci_simple.conf
+++ b/src/bandersnatch/tests/ci_simple.conf
@@ -1,0 +1,30 @@
+; Config for the Travis CI Integration Test that hits PyPI
+
+[mirror]
+directory = /tmp/pypi
+json = true
+cleanup = true
+master = https://pypi.org
+timeout = 60
+global-timeout = 18000
+workers = 3
+hash-index = true
+stop-on-error = true
+storage-backend = filesystem
+verifiers = 3
+keep_index_versions = 2
+compare-method = hash
+api-method = simple
+
+[plugins]
+enabled =
+    allowlist_project
+    allowlist_release
+
+[allowlist]
+packages =
+    ACMPlus
+    black>=24.1.0
+    pyaib
+
+; vim: set ft=cfg:


### PR DESCRIPTION
- Add github action that uses the PEP691 Simple Metadata to calculate which packages to sync
- Just to ensure it works ...
- It's not default yet
  - We can remove all this once it becomes the default