### PR TITLE
Refactor tests from unittest to pytest (issue #2264)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,7 @@
 
 - Declare workflow-level `permissions: contents: read` on the 8 remaining workflows (CVE-2025-30066 hardening) `PR #2241`
 - Skip base class tests in test runs `PR #2263`
+- Transitioned from unittest.Testcase to pytest fixtures `PR #2265`
 
 ## Documentation
 

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -8,6 +8,7 @@ mypy==2.0.0
 pre_commit==4.6.0
 pytest==9.0.3
 pytest-asyncio==1.3.0
+pytest-mock==3.15.1
 pytest-timeout==2.4.0
 setuptools==82.0.1
 tox==4.54.0

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -7,12 +7,8 @@ freezegun==1.5.5
 mypy==2.0.0
 pre_commit==4.6.0
 pytest==9.0.3
-<<<<<<< pytest-refactor-src-tests
-pytest-asyncio==1.3.0
-pytest-mock==3.15.1
-=======
 pytest-asyncio==1.4.0
->>>>>>> main
+pytest-mock==3.15.1
 pytest-timeout==2.4.0
 setuptools==82.0.1
 tox==4.55.1

--- a/src/bandersnatch/tests/conftest.py
+++ b/src/bandersnatch/tests/conftest.py
@@ -5,25 +5,17 @@ import unittest.mock as mock
 from collections import defaultdict
 from collections.abc import Iterator
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Dict
+from typing import TYPE_CHECKING, Any
 
-import boto3
 import pytest
 import pytest_asyncio
-from _pytest.capture import CaptureFixture
-from _pytest.fixtures import FixtureRequest
-from _pytest.monkeypatch import MonkeyPatch
-from s3path import (
-    PureS3Path,
-    S3Path,
-    accessor,
-    configuration_map,
-    register_configuration_parameter,
-)
+from pytest_mock import MockerFixture
 
 import bandersnatch.storage
 
 if TYPE_CHECKING:
+    from s3path import S3Path
+
     from bandersnatch.master import Master
     from bandersnatch.mirror import BandersnatchMirror
     from bandersnatch.package import Package
@@ -55,14 +47,8 @@ def event_loop() -> Iterator[asyncio.AbstractEventLoop]:
 
 
 @pytest.fixture(autouse=True)
-def stop_std_logging(request: FixtureRequest, capfd: CaptureFixture) -> None:
-    patcher = mock.patch("bandersnatch.log.setup_logging")
-    patcher.start()
-
-    def tearDown() -> None:
-        patcher.stop()
-
-    request.addfinalizer(tearDown)
+def stop_std_logging(mocker: MockerFixture) -> None:
+    mocker.patch("bandersnatch.log.setup_logging")
 
 
 async def _nosleep(*args: Any) -> None:
@@ -70,14 +56,8 @@ async def _nosleep(*args: Any) -> None:
 
 
 @pytest.fixture(autouse=True)
-def never_sleep(request: FixtureRequest) -> None:
-    patcher = mock.patch("asyncio.sleep", _nosleep)
-    patcher.start()
-
-    def tearDown() -> None:
-        patcher.stop()
-
-    request.addfinalizer(tearDown)
+def never_sleep(mocker: MockerFixture) -> None:
+    mocker.patch("asyncio.sleep", _nosleep)
 
 
 # Recreate storage plugins between test modules to prevent later tests
@@ -183,7 +163,7 @@ async def master(package_json: dict[str, Any]) -> "Master":
 
 @pytest.fixture
 def mirror(
-    tmpdir: Path, master: "Master", monkeypatch: MonkeyPatch
+    tmpdir: Path, master: "Master", monkeypatch: pytest.MonkeyPatch
 ) -> "BandersnatchMirror":
     monkeypatch.chdir(tmpdir)
     from bandersnatch.mirror import BandersnatchMirror
@@ -193,7 +173,7 @@ def mirror(
 
 @pytest.fixture
 def mirror_hash_index(
-    tmpdir: Path, master: "Master", monkeypatch: MonkeyPatch
+    tmpdir: Path, master: "Master", monkeypatch: pytest.MonkeyPatch
 ) -> "BandersnatchMirror":
     monkeypatch.chdir(tmpdir)
     from bandersnatch.mirror import BandersnatchMirror
@@ -202,36 +182,30 @@ def mirror_hash_index(
 
 
 @pytest.fixture
-def mirror_mock(request: FixtureRequest) -> mock.MagicMock:
-    patcher = mock.patch("bandersnatch.mirror.BandersnatchMirror")
-    mirror: mock.MagicMock = patcher.start()
+def mirror_mock(mocker: MockerFixture) -> mock.MagicMock:
+    mirror: mock.MagicMock = mocker.patch("bandersnatch.mirror.BandersnatchMirror")
 
     # Mock the synchronize method too to avoid TypeError exceptions since methods are
     # by default replaced by MagicMock instances when AsyncMock is necessary.
     instance = mirror.return_value
     instance.synchronize = mock.AsyncMock(return_value={})
 
-    def tearDown() -> None:
-        patcher.stop()
-
-    request.addfinalizer(tearDown)
     return mirror
 
 
 @pytest.fixture
-def logging_mock(request: FixtureRequest) -> mock.MagicMock:
-    patcher = mock.patch("logging.config.fileConfig")
-    logger: mock.MagicMock = patcher.start()
-
-    def tearDown() -> None:
-        patcher.stop()
-
-    request.addfinalizer(tearDown)
-    return logger
+def logging_mock(mocker: MockerFixture) -> Any:
+    return mocker.patch("logging.config.fileConfig")
 
 
 @pytest.fixture()
 def reset_configuration_cache() -> Iterator[None]:
+    try:
+        from s3path import accessor
+    except ImportError:
+        yield
+        return
+
     try:
         accessor.configuration_map.get_configuration.cache_clear()
         yield
@@ -241,6 +215,14 @@ def reset_configuration_cache() -> Iterator[None]:
 
 @pytest.fixture()
 def s3_mock(reset_configuration_cache: None) -> S3Path:
+    # makes sure other tests are not skipped if s3 deps are missing
+    boto3 = pytest.importorskip("boto3", reason="s3path/boto3 not installed")
+    s3path_mod = pytest.importorskip("s3path", reason="s3path not installed")
+    PureS3Path = s3path_mod.PureS3Path
+    S3Path = s3path_mod.S3Path
+    register_configuration_parameter = s3path_mod.register_configuration_parameter
+    configuration_map = s3path_mod.configuration_map
+
     if os.environ.get("os") != "ubuntu-latest" and os.environ.get("CI"):
         pytest.skip("Skip s3 test on non-posix server in github action")
     endpoint = os.environ.get("BANDERSNATCH_S3_ENDPOINT_URL", "http://localhost:9000")

--- a/src/bandersnatch/tests/conftest.py
+++ b/src/bandersnatch/tests/conftest.py
@@ -214,7 +214,7 @@ def reset_configuration_cache() -> Iterator[None]:
 
 
 @pytest.fixture()
-def s3_mock(reset_configuration_cache: None) -> S3Path:
+def s3_mock(reset_configuration_cache: None) -> "S3Path":
     # makes sure other tests are not skipped if s3 deps are missing
     boto3 = pytest.importorskip("boto3", reason="s3path/boto3 not installed")
     s3path_mod = pytest.importorskip("s3path", reason="s3path not installed")

--- a/src/bandersnatch/tests/test_configuration.py
+++ b/src/bandersnatch/tests/test_configuration.py
@@ -1,10 +1,9 @@
 import configparser
 import importlib.resources
-import os
-import unittest
+from collections.abc import Iterator
 from pathlib import Path
-from tempfile import TemporaryDirectory
-from unittest import TestCase
+
+import pytest
 
 from bandersnatch.config.diff_file_reference import eval_config_reference
 from bandersnatch.configuration import (
@@ -16,334 +15,313 @@ from bandersnatch.configuration import (
 from bandersnatch.simple import SimpleFormat
 
 
-class TestBandersnatchConf(TestCase):
+@pytest.fixture(autouse=True)
+def isolated_config(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> Iterator[None]:
     """
-    Tests for the BandersnatchConf singleton class
+    Isolate each test's working directory and singleton state.
     """
+    monkeypatch.chdir(tmp_path)
 
-    tempdir = None
-    cwd = None
+    # Ensure each test gets a fresh instance if needed
+    # We have a dedicated test to ensure we're creating a singleton
+    Singleton._instances = {}
 
-    def setUp(self) -> None:
-        self.cwd = os.getcwd()
-        self.tempdir = TemporaryDirectory()
-        os.chdir(self.tempdir.name)
-        # Hack to ensure each test gets fresh instance if needed
-        # We have a dedicated test to ensure we're creating a singleton
-        Singleton._instances = {}
+    yield
 
-    def tearDown(self) -> None:
-        if self.tempdir:
-            assert self.cwd
-            os.chdir(self.cwd)
-            self.tempdir.cleanup()
-            self.tempdir = None
+    Singleton._instances = {}
 
-    def test_is_singleton(self) -> None:
-        instance1 = BandersnatchConfig()
-        instance2 = BandersnatchConfig()
-        self.assertEqual(id(instance1), id(instance2))
 
-    def test_single_config__default__all_sections_present(self) -> None:
-        config_file = Path(
-            str(importlib.resources.files("bandersnatch") / "unittest.conf")
-        )
-        instance = BandersnatchConfig(config_file)
-        # All default values should at least be present and be the write types
-        for section in ["mirror", "plugins", "blocklist"]:
-            self.assertIn(section, instance.sections())
+# Singleton / basic config
 
-    def test_single_config__default__mirror__setting_attributes(self) -> None:
-        instance = BandersnatchConfig()
-        options = {option for option in instance["mirror"]}
-        self.assertSetEqual(
-            options,
+
+def test_is_singleton() -> None:
+    instance1 = BandersnatchConfig()
+    instance2 = BandersnatchConfig()
+    assert id(instance1) == id(instance2)
+
+
+def test_single_config__default__all_sections_present() -> None:
+    config_file = Path(str(importlib.resources.files("bandersnatch") / "unittest.conf"))
+    instance = BandersnatchConfig(config_file)
+    for section in ["mirror", "plugins", "blocklist"]:
+        assert section in instance.sections()
+
+
+def test_single_config__default__mirror__setting_attributes() -> None:
+    instance = BandersnatchConfig()
+    options = {option for option in instance["mirror"]}
+    assert options == {
+        "allow-non-https",
+        "api-method",
+        "cleanup",
+        "compare-method",
+        "diff-append-epoch",
+        "diff-file",
+        "digest_name",
+        "download-mirror",
+        "download-mirror-no-fallback",
+        "global-timeout",
+        "hash-index",
+        "json",
+        "keep-index-versions",
+        "log-config",
+        "master",
+        "proxy",
+        "release-files",
+        "root_uri",
+        "simple-format",
+        "stop-on-error",
+        "storage-backend",
+        "storage-filesystem-manage-permissions",
+        "timeout",
+        "verifiers",
+        "workers",
+    }
+
+
+def test_single_config__default__mirror__setting__types() -> None:
+    """
+    Make sure all default mirror settings will cast to the correct types
+    """
+    instance = BandersnatchConfig()
+    for option, option_type in [
+        ("directory", str),
+        ("hash-index", bool),
+        ("json", bool),
+        ("master", str),
+        ("stop-on-error", bool),
+        ("storage-backend", str),
+        ("timeout", int),
+        ("global-timeout", int),
+        ("workers", int),
+        ("compare-method", str),
+        ("api-method", str),
+    ]:
+        assert isinstance(option_type(instance["mirror"].get(option)), option_type)
+
+
+def test_single_config_custom_setting_boolean() -> None:
+    instance = BandersnatchConfig()
+    instance.read_string("[mirror]\nhash-index=false\n")
+    assert not instance["mirror"].getboolean("hash-index")
+
+
+def test_single_config_custom_setting_int() -> None:
+    instance = BandersnatchConfig()
+    instance.read_string("[mirror]\ntimeout=999\n")
+    assert int(instance["mirror"]["timeout"]) == 999
+
+
+def test_single_config_custom_setting_str() -> None:
+    instance = BandersnatchConfig()
+    instance.read_string("[mirror]\nmaster=https://foo.bar.baz\n")
+    assert instance["mirror"]["master"] == "https://foo.bar.baz"
+
+
+def test_multiple_instances_custom_setting_str() -> None:
+    instance1 = BandersnatchConfig()
+    instance1.read_string("[mirror]\nmaster=https://foo.bar.baz\n")
+    instance2 = BandersnatchConfig()
+    assert instance2["mirror"]["master"] == "https://foo.bar.baz"
+
+
+# validate_config_values
+
+
+def test_validate_config_values() -> None:
+    default_values = SetConfigValues(
+        False,
+        "",
+        "",
+        False,
+        "sha256",
+        "filesystem",
+        False,
+        True,
+        "hash",
+        "",
+        False,
+        SimpleFormat.ALL,
+        "simple",
+    )
+    no_options_configparser = BandersnatchConfig(load_defaults=True)
+    assert default_values == validate_config_values(no_options_configparser)
+
+
+def test_validate_config_values_release_files_false_sets_root_uri() -> None:
+    default_values = SetConfigValues(
+        False,
+        "https://files.pythonhosted.org",
+        "",
+        False,
+        "sha256",
+        "filesystem",
+        False,
+        False,
+        "hash",
+        "",
+        False,
+        SimpleFormat.ALL,
+        "simple",
+    )
+    release_files_false_configparser = BandersnatchConfig(load_defaults=True)
+    release_files_false_configparser["mirror"].update({"release-files": "false"})
+    assert default_values == validate_config_values(release_files_false_configparser)
+
+
+def test_validate_config_values_download_mirror_false_sets_no_fallback() -> None:
+    default_values = SetConfigValues(
+        False,
+        "",
+        "",
+        False,
+        "sha256",
+        "filesystem",
+        False,
+        True,
+        "hash",
+        "",
+        False,
+        SimpleFormat.ALL,
+        "simple",
+    )
+    release_files_false_configparser = BandersnatchConfig(load_defaults=True)
+    release_files_false_configparser["mirror"].update(
+        {
+            "download-mirror-no-fallback": "true",
+        }
+    )
+    assert default_values == validate_config_values(release_files_false_configparser)
+
+
+def test_validate_config_values_api_method_simple() -> None:
+    """Test that api_method='simple' is accepted and validated."""
+    simple_api_values = SetConfigValues(
+        False,
+        "",
+        "",
+        False,
+        "sha256",
+        "filesystem",
+        False,
+        True,
+        "hash",
+        "",
+        False,
+        SimpleFormat.ALL,
+        "simple",
+    )
+    simple_api_config = BandersnatchConfig(load_defaults=True)
+    simple_api_config["mirror"].update({"api-method": "simple"})
+    assert simple_api_values == validate_config_values(simple_api_config)
+
+
+def test_validate_config_values_api_method_xmlrpc() -> None:
+    """Test that api_method='xmlrpc' is accepted and validated."""
+    xmlrpc_api_values = SetConfigValues(
+        False,
+        "",
+        "",
+        False,
+        "sha256",
+        "filesystem",
+        False,
+        True,
+        "hash",
+        "",
+        False,
+        SimpleFormat.ALL,
+        "xmlrpc",
+    )
+    xmlrpc_api_config = BandersnatchConfig(load_defaults=True)
+    xmlrpc_api_config["mirror"].update({"api-method": "xmlrpc"})
+    assert xmlrpc_api_values == validate_config_values(xmlrpc_api_config)
+
+
+def test_validate_config_values_api_method_invalid() -> None:
+    """Test that invalid api_method raises ValueError."""
+    invalid_api_config = BandersnatchConfig(load_defaults=True)
+    invalid_api_config["mirror"].update({"api-method": "invalid"})
+
+    with pytest.raises(ValueError) as exc_info:
+        validate_config_values(invalid_api_config)
+
+    msg = str(exc_info.value)
+    assert "api-method invalid is not supported" in msg
+    assert "('simple', 'xmlrpc')" in msg
+
+
+def test_validate_config_values_api_method_defaults_to_simple() -> None:
+    """Test that api_method defaults to 'simple' when not specified."""
+    config = BandersnatchConfig(load_defaults=True)
+    # Remove the api-method config if it exists
+    if config.has_option("mirror", "api-method"):
+        config.remove_option("mirror", "api-method")
+    result = validate_config_values(config)
+    assert result.api_method == "simple"
+
+
+# diff-file reference expansion
+
+
+@pytest.mark.parametrize(
+    ("cfg_data", "expected"),
+    [
+        (
+            {"mirror": {"directory": "/test", "diff-file": r"{{mirror_directory}}"}},
+            "/test",
+        ),
+        (
+            {"mirror": {"directory": "/test", "diff-file": r"{{ mirror_directory }}"}},
+            "/test",
+        ),
+        (
             {
-                "allow-non-https",
-                "api-method",
-                "cleanup",
-                "compare-method",
-                "diff-append-epoch",
-                "diff-file",
-                "digest_name",
-                "download-mirror",
-                "download-mirror-no-fallback",
-                "global-timeout",
-                "hash-index",
-                "json",
-                "keep-index-versions",
-                "log-config",
-                "master",
-                "proxy",
-                "release-files",
-                "root_uri",
-                "simple-format",
-                "stop-on-error",
-                "storage-backend",
-                "storage-filesystem-manage-permissions",
-                "timeout",
-                "verifiers",
-                "workers",
+                "mirror": {
+                    "directory": "/test",
+                    "diff-file": r"{{ mirror_directory }}/diffs/new-files",
+                }
             },
-        )
-
-    def test_single_config__default__mirror__setting__types(self) -> None:
-        """
-        Make sure all default mirror settings will cast to the correct types
-        """
-        instance = BandersnatchConfig()
-        for option, option_type in [
-            ("directory", str),
-            ("hash-index", bool),
-            ("json", bool),
-            ("master", str),
-            ("stop-on-error", bool),
-            ("storage-backend", str),
-            ("timeout", int),
-            ("global-timeout", int),
-            ("workers", int),
-            ("compare-method", str),
-            ("api-method", str),
-        ]:
-            self.assertIsInstance(
-                option_type(instance["mirror"].get(option)), option_type
-            )
-
-    def test_single_config_custom_setting_boolean(self) -> None:
-        instance = BandersnatchConfig()
-        instance.read_string("[mirror]\nhash-index=false\n")
-
-        self.assertFalse(instance["mirror"].getboolean("hash-index"))
-
-    def test_single_config_custom_setting_int(self) -> None:
-        instance = BandersnatchConfig()
-        instance.read_string("[mirror]\ntimeout=999\n")
-
-        self.assertEqual(int(instance["mirror"]["timeout"]), 999)
-
-    def test_single_config_custom_setting_str(self) -> None:
-        instance = BandersnatchConfig()
-        instance.read_string("[mirror]\nmaster=https://foo.bar.baz\n")
-
-        self.assertEqual(instance["mirror"]["master"], "https://foo.bar.baz")
-
-    def test_multiple_instances_custom_setting_str(self) -> None:
-        instance1 = BandersnatchConfig()
-        instance1.read_string("[mirror]\nmaster=https://foo.bar.baz\n")
-
-        instance2 = BandersnatchConfig()
-
-        self.assertEqual(instance2["mirror"]["master"], "https://foo.bar.baz")
-
-    def test_validate_config_values(self) -> None:
-        default_values = SetConfigValues(
-            False,
-            "",
-            "",
-            False,
-            "sha256",
-            "filesystem",
-            False,
-            True,
-            "hash",
-            "",
-            False,
-            SimpleFormat.ALL,
-            "simple",
-        )
-        no_options_configparser = BandersnatchConfig(load_defaults=True)
-        self.assertEqual(
-            default_values, validate_config_values(no_options_configparser)
-        )
-
-    def test_validate_config_values_release_files_false_sets_root_uri(self) -> None:
-        default_values = SetConfigValues(
-            False,
-            "https://files.pythonhosted.org",
-            "",
-            False,
-            "sha256",
-            "filesystem",
-            False,
-            False,
-            "hash",
-            "",
-            False,
-            SimpleFormat.ALL,
-            "simple",
-        )
-        release_files_false_configparser = BandersnatchConfig(load_defaults=True)
-        release_files_false_configparser["mirror"].update({"release-files": "false"})
-        self.assertEqual(
-            default_values, validate_config_values(release_files_false_configparser)
-        )
-
-    def test_validate_config_values_download_mirror_false_sets_no_fallback(
-        self,
-    ) -> None:
-        default_values = SetConfigValues(
-            False,
-            "",
-            "",
-            False,
-            "sha256",
-            "filesystem",
-            False,
-            True,
-            "hash",
-            "",
-            False,
-            SimpleFormat.ALL,
-            "simple",
-        )
-        release_files_false_configparser = BandersnatchConfig(load_defaults=True)
-        release_files_false_configparser["mirror"].update(
+            "/test/diffs/new-files",
+        ),
+        (
             {
-                "download-mirror-no-fallback": "true",
-            }
-        )
-        self.assertEqual(
-            default_values, validate_config_values(release_files_false_configparser)
-        )
-
-    def test_validate_config_values_api_method_simple(self) -> None:
-        """Test that api_method='simple' is accepted and validated."""
-        simple_api_values = SetConfigValues(
-            False,
-            "",
-            "",
-            False,
-            "sha256",
-            "filesystem",
-            False,
-            True,
-            "hash",
-            "",
-            False,
-            SimpleFormat.ALL,
-            "simple",
-        )
-        simple_api_config = BandersnatchConfig(load_defaults=True)
-        simple_api_config["mirror"].update({"api-method": "simple"})
-        self.assertEqual(simple_api_values, validate_config_values(simple_api_config))
-
-    def test_validate_config_values_api_method_xmlrpc(self) -> None:
-        """Test that api_method='xmlrpc' is accepted and validated."""
-        xmlrpc_api_values = SetConfigValues(
-            False,
-            "",
-            "",
-            False,
-            "sha256",
-            "filesystem",
-            False,
-            True,
-            "hash",
-            "",
-            False,
-            SimpleFormat.ALL,
-            "xmlrpc",
-        )
-        xmlrpc_api_config = BandersnatchConfig(load_defaults=True)
-        xmlrpc_api_config["mirror"].update({"api-method": "xmlrpc"})
-        self.assertEqual(xmlrpc_api_values, validate_config_values(xmlrpc_api_config))
-
-    def test_validate_config_values_api_method_invalid(self) -> None:
-        """Test that invalid api_method raises ValueError."""
-        invalid_api_config = BandersnatchConfig(load_defaults=True)
-        invalid_api_config["mirror"].update({"api-method": "invalid"})
-        with self.assertRaises(ValueError) as context:
-            validate_config_values(invalid_api_config)
-        self.assertIn("api-method invalid is not supported", str(context.exception))
-        self.assertIn("('simple', 'xmlrpc')", str(context.exception))
-
-    def test_validate_config_values_api_method_defaults_to_simple(self) -> None:
-        """Test that api_method defaults to 'simple' when not specified."""
-        config = BandersnatchConfig(load_defaults=True)
-        # Remove the api-method config if it exists
-        if config.has_option("mirror", "api-method"):
-            config.remove_option("mirror", "api-method")
-        result = validate_config_values(config)
-        self.assertEqual(result.api_method, "simple")
-
-    def test_validate_config_diff_file_reference(self) -> None:
-        diff_file_test_cases = [
-            (
-                {
-                    "mirror": {
-                        "directory": "/test",
-                        "diff-file": r"{{mirror_directory}}",
-                    }
-                },
-                "/test",
-            ),
-            (
-                {
-                    "mirror": {
-                        "directory": "/test",
-                        "diff-file": r"{{ mirror_directory }}",
-                    }
-                },
-                "/test",
-            ),
-            (
-                {
-                    "mirror": {
-                        "directory": "/test",
-                        "diff-file": r"{{ mirror_directory }}/diffs/new-files",
-                    }
-                },
-                "/test/diffs/new-files",
-            ),
-            (
-                {
-                    "strings": {"test": "TESTING"},
-                    "mirror": {"diff-file": r"/var/log/{{ strings_test }}"},
-                },
-                "/var/log/TESTING",
-            ),
-            (
-                {
-                    "strings": {"test": "TESTING"},
-                    "mirror": {"diff-file": r"/var/log/{{ strings_test }}/diffs"},
-                },
-                "/var/log/TESTING/diffs",
-            ),
-        ]
-
-        for cfg_data, expected in diff_file_test_cases:
-            with self.subTest(
-                diff_file=cfg_data["mirror"]["diff-file"],
-                expected=expected,
-                cfg_data=cfg_data,
-            ):
-                cfg = BandersnatchConfig(load_defaults=True)
-                cfg.read_dict(cfg_data)
-                config_values = validate_config_values(cfg)
-                self.assertIsInstance(config_values.diff_file_path, str)
-                self.assertEqual(config_values.diff_file_path, expected)
-
-    def test_invalid_diff_file_reference_throws_exception(self) -> None:
-        invalid_diff_file_cases = [
-            (
-                r"{{ missing.underscore }}/foo",
-                "Unable to parse config option reference",
-            ),
-            (r"/var/{{ mirror_woops }}/foo", "No option 'woops' in section: 'mirror'"),
-        ]
-
-        for diff_file_val, expected_error in invalid_diff_file_cases:
-            with self.subTest(diff_file=diff_file_val, expected_error=expected_error):
-                cfg = configparser.ConfigParser()
-                cfg.read_dict({"mirror": {"diff-file": diff_file_val}})
-                self.assertRaisesRegex(
-                    ValueError,
-                    expected_error,
-                    eval_config_reference,
-                    cfg,
-                    diff_file_val,
-                )
+                "strings": {"test": "TESTING"},
+                "mirror": {"diff-file": r"/var/log/{{ strings_test }}"},
+            },
+            "/var/log/TESTING",
+        ),
+        (
+            {
+                "strings": {"test": "TESTING"},
+                "mirror": {"diff-file": r"/var/log/{{ strings_test }}/diffs"},
+            },
+            "/var/log/TESTING/diffs",
+        ),
+    ],
+)
+def test_validate_config_diff_file_reference(cfg_data: dict, expected: str) -> None:
+    cfg = BandersnatchConfig(load_defaults=True)
+    cfg.read_dict(cfg_data)
+    config_values = validate_config_values(cfg)
+    assert isinstance(config_values.diff_file_path, str)
+    assert config_values.diff_file_path == expected
 
 
-if __name__ == "__main__":
-    unittest.main()
+@pytest.mark.parametrize(
+    ("diff_file_val", "expected_error"),
+    [
+        (r"{{ missing.underscore }}/foo", "Unable to parse config option reference"),
+        (r"/var/{{ mirror_woops }}/foo", "No option 'woops' in section: 'mirror'"),
+    ],
+)
+def test_invalid_diff_file_reference_throws_exception(
+    diff_file_val: str, expected_error: str
+) -> None:
+    cfg = configparser.ConfigParser()
+    cfg.read_dict({"mirror": {"diff-file": diff_file_val}})
+    with pytest.raises(ValueError, match=expected_error):
+        eval_config_reference(cfg, diff_file_val)

--- a/src/bandersnatch/tests/test_filter.py
+++ b/src/bandersnatch/tests/test_filter.py
@@ -1,8 +1,6 @@
-import os
-import sys
-import unittest
-from tempfile import TemporaryDirectory
-from unittest import TestCase
+from pathlib import Path
+
+import pytest
 
 from bandersnatch.configuration import BandersnatchConfig
 from bandersnatch.tests.mock_config import mock_config
@@ -15,118 +13,104 @@ from bandersnatch.filter import (  # isort:skip
 )
 
 
-class TestBandersnatchFilter(TestCase):
-    """
-    Tests for the bandersnatch filtering classes
-    """
+@pytest.fixture(autouse=True)
+def isolated_tmpdir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.chdir(tmp_path)
 
-    tempdir = None
-    cwd = None
 
-    def setUp(self) -> None:
-        self.cwd = os.getcwd()
-        self.tempdir = TemporaryDirectory()
-        os.chdir(self.tempdir.name)
-        sys.stderr.write(self.tempdir.name)
-        sys.stderr.flush()
-
-    def tearDown(self) -> None:
-        if self.tempdir:
-            assert self.cwd
-            os.chdir(self.cwd)
-            self.tempdir.cleanup()
-            self.tempdir = None
-
-    def test__filter_project_plugins__loads(self) -> None:
-        mock_config("""\
+def test__filter_project_plugins__loads() -> None:
+    mock_config("""\
 [plugins]
 enabled = all
 """)
-        builtin_plugin_names = [
-            "blocklist_project",
-            "regex_project",
-            "allowlist_project",
-        ]
+    builtin_plugin_names = [
+        "blocklist_project",
+        "regex_project",
+        "allowlist_project",
+    ]
 
-        plugins = LoadedFilters().filter_project_plugins()
-        names = [plugin.name for plugin in plugins]
-        for name in builtin_plugin_names:
-            self.assertIn(name, names)
+    plugins = LoadedFilters().filter_project_plugins()
+    names = [plugin.name for plugin in plugins]
+    for name in builtin_plugin_names:
+        assert name in names
 
-    def test__filter_release_plugins__loads(self) -> None:
-        mock_config("""\
+
+def test__filter_release_plugins__loads() -> None:
+    mock_config("""\
 [plugins]
 enabled = all
 """)
-        builtin_plugin_names = [
-            "blocklist_release",
-            "prerelease_release",
-            "regex_release",
-            "latest_release",
-        ]
+    builtin_plugin_names = [
+        "blocklist_release",
+        "prerelease_release",
+        "regex_release",
+        "latest_release",
+    ]
 
-        plugins = LoadedFilters().filter_release_plugins()
-        names = [plugin.name for plugin in plugins]
-        for name in builtin_plugin_names:
-            self.assertIn(name, names)
+    plugins = LoadedFilters().filter_release_plugins()
+    names = [plugin.name for plugin in plugins]
+    for name in builtin_plugin_names:
+        assert name in names
 
-    def test__filter_no_plugin(self) -> None:
-        mock_config("""\
+
+def test__filter_no_plugin() -> None:
+    mock_config("""\
 [plugins]
 enabled =
 """)
 
-        plugins = LoadedFilters().filter_release_plugins()
-        self.assertEqual(len(plugins), 0)
+    plugins = LoadedFilters().filter_release_plugins()
+    assert len(plugins) == 0
 
-        plugins = LoadedFilters().filter_project_plugins()
-        self.assertEqual(len(plugins), 0)
+    plugins = LoadedFilters().filter_project_plugins()
+    assert len(plugins) == 0
 
-    def test__filter_base_clases(self) -> None:
-        """
-        Test the base filter classes
-        """
 
-        plugin = Filter()
-        self.assertEqual(plugin.name, "filter")
-        try:
-            plugin.initialize_plugin()
-            error = False
-        except Exception:
-            error = True
-        self.assertFalse(error)
+def test__filter_base_classes() -> None:
+    """Test the base filter classes."""
 
-        plugin = FilterReleasePlugin()
-        self.assertIsInstance(plugin, Filter)
-        self.assertEqual(plugin.name, "release_plugin")
-        try:
-            plugin.filter({})
-            error = False
-        except Exception:
-            error = True
-        self.assertFalse(error)
+    plugin = Filter()
+    assert plugin.name == "filter"
+    try:
+        plugin.initialize_plugin()
+        error = False
+    except Exception:
+        error = True
+    assert not error
 
-        plugin = FilterProjectPlugin()
-        self.assertIsInstance(plugin, Filter)
-        self.assertEqual(plugin.name, "project_plugin")
-        try:
-            result = plugin.check_match(key="value")
-            error = False
-            self.assertIsInstance(result, bool)
-        except Exception:
-            error = True
-        self.assertFalse(error)
+    plugin = FilterReleasePlugin()
+    assert isinstance(plugin, Filter)
+    assert plugin.name == "release_plugin"
+    try:
+        plugin.filter({})
+        error = False
+    except Exception:
+        error = True
+    assert not error
 
-    def test_deprecated_keys(self) -> None:
-        instance = BandersnatchConfig()
-        instance.read_string("[allowlist]\npackages=foo\n[blocklist]\npackages=bar\n")
+    plugin = FilterProjectPlugin()
+    assert isinstance(plugin, Filter)
+    assert plugin.name == "project_plugin"
+    try:
+        result = plugin.check_match(key="value")
+        error = False
+        assert isinstance(result, bool)
+    except Exception:
+        error = True
+    assert not error
 
-        plugin = Filter()
-        assert plugin.allowlist.name == "allowlist"
-        assert plugin.blocklist.name == "blocklist"
 
-    def test__filter_project_blocklist_allowlist__pep503_normalize(self) -> None:
-        mock_config("""\
+def test_deprecated_keys() -> None:
+    instance = BandersnatchConfig()
+    instance.read_string("[allowlist]\npackages=foo\n[blocklist]\npackages=bar\n")
+
+    plugin = Filter()
+    assert plugin.allowlist.name == "allowlist"
+    assert plugin.blocklist.name == "blocklist"
+
+
+def test__filter_project_blocklist_allowlist__pep503_normalize() -> None:
+    mock_config("""\
 [plugins]
 enabled =
     blocklist_project
@@ -143,19 +127,11 @@ packages =
     trove----classifiers
 """)
 
-        plugins = {
-            plugin.name: plugin for plugin in LoadedFilters().filter_project_plugins()
-        }
+    plugins = {
+        plugin.name: plugin for plugin in LoadedFilters().filter_project_plugins()
+    }
 
-        self.assertTrue(plugins["blocklist_project"].check_match(name="sampleproject"))
-        self.assertTrue(
-            plugins["blocklist_project"].check_match(name="trove-classifiers")
-        )
-        self.assertFalse(plugins["allowlist_project"].check_match(name="sampleproject"))
-        self.assertFalse(
-            plugins["allowlist_project"].check_match(name="trove-classifiers")
-        )
-
-
-if __name__ == "__main__":
-    unittest.main()
+    assert plugins["blocklist_project"].check_match(name="sampleproject")
+    assert plugins["blocklist_project"].check_match(name="trove-classifiers")
+    assert not plugins["allowlist_project"].check_match(name="sampleproject")
+    assert not plugins["allowlist_project"].check_match(name="trove-classifiers")

--- a/src/bandersnatch/tests/test_main.py
+++ b/src/bandersnatch/tests/test_main.py
@@ -7,8 +7,6 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 import pytest
-from _pytest.capture import CaptureFixture
-from _pytest.logging import LogCaptureFixture
 
 import bandersnatch.mirror
 import bandersnatch.storage
@@ -34,7 +32,7 @@ def reset_config_singleton() -> None:
 pytestmark = pytest.mark.usefixtures("reset_config_singleton")
 
 
-def test_main_help(capfd: CaptureFixture) -> None:
+def test_main_help(capfd: pytest.CaptureFixture[str]) -> None:
     sys.argv = ["bandersnatch", "--help"]
     with pytest.raises(SystemExit):
         main(asyncio.new_event_loop())
@@ -43,7 +41,7 @@ def test_main_help(capfd: CaptureFixture) -> None:
     assert "" == err
 
 
-def test_main_create_config(caplog: LogCaptureFixture, tmpdir: Path) -> None:
+def test_main_create_config(caplog: pytest.LogCaptureFixture, tmpdir: Path) -> None:
     sys.argv = ["bandersnatch", "-c", str(tmpdir / "bandersnatch.conf"), "mirror"]
     assert main(asyncio.new_event_loop()) == 1
     assert "creating default config" in caplog.text
@@ -51,7 +49,9 @@ def test_main_create_config(caplog: LogCaptureFixture, tmpdir: Path) -> None:
     assert conf_path.exists()
 
 
-def test_main_cant_create_config(caplog: LogCaptureFixture, tmpdir: Path) -> None:
+def test_main_cant_create_config(
+    caplog: pytest.LogCaptureFixture, tmpdir: Path
+) -> None:
     sys.argv = [
         "bandersnatch",
         "-c",

--- a/src/bandersnatch/tests/test_package.py
+++ b/src/bandersnatch/tests/test_package.py
@@ -2,7 +2,6 @@ from asyncio import TimeoutError
 from unittest.mock import AsyncMock
 
 import pytest
-from _pytest.capture import CaptureFixture
 
 from bandersnatch.errors import ConnectionTimeout, PackageNotFound, StaleMetadata
 from bandersnatch.master import Master, StalePage
@@ -21,7 +20,7 @@ def test_package_accessors(package: Package) -> None:
 
 @pytest.mark.asyncio
 async def test_package_update_metadata_gives_up_after_3_stale_responses(
-    caplog: CaptureFixture, master: Master
+    caplog: pytest.LogCaptureFixture, master: Master
 ) -> None:
     master.get_package_metadata = AsyncMock(side_effect=StalePage)  # type: ignore
     package = Package("foo", serial=11)
@@ -33,7 +32,9 @@ async def test_package_update_metadata_gives_up_after_3_stale_responses(
 
 
 @pytest.mark.asyncio
-async def test_package_not_found(caplog: CaptureFixture, master: Master) -> None:
+async def test_package_not_found(
+    caplog: pytest.LogCaptureFixture, master: Master
+) -> None:
     pkg_name = "foo"
     master.get_package_metadata = AsyncMock(  # type: ignore
         side_effect=PackageNotFound(pkg_name)
@@ -47,7 +48,7 @@ async def test_package_not_found(caplog: CaptureFixture, master: Master) -> None
 
 @pytest.mark.asyncio
 async def test_package_update_metadata_gives_up_after_3_timeouts(
-    caplog: CaptureFixture, master: Master
+    caplog: pytest.LogCaptureFixture, master: Master
 ) -> None:
     master.get_package_metadata = AsyncMock(side_effect=TimeoutError)  # type: ignore
     package = Package("foo", serial=11)

--- a/src/bandersnatch/tests/test_utils.py
+++ b/src/bandersnatch/tests/test_utils.py
@@ -6,7 +6,6 @@ from tempfile import NamedTemporaryFile, TemporaryDirectory, gettempdir
 
 import aiohttp
 import pytest
-from _pytest.monkeypatch import MonkeyPatch
 
 from bandersnatch.utils import (  # isort:skip
     bandersnatch_safe_name,
@@ -68,7 +67,7 @@ def test_find_files() -> None:
         assert found_files == expected_found_files
 
 
-def test_rewrite(tmpdir: Path, monkeypatch: MonkeyPatch) -> None:
+def test_rewrite(tmpdir: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.chdir(tmpdir)
     with open("sample", "w") as f:
         f.write("bsdf")
@@ -81,7 +80,7 @@ def test_rewrite(tmpdir: Path, monkeypatch: MonkeyPatch) -> None:
         assert oct(mode) == "0o100644"
 
 
-def test_rewrite_fails(tmpdir: Path, monkeypatch: MonkeyPatch) -> None:
+def test_rewrite_fails(tmpdir: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.chdir(tmpdir)
     with open("sample", "w") as f:
         f.write("bsdf")
@@ -91,7 +90,9 @@ def test_rewrite_fails(tmpdir: Path, monkeypatch: MonkeyPatch) -> None:
     assert open("sample").read() == "bsdf"
 
 
-def test_rewrite_nonexisting_file(tmpdir: Path, monkeypatch: MonkeyPatch) -> None:
+def test_rewrite_nonexisting_file(
+    tmpdir: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     monkeypatch.chdir(tmpdir)
     with rewrite("sample", "w") as f:
         f.write("csdf")

--- a/src/bandersnatch/tests/test_verify.py
+++ b/src/bandersnatch/tests/test_verify.py
@@ -10,7 +10,6 @@ from typing import Any
 from unittest.mock import AsyncMock
 
 import pytest
-from _pytest.monkeypatch import MonkeyPatch
 from aiohttp.client_exceptions import ClientResponseError, ServerTimeoutError
 
 import bandersnatch
@@ -159,7 +158,7 @@ class FakeMirror:
 
 
 @pytest.mark.asyncio
-async def test_verify_producer(monkeypatch: MonkeyPatch) -> None:
+async def test_verify_producer(monkeypatch: pytest.MonkeyPatch) -> None:
     fm = FakeMirror("test_async_verify")
     fc = configparser.ConfigParser()
     fc["mirror"] = {}
@@ -216,7 +215,7 @@ async def test_delete_unowned_files() -> None:
 
 
 @pytest.mark.asyncio
-async def test_get_latest_json(monkeypatch: MonkeyPatch) -> None:
+async def test_get_latest_json(monkeypatch: pytest.MonkeyPatch) -> None:
     executor = ThreadPoolExecutor(max_workers=2)
     json_path = Path(gettempdir()) / f"unittest_{os.getpid()}.json"
     master = Master("https://unittest.org")
@@ -226,7 +225,7 @@ async def test_get_latest_json(monkeypatch: MonkeyPatch) -> None:
 
 
 @pytest.mark.asyncio
-async def test_metadata_verify(monkeypatch: MonkeyPatch) -> None:
+async def test_metadata_verify(monkeypatch: pytest.MonkeyPatch) -> None:
     class FakeArgs:
         delete = True
         dry_run = True
@@ -242,7 +241,7 @@ async def test_metadata_verify(monkeypatch: MonkeyPatch) -> None:
 
 @pytest.mark.asyncio
 async def test_get_latest_json_timeout(
-    tmp_path: Path, monkeypatch: MonkeyPatch
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     class FakeArgs:
         delete = True
@@ -271,7 +270,9 @@ async def test_get_latest_json_timeout(
 
 
 @pytest.mark.asyncio
-async def test_get_latest_json_404(tmp_path: Path, monkeypatch: MonkeyPatch) -> None:
+async def test_get_latest_json_404(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     class FakeArgs:
         delete = True
         dry_run = False
@@ -301,7 +302,9 @@ async def test_get_latest_json_404(tmp_path: Path, monkeypatch: MonkeyPatch) -> 
 
 
 @pytest.mark.asyncio
-async def test_verify_url_exception(tmp_path: Path, monkeypatch: MonkeyPatch) -> None:
+async def test_verify_url_exception(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     class FakeArgs:
         delete = True
         dry_run = False

--- a/src/test_docker_runner.py
+++ b/src/test_docker_runner.py
@@ -1,48 +1,31 @@
 import argparse
-from unittest import TestCase
+
+import pytest
 
 from runner import parseHourList
 
 
-class TestRunner(TestCase):
-    """
-    Tests for the bandersnatch runner script
-    """
+def test_parseHourList_ascending_range() -> None:
+    """Start time less than end time."""
+    assert parseHourList("10-18") == [10, 11, 12, 13, 14, 15, 16, 17, 18]
 
-    def setUp(self) -> None:
-        pass
 
-    def tearDown(self) -> None:
-        pass
+def test_parseHourList_same_start_end() -> None:
+    """Start and end match, expressed as a range."""
+    assert parseHourList("18-18") == [18]
 
-    def test__parseHourList__function(self) -> None:
-        # Case where start time is less than end time
-        input_time_range = "10-18"
-        expected_hours_list = [10, 11, 12, 13, 14, 15, 16, 17, 18]
-        hours_list = parseHourList(input_time_range)
-        self.assertEqual(hours_list, expected_hours_list)
 
-        # Case where start and end time match, but they are expressed as a range
-        input_time_range = "18-18"
-        expected_hours_list = [18]
-        hours_list = parseHourList(input_time_range)
-        self.assertEqual(hours_list, expected_hours_list)
+def test_parseHourList_crosses_midnight() -> None:
+    """Time range crosses the day boundary."""
+    assert parseHourList("23-5") == [23, 0, 1, 2, 3, 4, 5]
 
-        # Case where time range crosses the day
-        input_time_range = "23-5"
-        expected_hours_list = [23, 0, 1, 2, 3, 4, 5]
-        hours_list = parseHourList(input_time_range)
-        self.assertEqual(hours_list, expected_hours_list)
 
-        # Case where the string is a single number and not a range
-        input_time_range = "23"
-        expected_hours_list = [23]
-        hours_list = parseHourList(input_time_range)
-        self.assertEqual(hours_list, expected_hours_list)
+def test_parseHourList_single_number() -> None:
+    """Single number, not a range."""
+    assert parseHourList("23") == [23]
 
-        # Case where the string is a text, should raise ArgumentTypeError
-        input_time_range = "foo"
-        with self.assertRaises(argparse.ArgumentTypeError) as context:
-            parseHourList(input_time_range)
-        # Assert that the error message contains the user input string
-        self.assertIn(input_time_range, str(context.exception))
+
+def test_parseHourList_invalid_raises() -> None:
+    """Non-numeric input raises ArgumentTypeError containing the input string."""
+    with pytest.raises(argparse.ArgumentTypeError, match="foo"):
+        parseHourList("foo")


### PR DESCRIPTION
Refactored top level src tests and the `test_docker_runner.py` to use pytest completely and follow its testing principles. Added `pytest-mock` dependency to use its patcher method which is much more convenient and safe than doing patch.start() and patch.stop()

Moved s3 related test imports inside the test itself and used importorskip as the whole s3 testing situation has a dedicated requirements folder, its own test file etc. Importing them at the top of the src conftest means if those imports are missing, the whole suite crashes.

Added fixture for tmp directory handling in `test_filter.py`

Also changed CaptureFixture to LogCaptureFixture in test_package.py as those functions use the logger methods instead of std.

(I have 2 other chained PRs where ive attempted to refactor the plugins test files as well)

Love to here your thoughts on this refactor attempt and see if any changes are required.

Fixes ##2264