### PR TITLE
ci: add Python 3.15 to CI matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.12", "3.13", "3.14"]
+        python-version: ["3.12", "3.13", "3.14", "3.15"]
         os: [macOS-latest, windows-latest]
 
     steps:
@@ -33,6 +33,7 @@ jobs:
       uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
+        allow-prereleases: true
 
     - name: Install latest pip, setuptools + tox
       run: |

--- a/.github/workflows/ci_ubuntu.yml
+++ b/.github/workflows/ci_ubuntu.yml
@@ -21,7 +21,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.12", "3.13", "3.14"]
+        python-version: ["3.12", "3.13", "3.14", "3.15"]
         os: [ubuntu-latest]
 
     steps:
@@ -33,6 +33,7 @@ jobs:
       uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
+        allow-prereleases: true
 
     - name: Install latest pip, setuptools + tox
       run: |

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,7 @@
 
 ## CI / test
 
+- Add Python 3.15 to CI matrix and supported versions `PR #2239`
 - Declare workflow-level `permissions: contents: read` on the 8 remaining workflows (CVE-2025-30066 hardening) `PR #2241`
 - Skip base class tests in test runs `PR #2263`
 - Transitioned from unittest.TestCase to pytest fixtures (`PR #2265`, `PR #2273`, `PR #2274`)
@@ -17,6 +18,7 @@
 
 - Docs: add troubleshooting for Simple API JSON mirroring `PR #2145`
 - Docs: list all supported python versions for `exclude_platform` in filtering configuration `PR #2232`
+- Docs: document running the full test suite against a specific Python version via Docker
 
 ## Bug Fixes
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -92,6 +92,29 @@ S3 unit tests use [moto](https://github.com/getmoto/moto) for an in-memory AWS m
 services or Docker containers required. The `moto[s3]` package is included in `requirements_test.txt`
 and tests will run automatically as part of the standard test suite on all platforms.
 
+### Running the Full Test Suite Against a Specific Python via Docker
+
+If you don't have a given Python version installed locally (e.g. a pre-release
+like 3.15), you can run the whole test suite inside an official `python:<ver>`
+Docker image. The S3 tests use moto's in-memory mock (see above), so no minio
+sidecar or extra network setup is required:
+
+```bash
+docker run --rm \
+  -v "$PWD":/app -w /app \
+  python:3.15-rc bash -c '
+    pip install --upgrade pip setuptools tox &&
+    pip install -r requirements.txt -r requirements_test.txt -r requirements_s3.txt &&
+    pip install -e . &&
+    TOXENV=py3 python test_runner.py
+  '
+```
+
+Swap `python:3.15-rc` for any tag on
+[Docker Hub `python`](https://hub.docker.com/_/python) (e.g. `python:3.14`,
+`python:3.13`). Use `TOXENV=INTEGRATION` instead of `TOXENV=py3` to run the
+integration test.
+
 ## Creating a Pull Request
 
 ### Changelog entry

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,14 +1,10 @@
 aiohttp==3.14.0
 aiohttp-socks==0.11.0
-async-timeout==5.0.1
 attrs==26.1.0
-chardet==7.4.3
 filelock==3.29.0
 humanfriendly==10.0
 idna==3.15
-lxml==6.1.1
 multidict==6.7.1
 packaging==26.2
-pyparsing==3.3.2
 setuptools==82.0.1
 yarl==1.23.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,6 +6,7 @@ classifiers =
     Programming Language :: Python :: 3.12
     Programming Language :: Python :: 3.13
     Programming Language :: Python :: 3.14
+    Programming Language :: Python :: 3.15
 description = Mirroring tool that implements the client (mirror) side of PEP 381
 long_description = file:README.md
 long_description_content_type = text/markdown


### PR DESCRIPTION
## Summary
- Add `3.15` to the `python-version` matrix in `ci.yml` and `ci_ubuntu.yml`, with `allow-prereleases: true` so `setup-python` picks up the current alpha/beta (3.15 final is expected ~Oct 2026).
- Add the 3.15 trove classifier in `setup.cfg`.
- Drop now-unused pins from `requirements.txt` (`lxml`, `async-timeout`, `chardet`, `pyparsing`). `lxml` was a relic of the removed XML-RPC client and had no wheel for 3.15, breaking the build; the others are no longer in the dependency closure under `python_requires>=3.12`.
- Document a Docker-based workflow in `docs/CONTRIBUTING.md` for running the full test suite against any Python version using the official `python:<ver>` image.

## Test plan
S3 unit tests now use moto's in-memory mock (merged via #2272), so the minio/Docker sidecar that earlier revisions of this PR relied on is no longer required.

- [ ] Unit tests (`TOXENV=py3`) green on the CI matrix — S3 tests run against moto in-memory, no sidecar
- [ ] Integration test (`TOXENV=INTEGRATION`) green on the CI matrix
- [ ] CI matrix is green for `3.12`, `3.13`, `3.14`, `3.15` across `ubuntu-latest`, `macOS-latest`, `windows-latest`

To reproduce against a specific Python version locally (also in `docs/CONTRIBUTING.md`):

```bash
docker run --rm \
  -v "$PWD":/app -w /app python:3.15-rc bash -c '
    pip install --upgrade pip setuptools tox &&
    pip install -r requirements.txt -r requirements_test.txt -r requirements_s3.txt &&
    pip install -e . &&
    TOXENV=py3 python test_runner.py &&
    TOXENV=INTEGRATION python test_runner.py
  '
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
