### PR TITLE
Update get hash and others

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,7 @@
 - Allow configuring any PEP691 compliant digest that the index offers `PR #2262`
 - Use hashlib.file_digest() to calculate file hashes when verifying `PR #2277`
 - Add new `versions_count_project_metadata` filter plugin to filter packages by total version count `PR #2281`
+- Update get_hash() method for filesystem storage backend to use hashlib.file_digest() `PR #2288`
 
 ## CI / test
 

--- a/src/bandersnatch/package.py
+++ b/src/bandersnatch/package.py
@@ -151,3 +151,14 @@ class Package:
         if releases:
             return True
         return False
+
+    @classmethod
+    def from_metadata(cls, metadata: dict[str, Any]) -> Package:
+        try:
+            name = metadata["info"]["name"]
+        except (KeyError, TypeError) as e:
+            raise ValueError(f"Invalid PyPI metadata: {e}") from e
+
+        pkg = cls(name)
+        pkg._metadata = metadata
+        return pkg

--- a/src/bandersnatch/package.py
+++ b/src/bandersnatch/package.py
@@ -155,10 +155,18 @@ class Package:
     @classmethod
     def from_metadata(cls, metadata: dict[str, Any]) -> "Package":
         try:
-            name = metadata["info"]["name"]
-        except (KeyError, TypeError) as e:
+            info = metadata["info"]
+            releases = metadata["releases"]
+            name = info["name"]
+            if (
+                not isinstance(info, dict)
+                or not isinstance(releases, dict)
+                or not isinstance(name, str)
+            ):
+                raise TypeError("Unexpected metadata types")
+            pkg = cls(name)
+        except (KeyError, TypeError, ValueError) as e:
             raise ValueError(f"Invalid PyPI metadata: {e}") from e
 
-        pkg = cls(name)
         pkg._metadata = metadata
         return pkg

--- a/src/bandersnatch/package.py
+++ b/src/bandersnatch/package.py
@@ -153,7 +153,7 @@ class Package:
         return False
 
     @classmethod
-    def from_metadata(cls, metadata: dict[str, Any]) -> Package:
+    def from_metadata(cls, metadata: dict[str, Any]) -> "Package":
         try:
             name = metadata["info"]["name"]
         except (KeyError, TypeError) as e:

--- a/src/bandersnatch/tests/test_package.py
+++ b/src/bandersnatch/tests/test_package.py
@@ -14,9 +14,19 @@ def test_package_from_metadata(package_json: dict) -> None:
     assert pkg.metadata is package_json
 
 
-def test_package_from_metadata_invalid() -> None:
+@pytest.mark.parametrize(
+    "metadata",
+    [
+        {"releases": {}},
+        {"info": {"name": "foo"}},
+        {"info": {"name": 123}, "releases": {}},
+        {"info": "not-a-dict", "releases": {}},
+        {"info": {"name": "foo"}, "releases": []},
+    ],
+)
+def test_package_from_metadata_invalid(metadata: dict) -> None:
     with pytest.raises(ValueError, match="Invalid PyPI metadata"):
-        Package.from_metadata({"releases": {}})
+        Package.from_metadata(metadata)
 
 
 def test_package_accessors(package: Package) -> None:

--- a/src/bandersnatch/tests/test_package.py
+++ b/src/bandersnatch/tests/test_package.py
@@ -8,6 +8,17 @@ from bandersnatch.master import Master, StalePage
 from bandersnatch.package import Package
 
 
+def test_package_from_metadata(package_json: dict) -> None:
+    pkg = Package.from_metadata(package_json)
+    assert pkg.name == "foo"
+    assert pkg.metadata is package_json
+
+
+def test_package_from_metadata_invalid() -> None:
+    with pytest.raises(ValueError, match="Invalid PyPI metadata"):
+        Package.from_metadata({"releases": {}})
+
+
 def test_package_accessors(package: Package) -> None:
     assert package.info == {"name": "Foo", "version": "0.1"}
     assert package.last_serial == 654_321

