### PR TITLE
CI: add fail_ci_if_error to codecov upload steps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,7 @@ jobs:
         PYTHON: ${{ matrix.python-version }}
       with:
         env_vars: OS,PYTHON
+        fail_ci_if_error: true
         files: coverage.xml
         token: ${{ secrets.CODECOV_TOKEN }}
 

--- a/.github/workflows/ci_ubuntu.yml
+++ b/.github/workflows/ci_ubuntu.yml
@@ -59,6 +59,7 @@ jobs:
         PYTHON: ${{ matrix.python-version }}
       with:
         env_vars: OS,PYTHON
+        fail_ci_if_error: true
         files: coverage.xml
         token: ${{ secrets.CODECOV_TOKEN }}
 


### PR DESCRIPTION
## Summary

- Adds `fail_ci_if_error: true` to the `codecov/codecov-action` step in both `ci.yml` and `ci_ubuntu.yml`
- Ensures CI fails visibly if coverage upload to Codecov errors, rather than silently passing

## Test plan

- [ ] Confirm CI passes on this PR
- [ ] Verify the codecov upload step is present and configured correctly in both workflow files