### PR TITLE
docs(config): note master can be another bandersnatch mirror (#2098)

### DIFF
--- a/src/bandersnatch/example.conf
+++ b/src/bandersnatch/example.conf
@@ -12,7 +12,11 @@ release-files = true
 ; Cleanup legacy non PEP 503 normalized named simple directories
 cleanup = false
 
-; The PyPI server which will be mirrored.
+; The PyPI server which will be mirrored. As of bandersnatch 7.0 the
+; upstream must speak the PEP 691 JSON Simple API; this can be pypi.org,
+; the test PyPI, or another bandersnatch mirror. See
+; docs/mirror_from_mirror_simple_api.rst for the full procedure when
+; chaining mirrors.
 ; master = https://test.pypi.org
 ; scheme for PyPI server MUST be https
 master = https://pypi.org


### PR DESCRIPTION
## Summary

Extends the comment above `master =` in `src/bandersnatch/example.conf` so an operator reading only the example config knows the upstream can be another bandersnatch mirror, not just `pypi.org`.

## Why this matters

In #2098, the reporter set up a mirror-of-mirror chain and wasn't sure whether `master =` could point at another bandersnatch instance. The dedicated docs page (`docs/mirror_from_mirror_simple_api.rst`, added by #2145) covers the full procedure. But `example.conf:15-18` is the file most operators read first when stamping out a new mirror, and the existing comment only mentions `pypi.org` and the test instance:

```
; The PyPI server which will be mirrored.
; master = https://test.pypi.org
; scheme for PyPI server MUST be https
master = https://pypi.org
```

Maintainer @cooperlees called this out explicitly in the 2025-12-22 comment on the issue:

> "We probably want to update the description in example config of master:
> https://github.com/pypa/bandersnatch/blob/main/src/bandersnatch/example.conf"

## Changes

Extends the comment block (`src/bandersnatch/example.conf:15`) to:

- Note that as of 7.0 the upstream must speak the PEP 691 JSON Simple API.
- Spell out the three valid upstream kinds: pypi.org, test PyPI, or another bandersnatch mirror.
- Point to `docs/mirror_from_mirror_simple_api.rst` for the chained-mirror procedure.

The actual `master = https://pypi.org` value is unchanged.

## Testing

Comment-only change. No CI exercise needed beyond the standard build.

Fixes #2098
