### PR TITLE
Use Furo theme for docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -110,7 +110,7 @@ myst_heading_anchors = 3
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
-html_theme = "default"
+html_theme = "furo"
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the
@@ -189,16 +189,6 @@ html_short_title = "Bandersnatch documentation"
 
 # Output file base name for HTML help builder.
 htmlhelp_basename = doc_module.__name__
-html_theme = "default"
-
-# Determine available themes and settings
-try:
-    import pypa_theme  # noqa: F401
-
-    html_theme = "pypa_theme"
-except ImportError:
-    print("WARNING: 'pypa_theme' isn't available, falling back to 'default' HTML theme")
-    html_theme = "default"
 
 # -- Options for LaTeX output ---------------------------------------------
 

--- a/requirements_docs.txt
+++ b/requirements_docs.txt
@@ -1,4 +1,5 @@
 docutils==0.21.2
+furo==2025.9.25
 pyparsing==3.2.5
 python-dateutil==2.9.0.post0
 packaging==25.0
@@ -7,8 +8,5 @@ sphinx==8.2.3
 MyST-Parser==4.0.1
 xmlrpc2==0.3.1
 sphinx-argparse-cli==1.20.1
-
-git+https://github.com/pypa/pypa-docs-theme.git#egg=pypa-docs-theme
-python-docs-theme==2025.10
 
 # Note: Optional storage backends are documented without importing their deps.


### PR DESCRIPTION
Fixes https://github.com/pypa/bandersnatch/issues/2090.

I think the problem is with the PyPA Sphinx Theme theme, and the repo https://github.com/pypa/pypa-docs-theme was archived last year.

Instead, we could use something a bit more modern and, more to the point, maintained such as Furo: https://github.com/pradyunsg/furo