### PR TITLE
Add musllinux platform tag to list of excludable Linux platforms

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+# Unreleased
+
+## New Features
+
+- Add musllinux platform tag to list of excludable Linux platforms `PR #2109`
+
 # 7.0.0
 
 ## New Features / big changes

--- a/src/bandersnatch_filter_plugins/filename_name.py
+++ b/src/bandersnatch_filter_plugins/filename_name.py
@@ -57,6 +57,7 @@ class ExcludePlatformFilter(FilterReleaseFilePlugin):
         "manylinux2014_ppc64",  # PEP 599
         "manylinux2014_ppc64le",  # PEP 599
         "manylinux2014_s390x",  # PEP 599
+        "musllinux",  # PEP 656
     ]
 
     def initialize_plugin(self) -> None:


### PR DESCRIPTION
PEP 656 introduced a new platform tag series _musllinux_ for binary Python package distributions for a Python installation that depends on musl on a Linux distribution. 

https://peps.python.org/pep-0656/

Environments strictly using the glibc library should be able to exclude these binaries from their PyPI mirroring client to limit bloating.