### PR TITLE
Optimize hash method

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@
 ## New Features
 
 - Allow configuring any PEP691 compliant digest that the index offers `PR #2262`
+- Use hashlib.file_digest() to calculate file hashes when verifying `PR #2277`
 
 ## CI / test
 

--- a/src/bandersnatch/utils.py
+++ b/src/bandersnatch/utils.py
@@ -59,12 +59,11 @@ def convert_url_to_path(url: str) -> str:
 
 
 def hash(path: Path, function: str = "sha256") -> str:
-    h = getattr(hashlib, function)
-    content = path.read_bytes()
-    result = h(content).hexdigest()
-    if isinstance(result, str):
-        return result
-    raise TypeError("hashlib did not return str")
+    with path.open("rb") as f:
+        return hashlib.file_digest(
+            f,
+            function,
+        ).hexdigest()
 
 
 def find(root: Path | str, dirs: bool = True) -> str:


### PR DESCRIPTION
Replace hashing implementation based on `Path.read_bytes()` with `hashlib.file_digest()` in the hash() utility.
This changes hashing from loading the entire file into memory to streaming directly from the file object.
(Would speed up the verify action)

I stumbled on this when looking at this issue: (issue #2052)
As bandersnatch now requires python 3.12 and here we can use this new function which is significantly faster

My benches:

os: windows

i generated 3 files (100mg, 1gb and 5gb) filled with random bytes
Then ran this bench script: 
[bench_hash.py](https://github.com/user-attachments/files/28801714/bench_hash.py)
I observed that the existing hash method took 50 seconds on first runs and averaged 22 seconds in subsequent runs (probably due to OS hot caches)
Whereas the file_digest didnt cross 6 seconds. feel free to run the inspect the bench script and run it. 

The reason this does well is the existing path.read_bytes() loads the entire file in mem. file_digest() streams and has a dedicated C implementation for it.