### PR TITLE
Remove hardcoded SimpleDigest enum and validate digest against hashlib (issue #1451)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,6 +19,7 @@
 ## New Features
 
 - Make filesystem permissions management configurable `PR #2137`
+- Allow configuring any PEP691 compliant digest that the index offers `PR #2262`
 
 # 7.0.1
 

--- a/src/bandersnatch/configuration.py
+++ b/src/bandersnatch/configuration.py
@@ -13,7 +13,7 @@ from typing import Any, NamedTuple
 
 from .config.diff_file_reference import eval_config_reference, has_config_reference
 from .config.exceptions import ConfigError, ConfigFileNotFound
-from .simple import SimpleDigest, SimpleFormat, get_digest_value, get_format_value
+from .simple import InvalidDigestFormat, SimpleFormat, get_digest_value, get_format_value
 
 logger = logging.getLogger("bandersnatch")
 
@@ -29,7 +29,7 @@ class SetConfigValues(NamedTuple):
     root_uri: str
     diff_file_path: str
     diff_append_epoch: bool
-    digest_name: SimpleDigest
+    digest_name: str
     storage_backend_name: str
     cleanup: bool
     release_files_save: bool
@@ -169,7 +169,7 @@ def validate_config_values(  # noqa: C901
 
     try:
         digest_name = get_digest_value(config.get("mirror", "digest_name"))
-    except ValueError as e:
+    except InvalidDigestFormat as e:
         logger.error(
             f"Supplied digest_name {config.get('mirror', 'digest_name')} is "
             + "not supported! Please update the digest_name in the [mirror] "

--- a/src/bandersnatch/configuration.py
+++ b/src/bandersnatch/configuration.py
@@ -13,7 +13,12 @@ from typing import Any, NamedTuple
 
 from .config.diff_file_reference import eval_config_reference, has_config_reference
 from .config.exceptions import ConfigError, ConfigFileNotFound
-from .simple import InvalidDigestFormat, SimpleFormat, get_digest_value, get_format_value
+from .simple import (
+    InvalidDigestFormat,
+    SimpleFormat,
+    get_digest_value,
+    get_format_value,
+)
 
 logger = logging.getLogger("bandersnatch")
 

--- a/src/bandersnatch/mirror.py
+++ b/src/bandersnatch/mirror.py
@@ -331,6 +331,9 @@ class BandersnatchMirror(Mirror):
         package.filter_all_releases_files(self.filters.filter_release_file_plugins())
         package.filter_all_releases(self.filters.filter_release_plugins())
 
+        # digests are validated at runtime based on the index metadata
+        self.simple_api.validate_digest_availability(package)
+
         if self.release_files_save:
             await self.sync_release_files(package)
 

--- a/src/bandersnatch/simple.py
+++ b/src/bandersnatch/simple.py
@@ -1,7 +1,8 @@
+import hashlib
 import html
 import json
 import logging
-from enum import Enum, StrEnum, auto
+from enum import Enum, auto
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, NamedTuple
 from urllib.parse import urlparse
@@ -23,16 +24,6 @@ class SimpleFormat(Enum):
     JSON = auto()
 
 
-class SimpleDigests(NamedTuple):
-    sha256: str
-    md5: str
-
-
-class SimpleDigest(StrEnum):
-    SHA256 = "sha256"
-    MD5 = "md5"
-
-
 logger = logging.getLogger(__name__)
 
 
@@ -42,7 +33,7 @@ class InvalidSimpleFormat(KeyError):
     pass
 
 
-class InvalidDigestFormat(ValueError):
+class InvalidDigestFormat(Exception):
     """We don't have a valid digest choice from configuration"""
 
     pass
@@ -59,15 +50,13 @@ def get_format_value(format: str) -> SimpleFormat:
         )
 
 
-def get_digest_value(digest: str) -> SimpleDigest:
-    try:
-        return SimpleDigest[digest.upper()]
-    except KeyError:
-        valid_digests = sorted([v.name for v in SimpleDigest])
-        raise InvalidDigestFormat(
-            f"{digest} is not a valid Simple API file hash digest. "
-            + f"Valid Options: {valid_digests}"
-        )
+def get_digest_value(digest: str) -> str:
+    if digest in hashlib.algorithms_available:
+        return digest
+    raise InvalidDigestFormat(
+        f"{digest} is not a valid Simple API file hash digest. "
+        + f"Valid Options: {sorted(hashlib.algorithms_available)}"
+    )
 
 
 class SimpleAPI:
@@ -84,16 +73,12 @@ class SimpleAPI:
         storage_backend: "Storage",
         format: SimpleFormat | str,
         diff_file_list: list[Path],
-        digest_name: SimpleDigest | str,
+        digest_name: str,
         hash_index: bool,
         root_uri: str | None,
     ) -> None:
         self.diff_file_list = diff_file_list
-        self.digest_name = (
-            get_digest_value(digest_name)
-            if isinstance(digest_name, str)
-            else digest_name
-        )
+        self.digest_name = get_digest_value(digest_name)
         self.format = get_format_value(format) if isinstance(format, str) else format
         self.hash_index = hash_index
         self.root_uri = root_uri
@@ -160,6 +145,20 @@ class SimpleAPI:
             raise RuntimeError(f"Got invalid download URL: {url}")
         prefix = self.root_uri if self.root_uri else "../.."
         return prefix + parsed.path
+
+    def validate_digest_availability(self, package: Package) -> None:
+        for f in package.release_files:
+            if self.digest_name not in f["digests"]:
+                configurable = sorted(
+                    k
+                    for k in f["digests"].keys()
+                    if k in hashlib.algorithms_available
+                )
+                raise InvalidDigestFormat(
+                    f"Configured digest {self.digest_name!r} is not provided for "
+                    f"{f['filename']} in {package.name}. "
+                    f"Valid configurable digests for this source: {configurable}. "
+                )
 
     def generate_html_simple_page(self, package: Package) -> str:
         # Generate the header of our simple page.

--- a/src/bandersnatch/simple.py
+++ b/src/bandersnatch/simple.py
@@ -51,7 +51,9 @@ def get_format_value(format: str) -> SimpleFormat:
 
 
 def get_digest_value(digest: str) -> str:
-    normalized = digest.strip().lower() # pep452 guarantees all hashlib digest keys will be lowercase
+    normalized = (
+        digest.strip().lower()
+    )  # pep452 guarantees all hashlib digest keys will be lowercase
     if normalized in hashlib.algorithms_available:
         return normalized
     raise InvalidDigestFormat(

--- a/src/bandersnatch/simple.py
+++ b/src/bandersnatch/simple.py
@@ -51,8 +51,9 @@ def get_format_value(format: str) -> SimpleFormat:
 
 
 def get_digest_value(digest: str) -> str:
-    if digest in hashlib.algorithms_available:
-        return digest
+    normalized = digest.strip().lower() # pep452 guarantees all hashlib digest keys will be lowercase
+    if normalized in hashlib.algorithms_available:
+        return normalized
     raise InvalidDigestFormat(
         f"{digest} is not a valid Simple API file hash digest. "
         + f"Valid Options: {sorted(hashlib.algorithms_available)}"
@@ -150,9 +151,7 @@ class SimpleAPI:
         for f in package.release_files:
             if self.digest_name not in f["digests"]:
                 configurable = sorted(
-                    k
-                    for k in f["digests"].keys()
-                    if k in hashlib.algorithms_available
+                    k for k in f["digests"].keys() if k in hashlib.algorithms_available
                 )
                 raise InvalidDigestFormat(
                     f"Configured digest {self.digest_name!r} is not provided for "

--- a/src/bandersnatch/tests/test_configuration.py
+++ b/src/bandersnatch/tests/test_configuration.py
@@ -13,7 +13,7 @@ from bandersnatch.configuration import (
     Singleton,
     validate_config_values,
 )
-from bandersnatch.simple import SimpleDigest, SimpleFormat
+from bandersnatch.simple import SimpleFormat
 
 
 class TestBandersnatchConf(TestCase):
@@ -141,7 +141,7 @@ class TestBandersnatchConf(TestCase):
             "",
             "",
             False,
-            SimpleDigest.SHA256,
+            "sha256",
             "filesystem",
             False,
             True,
@@ -162,7 +162,7 @@ class TestBandersnatchConf(TestCase):
             "https://files.pythonhosted.org",
             "",
             False,
-            SimpleDigest.SHA256,
+            "sha256",
             "filesystem",
             False,
             False,
@@ -186,7 +186,7 @@ class TestBandersnatchConf(TestCase):
             "",
             "",
             False,
-            SimpleDigest.SHA256,
+            "sha256",
             "filesystem",
             False,
             True,
@@ -213,7 +213,7 @@ class TestBandersnatchConf(TestCase):
             "",
             "",
             False,
-            SimpleDigest.SHA256,
+            "sha256",
             "filesystem",
             False,
             True,
@@ -234,7 +234,7 @@ class TestBandersnatchConf(TestCase):
             "",
             "",
             False,
-            SimpleDigest.SHA256,
+            "sha256",
             "filesystem",
             False,
             True,

--- a/src/bandersnatch/tests/test_main.py
+++ b/src/bandersnatch/tests/test_main.py
@@ -14,7 +14,7 @@ import bandersnatch.mirror
 import bandersnatch.storage
 from bandersnatch.configuration import Singleton
 from bandersnatch.main import main
-from bandersnatch.simple import SimpleFormat
+from bandersnatch.simple import InvalidDigestFormat, SimpleFormat
 
 if TYPE_CHECKING:
     from bandersnatch.mirror import BandersnatchMirror
@@ -127,7 +127,7 @@ def test_main_throws_exception_on_unsupported_digest_name(
         parser.write(fp)
     sys.argv = ["bandersnatch", "-c", conffile, "mirror"]
 
-    with pytest.raises(ValueError) as e:
+    with pytest.raises(InvalidDigestFormat) as e:
         main(asyncio.new_event_loop())
 
     assert "foobar is not a valid" in str(e.value)

--- a/src/bandersnatch/tests/test_simple.py
+++ b/src/bandersnatch/tests/test_simple.py
@@ -1,3 +1,4 @@
+import hashlib
 from configparser import ConfigParser
 from os import sep
 from pathlib import Path
@@ -12,7 +13,6 @@ from bandersnatch.simple import (
     InvalidDigestFormat,
     InvalidSimpleFormat,
     SimpleAPI,
-    SimpleDigest,
     SimpleFormat,
 )
 from bandersnatch.storage import Storage
@@ -42,19 +42,27 @@ def test_digest_invalid() -> None:
 
 def test_digest_valid() -> None:
     s = SimpleAPI(Storage(), "ALL", [], "md5", False, None)
-    assert s.digest_name == SimpleDigest.MD5
+    assert s.digest_name == "md5"
+
+
+def test_digest_not_provided_by_source() -> None:
+    s = SimpleAPI(Storage(), SimpleFormat.JSON, [], "sha512", False, None)
+    p = Package("69")
+    p._metadata = SIXTYNINE_METADATA  # only has md5 and sha256
+    with pytest.raises(InvalidDigestFormat, match="sha512.*not provided"):
+        s.validate_digest_availability(p)
 
 
 def test_digest_config_default() -> None:
     c = BandersnatchConfig(load_defaults=True)
     config = validate_config_values(c)
     s = SimpleAPI(Storage(), "ALL", [], config.digest_name, False, None)
-    assert config.digest_name.upper() in [v.name for v in SimpleDigest]
-    assert s.digest_name == SimpleDigest.SHA256
+    assert config.digest_name in hashlib.algorithms_available
+    assert s.digest_name == "sha256"
 
 
 def test_json_package_page() -> None:
-    s = SimpleAPI(Storage(), SimpleFormat.JSON, [], SimpleDigest.SHA256, False, None)
+    s = SimpleAPI(Storage(), SimpleFormat.JSON, [], "sha256", False, None)
     p = Package("69")
     p._metadata = SIXTYNINE_METADATA
     assert EXPECTED_SIMPLE_SIXTYNINE_JSON_1_1 == s.generate_json_simple_page(p)


### PR DESCRIPTION
The `SimpleDigest` StrEnum hardcoded sha256 and md5 as the only valid
digest names. This replaces it with a check against `hashlib.algorithms_available`,
so any algorithm PyPI starts offering that hashlib supports will work without
a code change.

One non-obvious decision: `InvalidDigestFormat` now inherits `Exception` instead
of `ValueError`. The reason is that removing the enum means an invalid-but-hashlib-
valid digest (e.g. sha512) passes startup validation but fails at runtime when
the source index doesn't provide it. `BandersnatchMirror.on_error` has a pre-
existing `isinstance(exception, ValueError): pass` that would silently swallow this. `configuration.py`'s startup catch is updated to `except InvalidDigestFormat` accordingly.

`SimpleAPI.validate_digest_availability()` is called in `process_package` before
downloading files so a misconfigured digest fails immediately rather than after
pulling everything down.

Because we removed the hardcoded digests, validation will happen at process_package instead of initialization thus burning through some bandwidth if the digest is incorrectly configured