### PR TITLE
ci: declare workflow-level contents: read on the 8 remaining workflows

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     types: [opened, synchronize, labeled, unlabeled, reopened]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Changelog Entry Check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: bandersnatch CI python ${{ matrix.python-version }} on ${{matrix.os}}

--- a/.github/workflows/ci_ubuntu.yml
+++ b/.github/workflows/ci_ubuntu.yml
@@ -10,6 +10,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: bandersnatch CI python ${{ matrix.python-version }} on ${{matrix.os}}

--- a/.github/workflows/ci_xmlrpc_metadata.yml
+++ b/.github/workflows/ci_xmlrpc_metadata.yml
@@ -10,6 +10,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: bandersnatch xmlrpc metadata CI python ${{ matrix.python-version }} on ${{matrix.os}}

--- a/.github/workflows/doc_build.yml
+++ b/.github/workflows/doc_build.yml
@@ -9,6 +9,9 @@ on:
 env:
   FORCE_COLOR: 1
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     name: html + linkcheck build

--- a/.github/workflows/docker_upload.yml
+++ b/.github/workflows/docker_upload.yml
@@ -7,6 +7,9 @@ on:
   release:
     types: created
 
+permissions:
+  contents: read
+
 jobs:
   docker:
     runs-on: ubuntu-latest

--- a/.github/workflows/pypi_upload.yml
+++ b/.github/workflows/pypi_upload.yml
@@ -4,6 +4,9 @@ on:
   release:
     types: created
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: bandersnatch PyPI Upload

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -9,6 +9,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: bandersnatch Security Audit

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Unreleased
 
+## CI
+
+- Declare workflow-level `permissions: contents: read` on the 8 remaining workflows (CVE-2025-30066 hardening) `PR #2241`
+
 ## Documentation
 
 - Docs: add troubleshooting for Simple API JSON mirroring `PR #2145`


### PR DESCRIPTION
Adds explicit `permissions: contents: read` at workflow scope to each of the 8 workflows in `.github/workflows/` that was still relying on the repo default. None of these workflows call a GitHub API beyond the initial checkout, so `contents: read` is sufficient for each.

| Workflow | What it does |
|---|---|
| `changelog.yml` | greps `CHANGES.md` for the PR number |
| `ci.yml`, `ci_ubuntu.yml`, `ci_xmlrpc_metadata.yml` | tox + integration tests |
| `doc_build.yml` | sphinx html + linkcheck |
| `docker_upload.yml` | docker buildx push to Docker Hub via secrets |
| `pypi_upload.yml` | `twine upload` to PyPI via `PYPI_TOKEN` secret (not OIDC) |
| `security.yml` | scheduled pip-audit / safety scan |

`pypi_upload.yml` uses a `PYPI_TOKEN` secret for upload, not OIDC trusted publishing, so `id-token: write` is not required. If you ever switch to trusted publishing the scope should be added at that point.

## Why

Standard supply-chain hygiene grounded in CVE-2025-30066 (the March 2025 `tj-actions/changed-files` compromise): a tampered third-party action exfiltrated `GITHUB_TOKEN` from workflow logs and the leaked token retained whatever scope was issued at the workflow level. Pinning per workflow bounds runtime authority irrespective of repo or org default, gives drift protection if that default ever widens, and is what the OpenSSF Scorecard `Token-Permissions` check credits per file.

YAML validated locally with `yaml.safe_load` on each touched file.

(CHANGES.md entry added in the next commit so the PR number is known.)