### PR TITLE
Skip baseclass tests (Issue #2088)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -25,7 +25,6 @@
 
 - Make filesystem permissions management configurable `PR #2137`
 
-
 # 7.0.1
 
 ## New Features

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -21,6 +21,10 @@
 - Make filesystem permissions management configurable `PR #2137`
 - Allow configuring any PEP691 compliant digest that the index offers `PR #2262`
 
+## CI / test
+
+- Skip base class tests in test runs `PR #2263`
+
 # 7.0.1
 
 ## New Features

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,8 +1,13 @@
 # Unreleased
 
-## CI
+## New Features
+
+- Allow configuring any PEP691 compliant digest that the index offers `PR #2262`
+
+## CI / test
 
 - Declare workflow-level `permissions: contents: read` on the 8 remaining workflows (CVE-2025-30066 hardening) `PR #2241`
+- Skip base class tests in test runs `PR #2263`
 
 ## Documentation
 
@@ -19,11 +24,7 @@
 ## New Features
 
 - Make filesystem permissions management configurable `PR #2137`
-- Allow configuring any PEP691 compliant digest that the index offers `PR #2262`
 
-## CI / test
-
-- Skip base class tests in test runs `PR #2263`
 
 # 7.0.1
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -56,13 +56,13 @@ Successfully installed pip-10.0.1
 - Then install the dependencies to the venv:
 
 ```console
-/path/to/venv/bin/pip install -r requirements.txt -r test-requirements.txt
+/path/to/venv/bin/pip install -r requirements.txt -r requirements_test.txt
 ```
 
 For example:
 
 ```console
-$ bandersnatchvenv/bin/pip install -r requirements.txt -r test-requirements.txt
+$ bandersnatchvenv/bin/pip install -r requirements.txt -r requirements_test.txt
 ...
 Collecting pyparsing==2.1.10 (from -r requirements.txt (line 3))
   Downloading https://files.pythonhosted.org/packages/2b/f7/e5a178fc3ea4118a0edce2a8d51fc14e680c745cf4162e4285b437c43c94/pyparsing-2.1.10-py2.py3-none-any.whl (56kB)
@@ -191,7 +191,7 @@ Example output:
 $ tox
 GLOB sdist-make: /Users/dhubbard/PycharmProjects/bandersnatch/setup.py
 py36 create: /Users/dhubbard/PycharmProjects/bandersnatch/.tox/py36
-py36 installdeps: -rtest-requirements.txt
+py36 installdeps: -rrequirements_test.txt
 py36 inst: /Users/dhubbard/PycharmProjects/bandersnatch/.tox/dist/bandersnatch-2.2.1.zip
 py36 installed: apipkg==1.4,attrs==18.1.0,bandersnatch==2.2.1,certifi==2018.4.16,chardet==3.0.4,coverage==4.5.1,execnet==1.5.0,flake8==3.5.0,idna==2.6,mccabe==0.6.1,more-itertools==4.1.0,packaging==17.1,pep8==1.7.1,pluggy==0.6.0,py==1.5.3,pycodestyle==2.3.1,pyflakes==1.6.0,pyparsing==2.2.0,pytest==3.5.1,pytest-cache==1.0,pytest-codecheckers==0.2,pytest-cov==2.5.1,pytest-timeout==1.2.1,python-dateutil==2.7.3,requests==2.18.4,six==1.11.0,tox==3.0.0,urllib3==1.22,virtualenv==15.2.0,xmlrpc2==0.3.1
 py36 runtests: PYTHONHASHSEED='42669967'

--- a/src/bandersnatch/tests/plugins/test_storage_plugins.py
+++ b/src/bandersnatch/tests/plugins/test_storage_plugins.py
@@ -15,8 +15,11 @@ from bandersnatch.package import Package
 from bandersnatch.tests.mock_config import mock_config
 from bandersnatch_storage_plugins import filesystem
 
-if TYPE_CHECKING:
-    pass
+# Only true for static analyzers in IDE
+if TYPE_CHECKING:  # pragma: no cover
+    _Base = TestCase
+else:  # pragma: no cover
+    _Base = object
 
 SAMPLE_FILE_CONTENT = "I am a sample!\n"
 BASE_SAMPLE_FILE = os.path.join(
@@ -24,7 +27,7 @@ BASE_SAMPLE_FILE = os.path.join(
 )
 
 
-class BasePluginTestCase(TestCase):
+class BasePluginTestCase(_Base):
     tempdir = None
     cwd = None
     backend: str | None = None
@@ -544,7 +547,7 @@ web{0}simple{0}index.html""".format(os.sep).strip()
                 self.assertEqual(self.plugin.get_hash(path, function=fn), hash_val)
 
 
-class TestFilesystemStoragePlugin(BaseStoragePluginTestCase):
+class TestFilesystemStoragePlugin(BaseStoragePluginTestCase, TestCase):
     backend = "filesystem"
 
 


### PR DESCRIPTION
`test_storage_plugins.py` has a base class pattern where all the test functions are written in a base class and the actual test class just inherits and changes the attributes. The issue was pytest includes all classes inheriting `unittest.Testcase` by default for testing. Since the base class didnt have any backend attribute, all its tests were skipped.

The solution is to make pytest skip the base class during test runs. Removed the Testcase object inheritance from the base class and moved down to actual test class. (This causes the IDE to throw warnings so used TYPE_CHECKING flag to avoid that)

(Also made a small file name correction in the contributing md file)

Fixes #2088 