--- a/src/bandersnatch/tests/test_verify.py
+++ b/src/bandersnatch/tests/test_verify.py
@@ -493,7 +493,9 @@ def _pkg_json(filename: str, url: str, sha256: str, size: int) -> str:
 
 
 @pytest.mark.asyncio
-async def test_verify_skips_invalid_metadata(tmp_path: Path) -> None:
+async def test_verify_skips_invalid_metadata(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
     """verify() skips JSON that parses but lacks required PyPI metadata."""
     jsonpath = tmp_path / "web" / "json"
     jsonpath.mkdir(parents=True)
@@ -510,11 +512,55 @@ async def test_verify_skips_invalid_metadata(tmp_path: Path) -> None:
     master = Master(fc.get("mirror", "master"))
     all_files: list[PATH_TYPES] = []
 
-    await verify(
-        master, fc, storage_backend, "badpackage", tmp_path, all_files, FakeArgs()  # type: ignore
-    )
+    with caplog.at_level("ERROR"):
+        await verify(
+            master,
+            fc,  # type: ignore[arg-type]
+            storage_backend,
+            "badpackage",
+            tmp_path,
+            all_files,
+            FakeArgs(),  # type: ignore[arg-type]
+        )
 
     assert all_files == []
+    assert "into a Package" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_verify_skips_malformed_json(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """verify() skips JSON files that fail to parse."""
+    jsonpath = tmp_path / "web" / "json"
+    jsonpath.mkdir(parents=True)
+    (jsonpath / "badpackage").write_text("{not valid json")
+
+    class FakeArgs:
+        dry_run = False
+        json_update = False
+        delete = False
+        workers = 1
+
+    fc = FakeConfig()
+    storage_backend = _make_fs_storage(tmp_path)
+    master = Master(fc.get("mirror", "master"))
+    all_files: list[PATH_TYPES] = []
+
+    with caplog.at_level("ERROR"):
+        await verify(
+            master,
+            fc,  # type: ignore[arg-type]
+            storage_backend,
+            "badpackage",
+            tmp_path,
+            all_files,
+            FakeArgs(),  # type: ignore[arg-type]
+        )
+
+    assert all_files == []
+    assert "metadata:" in caplog.text
+    assert "into a Package" not in caplog.text
 
 
 @pytest.mark.asyncio

--- a/src/bandersnatch/tests/test_verify.py
+++ b/src/bandersnatch/tests/test_verify.py
@@ -493,6 +493,31 @@ def _pkg_json(filename: str, url: str, sha256: str, size: int) -> str:
 
 
 @pytest.mark.asyncio
+async def test_verify_skips_invalid_metadata(tmp_path: Path) -> None:
+    """verify() skips JSON that parses but lacks required PyPI metadata."""
+    jsonpath = tmp_path / "web" / "json"
+    jsonpath.mkdir(parents=True)
+    (jsonpath / "badpackage").write_text(json.dumps({"releases": {}}))
+
+    class FakeArgs:
+        dry_run = False
+        json_update = False
+        delete = False
+        workers = 1
+
+    fc = FakeConfig()
+    storage_backend = _make_fs_storage(tmp_path)
+    master = Master(fc.get("mirror", "master"))
+    all_files: list[PATH_TYPES] = []
+
+    await verify(
+        master, fc, storage_backend, "badpackage", tmp_path, all_files, FakeArgs()  # type: ignore
+    )
+
+    assert all_files == []
+
+
+@pytest.mark.asyncio
 async def test_verify_dry_run_logs_but_does_not_fetch(tmp_path: Path) -> None:
     """verify() logs [DRY RUN] and never calls fetch_and_store when dry_run=True."""
     content = b"wheel content"

--- a/src/bandersnatch/verify.py
+++ b/src/bandersnatch/verify.py
@@ -167,13 +167,15 @@ async def verify(
         with storage_backend.open_file(json_full_path, text=True) as jfp:
             metadata = json.load(jfp)
     except json.decoder.JSONDecodeError as jde:
-        logger.error(f"Failed to load {json_full_path}: {jde} - skipping ...")
+        logger.error(f"Failed to load {json_full_path} metadata: {jde} - skipping ...")
         return
 
     try:
         pkg = Package.from_metadata(metadata)
     except ValueError as e:
-        logger.error(f"Failed to load {json_full_path}: {e} - skipping ...")
+        logger.error(
+            f"Failed to load {json_full_path} into a Package: {e} - skipping ..."
+        )
         return
 
     # apply releases filter plugins like class Package

--- a/src/bandersnatch/verify.py
+++ b/src/bandersnatch/verify.py
@@ -165,18 +165,21 @@ async def verify(
 
     try:
         with storage_backend.open_file(json_full_path, text=True) as jfp:
-            pkg = json.load(jfp)
+            metadata = json.load(jfp)
     except json.decoder.JSONDecodeError as jde:
         logger.error(f"Failed to load {json_full_path}: {jde} - skipping ...")
         return
 
+    try:
+        pkg = Package.from_metadata(metadata)
+    except ValueError as e:
+        logger.error(f"Failed to load {json_full_path}: {e} - skipping ...")
+        return
+
     # apply releases filter plugins like class Package
-    pkg_c = Package(pkg["info"]["name"])
-    # TODO: Maybe make a load_metadata method in Package
-    pkg_c._metadata = pkg
-    pkg = pkg_c
-    pkg.filter_all_releases_files(LoadedFilters().filter_release_file_plugins())
-    pkg.filter_all_releases(LoadedFilters().filter_release_plugins())
+    loaded_filters = LoadedFilters()
+    pkg.filter_all_releases_files(loaded_filters.filter_release_file_plugins())
+    pkg.filter_all_releases(loaded_filters.filter_release_plugins())
 
     # Build the expected FileSpec list for all release files in this package.
     specs: list[FileSpec] = []

--- a/src/bandersnatch_storage_plugins/filesystem.py
+++ b/src/bandersnatch_storage_plugins/filesystem.py
@@ -268,19 +268,15 @@ class FilesystemStorage(StoragePlugin):
         return path.is_file()
 
     def get_hash(self, path: PATH_TYPES, function: str = "sha256") -> str:
-        h = getattr(hashlib, function)()
         if not isinstance(path, pathlib.Path):
             path = pathlib.Path(path)
         logger.debug(
             f"Opening {path.as_posix()} in binary mode for hash calculation..."
         )
         with open(path.absolute().as_posix(), "rb") as f:
-            for chunk in iter(lambda: f.read(128 * 1024), b""):
-                logger.debug(f"Read chunk: {chunk!s}")
-                h.update(chunk)
-        digest = h.hexdigest()
+            digest = hashlib.file_digest(f, function).hexdigest()
         logger.debug(f"Calculated digest: {digest!s}")
-        return str(h.hexdigest())
+        return digest
 
     def get_file_size(self, path: PATH_TYPES) -> int:
         """Return the file size of provided path."""

--- a/src/bandersnatch_storage_plugins/filesystem.py
+++ b/src/bandersnatch_storage_plugins/filesystem.py
@@ -276,7 +276,7 @@ class FilesystemStorage(StoragePlugin):
         with open(path.absolute().as_posix(), "rb") as f:
             digest = hashlib.file_digest(f, function).hexdigest()
         logger.debug(f"Calculated digest: {digest!s}")
-        return digest
+        return str(digest)
 
     def get_file_size(self, path: PATH_TYPES) -> int:
         """Return the file size of provided path."""


### PR DESCRIPTION
- get_hash() in file_system implements the same hashlib.file_digest as in utils hash() method.
- LoadedFilters() was initialized twice, moved the init outside
- Made a clean classmethod for package class to create a package object from a pkg dict