### PR TITLE
Refactor mirror core

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,7 +8,7 @@
 - `bandersnatch verify` now honours `compare-method` and `digest_name` config settings (previously always performed a sha256 hash regardless of config). The S3 backend's `verify_files` honours `compare-method` too: `stat` mode trusts a matching upload time with no content read, while `hash` mode always confirms content.
 - S3 verify now back-fills hash metadata for legacy objects on first verify (unless `--dry-run`), making future runs use only fast `HeadObject` calls; upload time and digest are validated and stored via the storage backend, with `.s3keep` logic moved fully into the S3 plugin.
 - Core verify and mirror flows now rely on storage backend methods (`set_hash`, etc.) for hash and metadata handling, enabling backend-specific optimizations.
-- Mirror skip checks use `Storage.release_file_is_current()`; S3 certifies with one `HeadObject`, migrates legacy objects on first check, and stamps metadata on `PutObject`. Storage plugins must accept optional `file_metadata` on `rewrite()`.
+- Mirror skip checks use `Storage.release_file_is_current()`; S3 certifies with one `HeadObject`, migrates legacy objects on first check, and stamps metadata on `PutObject`. Storage plugins must accept optional `file_metadata` on `rewrite()`. `PR #2296 `
 - Remove legacy XML-RPC support paths; metadata sync now uses only the PEP 691 Simple API `PR #2276`
 - Allow configuring any PEP691 compliant digest that the index offers `PR #2262`
 - Use hashlib.file_digest() to calculate file hashes when verifying `PR #2277`

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,7 +8,7 @@
 - `bandersnatch verify` now honours `compare-method` and `digest_name` config settings (previously always performed a sha256 hash regardless of config). The S3 backend's `verify_files` honours `compare-method` too: `stat` mode trusts a matching upload time with no content read, while `hash` mode always confirms content.
 - S3 verify now back-fills hash metadata for legacy objects on first verify (unless `--dry-run`), making future runs use only fast `HeadObject` calls; upload time and digest are validated and stored via the storage backend, with `.s3keep` logic moved fully into the S3 plugin.
 - Core verify and mirror flows now rely on storage backend methods (`set_hash`, etc.) for hash and metadata handling, enabling backend-specific optimizations.
-- Mirror skip checks use `Storage.release_file_is_current()`; S3 certifies with one `HeadObject`, migrates legacy objects on first check, and stamps metadata on `PutObject`. Storage plugins must accept optional `file_metadata` on `rewrite()`. `PR #2296 `
+- Mirror skip checks use `Storage.release_file_is_current()`; S3 certifies with one `HeadObject`, migrates legacy objects on first check, and stamps metadata on `PutObject`. Storage plugins must accept optional `file_metadata` on `rewrite()`. `PR #2296`
 - Remove legacy XML-RPC support paths; metadata sync now uses only the PEP 691 Simple API `PR #2276`
 - Allow configuring any PEP691 compliant digest that the index offers `PR #2262`
 - Use hashlib.file_digest() to calculate file hashes when verifying `PR #2277`

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,7 @@
 - `bandersnatch verify` now honours `compare-method` and `digest_name` config settings (previously always performed a sha256 hash regardless of config). The S3 backend's `verify_files` honours `compare-method` too: `stat` mode trusts a matching upload time with no content read, while `hash` mode always confirms content.
 - S3 verify now back-fills hash metadata for legacy objects on first verify (unless `--dry-run`), making future runs use only fast `HeadObject` calls; upload time and digest are validated and stored via the storage backend, with `.s3keep` logic moved fully into the S3 plugin.
 - Core verify and mirror flows now rely on storage backend methods (`set_hash`, etc.) for hash and metadata handling, enabling backend-specific optimizations.
+- Mirror skip checks use `Storage.release_file_is_current()`; S3 certifies with one `HeadObject`, migrates legacy objects on first check, and stamps metadata on `PutObject`. Storage plugins must accept optional `file_metadata` on `rewrite()`.
 - Remove legacy XML-RPC support paths; metadata sync now uses only the PEP 691 Simple API `PR #2276`
 - Allow configuring any PEP691 compliant digest that the index offers `PR #2262`
 - Use hashlib.file_digest() to calculate file hashes when verifying `PR #2277`

--- a/docs/storage_options.md
+++ b/docs/storage_options.md
@@ -99,6 +99,13 @@ S3 uses automatic rate-limiting (adaptive retry mode), so transient errors are
 usually absorbed silently. Raise this only if you still see throttling warnings
 during large verify runs.
 
+#### Release-file metadata
+
+S3 objects store `sha256` and `uploaded-at` metadata so mirror sync and verify
+can skip unchanged files with a single `HeadObject`. Legacy objects are upgraded
+automatically on first successful check; run `bandersnatch verify` once after
+upgrading to migrate the whole bucket. No extra configuration is required.
+
 ### Serving your Mirror
 
 S3 Bandersnatch mirrors are designed to be served with s3 static sites and

--- a/src/bandersnatch/mirror.py
+++ b/src/bandersnatch/mirror.py
@@ -813,65 +813,19 @@ class BandersnatchMirror(Mirror):
             path = self._file_url_to_local_path(url)
         loop = asyncio.get_running_loop()
 
-        # Avoid downloading again if we have the file and it matches the hash.
-        if await loop.run_in_executor(self.storage_backend.executor, path.exists):
-            existing_file_size = await loop.run_in_executor(
-                self.storage_backend.executor, self.storage_backend.get_file_size, path
-            )
-            if existing_file_size != int(file_size):
-                logger.info(
-                    f"File size mismatch with local file {path}: expected {file_size} "
-                    + f"got {existing_file_size}, will re-download."
-                )
-                await loop.run_in_executor(self.storage_backend.executor, path.unlink)
-            elif self.compare_method == "stat":
-                existing_upload_time = await loop.run_in_executor(
-                    self.storage_backend.executor,
-                    self.storage_backend.get_upload_time,
-                    path,
-                )
-                if existing_upload_time == upload_time:
-                    return None
-                else:
-                    existing_hash = await loop.run_in_executor(
-                        self.storage_backend.executor,
-                        self.storage_backend.get_hash,
-                        str(path),
-                    )
-                    if existing_hash != sha256sum:
-                        logger.info(
-                            "File upload time and checksum mismatch with local "
-                            + f"file {path}: expected "
-                            + f"{sha256sum} got {existing_hash}, will re-download."
-                        )
-                        await loop.run_in_executor(
-                            self.storage_backend.executor, path.unlink
-                        )
-                    else:
-                        logger.info(f"Updating file upload time of local file {path}.")
-                        await loop.run_in_executor(
-                            self.storage_backend.executor,
-                            self.storage_backend.set_upload_time,
-                            path,
-                            upload_time,
-                        )
-                        return None
-            else:
-                existing_hash = await loop.run_in_executor(
-                    self.storage_backend.executor,
-                    self.storage_backend.get_hash,
-                    str(path),
-                )
-                if existing_hash == sha256sum:
-                    return None
-                else:
-                    logger.info(
-                        f"File checksum mismatch with local file {path}: expected "
-                        + f"{sha256sum} got {existing_hash}, will re-download."
-                    )
-                    await loop.run_in_executor(
-                        self.storage_backend.executor, path.unlink
-                    )
+        is_current = await loop.run_in_executor(
+            self.storage_backend.executor,
+            lambda: self.storage_backend.release_file_is_current(
+                path,
+                size=int(file_size),
+                upload_time=upload_time,
+                digest=sha256sum,
+                compare_method=self.compare_method,
+                digest_name=self.digest_name,
+            ),
+        )
+        if is_current:
+            return None
 
         logger.info(f"Downloading: {url}")
         await fetch_and_store(
@@ -915,26 +869,41 @@ async def fetch_and_store(
     response = await r_generator.asend(None)
 
     checksum = hashlib.new(digest_name)
-    with storage_backend.rewrite(path, "wb") as f:
-        while True:
-            chunk = await response.content.read(chunk_size)
-            if not chunk:
-                break
-            checksum.update(chunk)
-            f.write(chunk)
+    file_metadata = storage_backend.build_release_file_metadata(
+        digest, upload_time, digest_name
+    )
+    digest_mismatch = False
+    try:
+        with storage_backend.rewrite(path, "wb", file_metadata=file_metadata) as f:
+            while True:
+                chunk = await response.content.read(chunk_size)
+                if not chunk:
+                    break
+                checksum.update(chunk)
+                f.write(chunk)
 
-        existing_hash = checksum.hexdigest()
-        if existing_hash != digest:
-            # Bad case: the file we got does not match the expected
-            # checksum. Even if this should be the rare case of a
-            # re-upload this will fix itself in a later run.
-            raise ValueError(
-                f"Inconsistent file. {url} has hash {existing_hash} "
-                + f"instead of {digest}."
-            )
+            existing_hash = checksum.hexdigest()
+            if existing_hash != digest:
+                # Bad case: the file we got does not match the expected
+                # checksum. Even if this should be the rare case of a
+                # re-upload this will fix itself in a later run.
+                digest_mismatch = True
+                raise ValueError(
+                    f"Inconsistent file. {url} has hash {existing_hash} "
+                    + f"instead of {digest}."
+                )
+    except ValueError:
+        # delete that bad file
+        if (
+            digest_mismatch
+            and storage_backend.stamps_metadata_on_write()
+            and storage_backend.exists(path)
+        ):
+            storage_backend.delete_file(path)
+        raise
 
-    # set upload time and hash to avoid downloading again in next sync
-    storage_backend.stamp_file_metadata(path, digest, upload_time, digest_name)
+    if not storage_backend.stamps_metadata_on_write():
+        storage_backend.stamp_file_metadata(path, digest, upload_time, digest_name)
 
 
 async def _setup_diff_file(

--- a/src/bandersnatch/storage.py
+++ b/src/bandersnatch/storage.py
@@ -13,6 +13,7 @@ from collections import defaultdict
 from collections.abc import AsyncIterator, Generator, Iterable, Iterator, Sequence
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
+from enum import Enum
 from importlib.metadata import entry_points
 from typing import IO, Any, Protocol
 
@@ -48,6 +49,14 @@ class FileSpec:
 loaded_storage_plugins: dict[str, list["Storage"]] = defaultdict(list)
 
 logger = logging.getLogger("bandersnatch")
+
+
+class ReleaseFileStatus(Enum):
+    """Outcome of certifying a stored release file against expected attributes."""
+
+    CURRENT = "current"
+    MISSING = "missing"
+    MISMATCH = "mismatch"
 
 
 class StorageDirEntry(Protocol):
@@ -179,11 +188,87 @@ class Storage:
 
     @contextlib.contextmanager
     def rewrite(
-        self, filepath: PATH_TYPES, mode: str = "w", **kw: Any
+        self,
+        filepath: PATH_TYPES,
+        mode: str = "w",
+        file_metadata: dict[str, str] | None = None,
+        **kw: Any,
     ) -> Generator[IO, None, None]:
         """Rewrite an existing file atomically to avoid programs running in
-        parallel to have race conditions while reading."""
+        parallel to have race conditions while reading.
+
+        Storage plugins must accept ``file_metadata`` (even if ignored) so mirror
+        sync can attach backend-specific certifying metadata on upload.
+        """
         raise NotImplementedError
+
+    def build_release_file_metadata(
+        self,
+        digest: str,
+        upload_time: datetime.datetime,
+        digest_name: str = "sha256",
+    ) -> dict[str, str] | None:
+        """Return object metadata to attach at upload time, or None if unsupported."""
+        return None
+
+    def stamps_metadata_on_write(self) -> bool:
+        """True when ``rewrite(..., file_metadata=...)`` stores metadata on upload."""
+        return False
+
+    def release_file_is_current(
+        self,
+        path: PATH_TYPES,
+        *,
+        size: int,
+        upload_time: datetime.datetime,
+        digest: str,
+        compare_method: str = "hash",
+        digest_name: str = "sha256",
+    ) -> bool:
+        """
+        Return True when the stored release file matches expected attributes and
+        a download can be skipped.
+
+        When ``compare_method`` is ``stat`` and upload time differs but content
+        still matches ``digest``, metadata is refreshed in place (via
+        ``set_upload_time``) and True is returned.
+
+        If the file exists but content does not match, it is deleted and False
+        is returned.
+        """
+        if not self.exists(path):
+            return False
+        if size and self.get_file_size(path) != size:
+            logger.info(
+                f"File size mismatch with local file {path}: expected {size} "
+                f"got {self.get_file_size(path)}, will re-download."
+            )
+            self.delete_file(path)
+            return False
+        if compare_method == "stat":
+            if self.get_upload_time(path) == upload_time:
+                return True
+            existing_hash = self.get_hash(path, digest_name)
+            if existing_hash != digest:
+                logger.info(
+                    "File upload time and checksum mismatch with local "
+                    f"file {path}: expected {digest} got {existing_hash}, "
+                    "will re-download."
+                )
+                self.delete_file(path)
+                return False
+            logger.info(f"Updating file upload time of local file {path}.")
+            self.set_upload_time(path, upload_time)
+            return True
+        existing_hash = self.get_hash(path, digest_name)
+        if existing_hash == digest:
+            return True
+        logger.info(
+            f"File checksum mismatch with local file {path}: expected "
+            f"{digest} got {existing_hash}, will re-download."
+        )
+        self.delete_file(path)
+        return False
 
     @contextlib.contextmanager
     def update_safe(self, filename: PATH_TYPES, **kw: Any) -> Generator[IO, None, None]:

--- a/src/bandersnatch/storage.py
+++ b/src/bandersnatch/storage.py
@@ -238,10 +238,12 @@ class Storage:
         """
         if not self.exists(path):
             return False
-        if size and self.get_file_size(path) != size:
+
+        actual_size = self.get_file_size(path)
+        if actual_size != size:
             logger.info(
                 f"File size mismatch with local file {path}: expected {size} "
-                f"got {self.get_file_size(path)}, will re-download."
+                f"got {actual_size}, will re-download."
             )
             self.delete_file(path)
             return False

--- a/src/bandersnatch/tests/plugins/test_storage_plugin_s3.py
+++ b/src/bandersnatch/tests/plugins/test_storage_plugin_s3.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import UTC, datetime
 
 import pytest
 from s3path import S3Path, configuration_map
@@ -825,3 +825,354 @@ async def test_verify_files_s3_empty_specs(s3_mock: S3Path) -> None:
     backend = s3.S3Storage()
     bad = [s async for s in backend.verify_files([])]
     assert bad == []
+
+
+def test_release_file_is_current_uses_single_head_object(s3_mock: S3Path) -> None:
+    """release_file_is_current checks stored metadata with one HeadObject call."""
+    import hashlib
+
+    backend = s3.S3Storage()
+    bucket = s3_mock.bucket
+    content = b"release wheel payload"
+    path = f"/{bucket}/web/packages/aa/bb/pkg-1.0.whl"
+    digest = hashlib.sha256(content).hexdigest()
+    upload_time = datetime(2024, 6, 1, 12, 0, 0, tzinfo=UTC)
+    backend.write_file(path, content)
+    backend.stamp_file_metadata(path, digest, upload_time)
+
+    s3path_obj = s3.S3Path(path)
+    resource, _ = configuration_map.get_configuration(s3path_obj)
+    client = resource.meta.client
+
+    head_calls: list[dict] = []
+    original_head = client.head_object
+
+    def counting_head(**kwargs: object) -> object:
+        head_calls.append(kwargs)
+        return original_head(**kwargs)
+
+    client.head_object = counting_head
+    try:
+        assert backend.release_file_is_current(
+            path,
+            size=len(content),
+            upload_time=upload_time,
+            digest=digest,
+        )
+    finally:
+        client.head_object = original_head
+
+    assert len(head_calls) == 1
+
+
+def test_release_file_is_current_stat_mode(s3_mock: S3Path) -> None:
+    """In compare-method=stat, upload time alone certifies the file."""
+    backend = s3.S3Storage()
+    bucket = s3_mock.bucket
+    path = f"/{bucket}/web/packages/aa/bb/pkg-stat.whl"
+    upload_time = datetime(2025, 3, 1, tzinfo=UTC)
+    backend.write_file(path, b"")
+    backend.stamp_file_metadata(path, "wrong" * 12 + "0000", upload_time)
+
+    assert backend.release_file_is_current(
+        path,
+        size=0,
+        upload_time=upload_time,
+        digest="deadbeef" * 8,
+        compare_method="stat",
+    )
+
+
+def test_release_file_is_current_stat_refreshes_upload_time_when_hash_matches(
+    s3_mock: S3Path,
+) -> None:
+    """In stat mode a stale upload time is refreshed when stored hash matches."""
+    backend = s3.S3Storage()
+    bucket = s3_mock.bucket
+    path = f"/{bucket}/web/packages/aa/bb/pkg-stat-refresh.whl"
+    stored_time = datetime(2020, 1, 1, tzinfo=UTC)
+    expected_time = datetime(2025, 1, 1, tzinfo=UTC)
+    backend.write_file(path, b"")
+    backend.stamp_file_metadata(path, "abc" * 16, stored_time)
+
+    assert backend.release_file_is_current(
+        path,
+        size=0,
+        upload_time=expected_time,
+        digest="abc" * 16,
+        compare_method="stat",
+    )
+    assert backend.exists(path)
+    assert backend.get_upload_time(path) == expected_time
+
+
+def test_release_file_is_current_stat_deletes_when_content_mismatch(
+    s3_mock: S3Path,
+) -> None:
+    """In stat mode stale upload time with wrong content triggers re-download."""
+    backend = s3.S3Storage()
+    bucket = s3_mock.bucket
+    path = f"/{bucket}/web/packages/aa/bb/pkg-stat-bad.whl"
+    content = b"wheel bytes"
+    stored_time = datetime(2020, 1, 1, tzinfo=UTC)
+    expected_time = datetime(2025, 1, 1, tzinfo=UTC)
+    backend.write_file(path, content)
+    backend.set_upload_time(path, stored_time)
+
+    assert not backend.release_file_is_current(
+        path,
+        size=len(content),
+        upload_time=expected_time,
+        digest="deadbeef" * 8,
+        compare_method="stat",
+    )
+    assert not backend.exists(path)
+
+
+def test_rewrite_with_file_metadata_on_upload(s3_mock: S3Path) -> None:
+    """rewrite(..., file_metadata=...) attaches metadata on the initial upload."""
+    import hashlib
+
+    backend = s3.S3Storage()
+    bucket = s3_mock.bucket
+    path = f"/{bucket}/web/packages/aa/bb/pkg-meta.whl"
+    content = b"wheel with metadata"
+    digest = hashlib.sha256(content).hexdigest()
+    upload_time = datetime(2024, 1, 2, tzinfo=UTC)
+    metadata = backend.build_release_file_metadata(digest, upload_time)
+
+    with backend.rewrite(path, "wb", file_metadata=metadata) as fp:
+        fp.write(content)
+
+    assert backend.get_hash(path) == digest
+    assert backend.get_upload_time(path) == upload_time
+
+
+@pytest.mark.asyncio
+async def test_fetch_and_store_s3_skips_post_upload_copy(s3_mock: S3Path) -> None:
+    """fetch_and_store on S3 stamps metadata on PUT and does not CopyObject after."""
+    import hashlib
+    import unittest.mock as mock
+    from collections.abc import AsyncGenerator
+
+    from bandersnatch.mirror import fetch_and_store
+
+    backend = s3.S3Storage()
+    bucket = s3_mock.bucket
+    content = b"fresh download payload"
+    digest = hashlib.sha256(content).hexdigest()
+    upload_time = datetime(2024, 7, 1, tzinfo=UTC)
+    path = f"/{bucket}/web/packages/cc/dd/fresh-1.0.whl"
+    url = "https://example.com/packages/cc/dd/fresh-1.0.whl"
+
+    class _Content:
+        def __init__(self) -> None:
+            self._done = False
+
+        async def read(self, _: int) -> bytes:
+            if self._done:
+                return b""
+            self._done = True
+            return content
+
+    async def _fake_get(
+        url: str, required_serial: object, **kw: object
+    ) -> AsyncGenerator[mock.MagicMock, None]:
+        response = mock.MagicMock()
+        response.content = _Content()
+        yield response
+
+    fake_master = mock.MagicMock()
+    fake_master.get = _fake_get
+
+    s3path_obj = s3.S3Path(path)
+    resource, _ = configuration_map.get_configuration(s3path_obj)
+    client = resource.meta.client
+
+    copy_calls: list[dict] = []
+    original_copy = client.copy_object
+
+    def counting_copy(**kwargs: object) -> object:
+        copy_calls.append(kwargs)
+        return original_copy(**kwargs)
+
+    client.copy_object = counting_copy
+    try:
+        with mock.patch.object(backend, "stamp_file_metadata") as stamp_mock:
+            await fetch_and_store(fake_master, backend, url, path, digest, upload_time)
+            stamp_mock.assert_not_called()
+    finally:
+        client.copy_object = original_copy
+
+    assert len(copy_calls) == 0
+    assert backend.get_hash(path) == digest
+    assert backend.get_upload_time(path) == upload_time
+
+
+def test_release_file_is_current_legacy_backfills_hash(s3_mock: S3Path) -> None:
+    """Legacy skip-check back-fills sha256 metadata so the next check is HEAD-only."""
+    import hashlib
+
+    backend = s3.S3Storage()
+    bucket = s3_mock.bucket
+    content = b"legacy wheel bytes"
+    path = f"/{bucket}/web/packages/aa/bb/mirror-legacy-1.0.whl"
+    backend.write_file(path, content)
+    sha = hashlib.sha256(content).hexdigest()
+    upload_time = datetime(2024, 1, 1, tzinfo=UTC)
+
+    resource, _ = configuration_map.get_configuration(s3.S3Path(path))
+    obj = resource.Object(bucket, "web/packages/aa/bb/mirror-legacy-1.0.whl")
+    obj.load()
+    assert "sha256" not in obj.metadata
+
+    assert backend.release_file_is_current(
+        path,
+        size=len(content),
+        upload_time=upload_time,
+        digest=sha,
+    )
+
+    obj.load()
+    assert obj.metadata.get("sha256") == sha
+
+
+def test_release_file_is_current_legacy_backfill_preserves_uploaded_at(
+    s3_mock: S3Path,
+) -> None:
+    """Mirror legacy back-fill must preserve existing uploaded-at metadata."""
+    import hashlib
+
+    backend = s3.S3Storage()
+    bucket = s3_mock.bucket
+    content = b"legacy wheel with upload time"
+    path = f"/{bucket}/web/packages/aa/bb/mirror-legacy-preserved.whl"
+    backend.write_file(path, content)
+    upload_time = datetime(2023, 6, 1, tzinfo=UTC)
+    backend.set_upload_time(path, upload_time)
+    sha = hashlib.sha256(content).hexdigest()
+
+    assert backend.release_file_is_current(
+        path,
+        size=len(content),
+        upload_time=upload_time,
+        digest=sha,
+    )
+
+    resource, _ = configuration_map.get_configuration(s3.S3Path(path))
+    obj = resource.Object(bucket, "web/packages/aa/bb/mirror-legacy-preserved.whl")
+    obj.load()
+    assert obj.metadata.get("sha256") == sha
+    assert backend.get_upload_time(path) == upload_time
+
+
+def test_release_file_is_current_legacy_second_check_is_head_only(
+    s3_mock: S3Path,
+) -> None:
+    """After back-fill, release_file_is_current uses HeadObject only."""
+    import hashlib
+
+    backend = s3.S3Storage()
+    bucket = s3_mock.bucket
+    content = b"legacy wheel bytes"
+    path = f"/{bucket}/web/packages/aa/bb/mirror-legacy-headonly.whl"
+    backend.write_file(path, content)
+    sha = hashlib.sha256(content).hexdigest()
+    upload_time = datetime(2024, 1, 1, tzinfo=UTC)
+
+    assert backend.release_file_is_current(
+        path,
+        size=len(content),
+        upload_time=upload_time,
+        digest=sha,
+    )
+
+    s3path_obj = s3.S3Path(path)
+    resource, _ = configuration_map.get_configuration(s3path_obj)
+    client = resource.meta.client
+
+    head_calls: list[dict] = []
+    get_calls: list[dict] = []
+    original_head = client.head_object
+    original_get = client.get_object
+
+    def counting_head(**kwargs: object) -> object:
+        head_calls.append(kwargs)
+        return original_head(**kwargs)
+
+    def counting_get(**kwargs: object) -> object:
+        get_calls.append(kwargs)
+        return original_get(**kwargs)
+
+    client.head_object = counting_head
+    client.get_object = counting_get
+    try:
+        assert backend.release_file_is_current(
+            path,
+            size=len(content),
+            upload_time=upload_time,
+            digest=sha,
+        )
+    finally:
+        client.head_object = original_head
+        client.get_object = original_get
+
+    assert len(head_calls) == 1
+    assert len(get_calls) == 0
+
+
+@pytest.mark.asyncio
+async def test_fetch_and_store_s3_deletes_on_digest_mismatch(s3_mock: S3Path) -> None:
+    """A digest mismatch must not leave a trusted-metadata object in S3."""
+    import unittest.mock as mock
+    from collections.abc import AsyncGenerator
+
+    import pytest
+
+    from bandersnatch.mirror import fetch_and_store
+
+    backend = s3.S3Storage()
+    bucket = s3_mock.bucket
+    key = "web/packages/aa/bb/mismatch-1.0.whl"
+    content = b"the actual served bytes"
+    wrong_sha = "deadbeef" * 8
+    upload_time = datetime(2024, 3, 15, tzinfo=UTC)
+    path = f"/{bucket}/{key}"
+    url = "https://example.com/packages/aa/bb/mismatch-1.0.whl"
+
+    resource, _ = configuration_map.get_configuration(s3.S3Path(f"/{bucket}"))
+    resource.meta.client.put_object(
+        Bucket=bucket,
+        Key=key,
+        Body=content,
+        Metadata={
+            "sha256": wrong_sha,
+            backend.UPLOAD_TIME_METADATA_KEY: str(upload_time.timestamp()),
+        },
+    )
+    assert backend.exists(path)
+
+    class _Content:
+        def __init__(self) -> None:
+            self._done = False
+
+        async def read(self, _: int) -> bytes:
+            if self._done:
+                return b""
+            self._done = True
+            return content
+
+    async def _fake_get(
+        url: str, required_serial: object, **kw: object
+    ) -> AsyncGenerator[mock.MagicMock, None]:
+        response = mock.MagicMock()
+        response.content = _Content()
+        yield response
+
+    fake_master = mock.MagicMock()
+    fake_master.get = _fake_get
+
+    with pytest.raises(ValueError, match="Inconsistent file"):
+        await fetch_and_store(fake_master, backend, url, path, wrong_sha, upload_time)
+
+    assert not backend.exists(path)

--- a/src/bandersnatch/tests/plugins/test_storage_plugin_s3.py
+++ b/src/bandersnatch/tests/plugins/test_storage_plugin_s3.py
@@ -1176,3 +1176,236 @@ async def test_fetch_and_store_s3_deletes_on_digest_mismatch(s3_mock: S3Path) ->
         await fetch_and_store(fake_master, backend, url, path, wrong_sha, upload_time)
 
     assert not backend.exists(path)
+
+
+def test_release_file_is_current_missing_returns_false(s3_mock: S3Path) -> None:
+    """A missing object is not current and must not be deleted."""
+    backend = s3.S3Storage()
+    path = f"/{s3_mock.bucket}/web/packages/aa/bb/does-not-exist.whl"
+
+    assert not backend.release_file_is_current(
+        path,
+        size=10,
+        upload_time=datetime(2024, 1, 1, tzinfo=UTC),
+        digest="abc" * 16,
+    )
+
+
+def test_release_file_is_current_hash_mismatch_deletes(s3_mock: S3Path) -> None:
+    """Wrong stored hash triggers delete and re-download."""
+    backend = s3.S3Storage()
+    bucket = s3_mock.bucket
+    path = f"/{bucket}/web/packages/aa/bb/hash-mismatch.whl"
+    content = b"wheel payload"
+    upload_time = datetime(2024, 1, 1, tzinfo=UTC)
+    backend.write_file(path, content)
+    backend.stamp_file_metadata(path, "deadbeef" * 8, upload_time)
+
+    assert not backend.release_file_is_current(
+        path,
+        size=len(content),
+        upload_time=upload_time,
+        digest="abc" * 16,
+    )
+    assert not backend.exists(path)
+
+
+def test_release_file_is_current_size_mismatch_deletes(s3_mock: S3Path) -> None:
+    """Wrong ContentLength triggers delete and re-download."""
+    import hashlib
+
+    backend = s3.S3Storage()
+    bucket = s3_mock.bucket
+    content = b"wheel payload"
+    path = f"/{bucket}/web/packages/aa/bb/size-mismatch.whl"
+    digest = hashlib.sha256(content).hexdigest()
+    upload_time = datetime(2024, 1, 1, tzinfo=UTC)
+    backend.write_file(path, content)
+    backend.stamp_file_metadata(path, digest, upload_time)
+
+    assert not backend.release_file_is_current(
+        path,
+        size=len(content) + 1,
+        upload_time=upload_time,
+        digest=digest,
+    )
+    assert not backend.exists(path)
+
+
+def test_upload_time_from_head_rejects_invalid_metadata(s3_mock: S3Path) -> None:
+    backend = s3.S3Storage()
+    assert (
+        backend._upload_time_from_head({"Metadata": {"uploaded-at": "not-a-ts"}})
+        is None
+    )
+    assert backend._upload_time_from_head({"Metadata": {}}) is None
+
+
+def test_release_file_is_current_stat_legacy_backfills_hash_and_upload_time(
+    s3_mock: S3Path,
+) -> None:
+    """Stat mode with legacy object back-fills hash and refreshed upload time."""
+    import hashlib
+
+    backend = s3.S3Storage()
+    bucket = s3_mock.bucket
+    content = b"legacy stat wheel"
+    path = f"/{bucket}/web/packages/aa/bb/stat-legacy-backfill.whl"
+    stored_time = datetime(2020, 1, 1, tzinfo=UTC)
+    expected_time = datetime(2025, 6, 1, tzinfo=UTC)
+    sha = hashlib.sha256(content).hexdigest()
+    backend.write_file(path, content)
+    backend.set_upload_time(path, stored_time)
+
+    assert backend.release_file_is_current(
+        path,
+        size=len(content),
+        upload_time=expected_time,
+        digest=sha,
+        compare_method="stat",
+    )
+
+    assert backend.get_hash(path) == sha
+    assert backend.get_upload_time(path) == expected_time
+
+
+def test_certify_from_head_dry_run_logs_stat_refresh(
+    s3_mock: S3Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Dry-run certify logs when upload time would be refreshed."""
+    import logging
+
+    backend = s3.S3Storage()
+    bucket = s3_mock.bucket
+    key = "web/packages/aa/bb/dry-run-stat.whl"
+    path = f"/{bucket}/{key}"
+    digest = "abc" * 16
+    stored_time = datetime(2020, 1, 1, tzinfo=UTC)
+    expected_time = datetime(2025, 1, 1, tzinfo=UTC)
+    backend.write_file(path, b"")
+    backend.stamp_file_metadata(path, digest, stored_time)
+
+    resource, _ = configuration_map.get_configuration(s3.S3Path(path))
+    client = resource.meta.client
+    head = client.head_object(Bucket=bucket, Key=key)
+
+    from bandersnatch.storage import ReleaseFileStatus
+
+    with caplog.at_level(logging.DEBUG, logger="bandersnatch"):
+        status = backend._certify_from_head(
+            client,
+            bucket,
+            key,
+            head,
+            size=0,
+            upload_time=expected_time,
+            digest=digest,
+            compare_method="stat",
+            digest_name="sha256",
+            backfill=False,
+            would_backfill_label="dry-run-stat.whl",
+            refresh_stale_metadata=True,
+        )
+
+    assert status is ReleaseFileStatus.CURRENT
+    assert "[DRY RUN] would refresh upload time metadata" in caplog.text
+
+
+def test_rewrite_with_file_metadata_restores_explicit_config(
+    s3_mock: S3Path,
+) -> None:
+    """rewrite(..., file_metadata=...) restores per-path params after upload."""
+    import hashlib
+
+    config = mock_config("""
+[mirror]
+directory = /tmp/pypi
+json = true
+master = https://pypi.org
+timeout = 60
+global-timeout = 18000
+workers = 3
+hash-index = true
+stop-on-error = true
+storage-backend = s3
+verifiers = 3
+keep_index_versions = 2
+compare-method = hash
+[s3]
+region_name = us-east-1
+aws_access_key_id = 123456
+aws_secret_access_key = 123456
+endpoint_url = http://localhost:9090
+signature_version = s3v4
+config_param_ServerSideEncryption = AES256
+""")
+    backend = s3.S3Storage(config=config)
+    backend.initialize_plugin()
+
+    bucket = s3_mock.bucket
+    path = f"/{bucket}/web/packages/aa/bb/config-meta.whl"
+    content = b"wheel with sse metadata"
+    digest = hashlib.sha256(content).hexdigest()
+    upload_time = datetime(2024, 1, 2, tzinfo=UTC)
+    metadata = backend.build_release_file_metadata(digest, upload_time)
+
+    with backend.rewrite(path, "wb", file_metadata=metadata) as fp:
+        fp.write(content)
+
+    assert backend.get_hash(path) == digest
+    assert backend.get_upload_time(path) == upload_time
+    assert backend._copy_object_kwargs()["ServerSideEncryption"] == "AES256"
+
+
+def test_release_file_is_current_accepts_str_path(s3_mock: S3Path) -> None:
+    """release_file_is_current coerces plain paths to the S3 path backend."""
+    import hashlib
+
+    backend = s3.S3Storage()
+    bucket = s3_mock.bucket
+    content = b"str path wheel"
+    rel = f"/{bucket}/web/packages/aa/bb/str-path.whl"
+    digest = hashlib.sha256(content).hexdigest()
+    upload_time = datetime(2024, 1, 1, tzinfo=UTC)
+    backend.write_file(rel, content)
+    backend.stamp_file_metadata(rel, digest, upload_time)
+
+    assert backend.release_file_is_current(
+        rel,
+        size=len(content),
+        upload_time=upload_time,
+        digest=digest,
+    )
+
+
+@pytest.mark.asyncio
+async def test_verify_files_s3_dry_run_logs_legacy_backfill(
+    s3_mock: S3Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Dry-run verify logs when legacy hash metadata would be back-filled."""
+    import hashlib
+    import logging
+
+    from bandersnatch.storage import FileSpec
+
+    backend = s3.S3Storage()
+    bucket = s3_mock.bucket
+    content = b"legacy wheel bytes"
+    path = f"/{bucket}/web/packages/aa/bb/legacy-dry-run.whl"
+    backend.write_file(path, content)
+    sha = hashlib.sha256(content).hexdigest()
+
+    spec = FileSpec(
+        path=s3.S3Path(path),
+        url="https://example.com/legacy-dry-run.whl",
+        filename="legacy-dry-run.whl",
+        size=len(content),
+        digests={"sha256": sha},
+        upload_time=datetime(2024, 1, 1, tzinfo=UTC),
+    )
+
+    with caplog.at_level(logging.DEBUG, logger="bandersnatch"):
+        bad = [s async for s in backend.verify_files([spec], dry_run=True)]
+
+    assert bad == []
+    assert "[DRY RUN] would back-fill sha256 metadata" in caplog.text

--- a/src/bandersnatch/tests/plugins/test_storage_plugins.py
+++ b/src/bandersnatch/tests/plugins/test_storage_plugins.py
@@ -495,3 +495,30 @@ def test_get_hash(
         storage_env.plugin.get_hash(path, function=hash_func)
         == expected_hashes[hash_func]
     )
+
+
+def test_release_file_is_current_stat_refreshes_upload_time(
+    storage_env: StorageTestEnv,
+) -> None:
+    """Stat mode mirror skip refreshes mtime when content hash still matches."""
+    import datetime
+    import os
+
+    path = storage_env.plugin.PATH_BACKEND(
+        storage_env.mirror_base_path / "stat_refresh.bin"
+    )
+    path.write_bytes(b"sample payload for stat refresh")
+    stale = datetime.datetime(2020, 1, 1, tzinfo=datetime.UTC).timestamp()
+    os.utime(path, (stale, stale))
+
+    expected_time = datetime.datetime(2025, 6, 1, 12, 0, tzinfo=datetime.UTC)
+    digest = storage_env.plugin.get_hash(path, "sha256")
+
+    assert storage_env.plugin.release_file_is_current(
+        path,
+        size=path.stat().st_size,
+        upload_time=expected_time,
+        digest=digest,
+        compare_method="stat",
+    )
+    assert storage_env.plugin.get_upload_time(path) == expected_time

--- a/src/bandersnatch/tests/plugins/test_storage_plugins.py
+++ b/src/bandersnatch/tests/plugins/test_storage_plugins.py
@@ -522,3 +522,109 @@ def test_release_file_is_current_stat_refreshes_upload_time(
         compare_method="stat",
     )
     assert storage_env.plugin.get_upload_time(path) == expected_time
+
+
+def test_release_file_is_current_stat_matches_upload_time(
+    storage_env: StorageTestEnv,
+) -> None:
+    """Stat mode returns True immediately when upload time already matches."""
+    import datetime
+
+    path = storage_env.plugin.PATH_BACKEND(
+        storage_env.mirror_base_path / "stat_match.bin"
+    )
+    path.write_bytes(b"payload")
+    expected_time = datetime.datetime(2025, 6, 1, 12, 0, tzinfo=datetime.UTC)
+    storage_env.plugin.set_upload_time(path, expected_time)
+    digest = storage_env.plugin.get_hash(path, "sha256")
+
+    assert storage_env.plugin.release_file_is_current(
+        path,
+        size=path.stat().st_size,
+        upload_time=expected_time,
+        digest=digest,
+        compare_method="stat",
+    )
+
+
+def test_release_file_is_current_stat_deletes_on_hash_mismatch(
+    storage_env: StorageTestEnv,
+) -> None:
+    """Stat mode deletes when upload time differs and content hash does not match."""
+    import datetime
+    import os
+
+    path = storage_env.plugin.PATH_BACKEND(
+        storage_env.mirror_base_path / "stat_hash_bad.bin"
+    )
+    path.write_bytes(b"payload")
+    stale = datetime.datetime(2020, 1, 1, tzinfo=datetime.UTC).timestamp()
+    os.utime(path, (stale, stale))
+
+    assert not storage_env.plugin.release_file_is_current(
+        path,
+        size=path.stat().st_size,
+        upload_time=datetime.datetime(2025, 1, 1, tzinfo=datetime.UTC),
+        digest="deadbeef" * 8,
+        compare_method="stat",
+    )
+    assert not path.exists()
+
+
+def test_release_file_is_current_missing_returns_false(
+    storage_env: StorageTestEnv,
+) -> None:
+    """Missing files are not current."""
+    import datetime
+
+    path = storage_env.plugin.PATH_BACKEND(
+        storage_env.mirror_base_path / "does_not_exist.bin"
+    )
+
+    assert not storage_env.plugin.release_file_is_current(
+        path,
+        size=1,
+        upload_time=datetime.datetime(2025, 1, 1, tzinfo=datetime.UTC),
+        digest="abc" * 16,
+    )
+
+
+def test_release_file_is_current_size_mismatch_deletes(
+    storage_env: StorageTestEnv,
+) -> None:
+    """Wrong size deletes the local file before re-download."""
+    import datetime
+
+    path = storage_env.plugin.PATH_BACKEND(
+        storage_env.mirror_base_path / "size_bad.bin"
+    )
+    path.write_bytes(b"payload")
+    digest = storage_env.plugin.get_hash(path, "sha256")
+
+    assert not storage_env.plugin.release_file_is_current(
+        path,
+        size=path.stat().st_size + 1,
+        upload_time=datetime.datetime(2025, 1, 1, tzinfo=datetime.UTC),
+        digest=digest,
+    )
+    assert not path.exists()
+
+
+def test_release_file_is_current_hash_mismatch_deletes(
+    storage_env: StorageTestEnv,
+) -> None:
+    """Hash mode deletes when the stored digest does not match."""
+    import datetime
+
+    path = storage_env.plugin.PATH_BACKEND(
+        storage_env.mirror_base_path / "hash_bad.bin"
+    )
+    path.write_bytes(b"payload")
+
+    assert not storage_env.plugin.release_file_is_current(
+        path,
+        size=path.stat().st_size,
+        upload_time=datetime.datetime(2025, 1, 1, tzinfo=datetime.UTC),
+        digest="deadbeef" * 8,
+    )
+    assert not path.exists()

--- a/src/bandersnatch/tests/test_mirror.py
+++ b/src/bandersnatch/tests/test_mirror.py
@@ -10,6 +10,7 @@ from typing import Any, NoReturn
 
 import pytest
 from freezegun import freeze_time
+from pytest_mock import MockerFixture
 
 from bandersnatch import utils
 from bandersnatch.configuration import BandersnatchConfig, Singleton
@@ -1006,6 +1007,47 @@ async def test_package_sync_does_not_touch_existing_local_file(
     # Only compare the relevant stat fields
     assert old_stat.st_mtime == Path(pkg_file_path_str).stat().st_mtime
     assert old_stat.st_ctime == Path(pkg_file_path_str).stat().st_ctime
+
+
+@pytest.mark.asyncio
+async def test_download_file_stat_mode_refreshes_stale_upload_time(
+    tmpdir: Path,
+    master: Master,
+    monkeypatch: pytest.MonkeyPatch,
+    mocker: MockerFixture,
+) -> None:
+    """With compare-method=stat, stale mtime is updated when content still matches."""
+    from datetime import UTC, datetime
+
+    monkeypatch.chdir(tmpdir)
+    mirror = BandersnatchMirror(tmpdir, master, compare_method="stat")
+    pkg_file_path = Path("web/packages/any/f/foo/foo.zip")
+    touch_files([pkg_file_path])
+    with pkg_file_path.open("wb") as f:
+        f.write(b"")
+
+    stale_mtime = datetime(2020, 1, 1, tzinfo=UTC).timestamp()
+    os.utime(pkg_file_path, (stale_mtime, stale_mtime))
+
+    fetch_mock = mocker.patch(
+        "bandersnatch.mirror.fetch_and_store",
+        new_callable=mock.AsyncMock,
+    )
+    expected_upload_time = datetime(2000, 2, 2, 1, 23, 45, 123456, tzinfo=UTC)
+    empty_sha256 = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+
+    result = await mirror.download_file(
+        "https://pypi.example.com/packages/any/f/foo/foo.zip",
+        "0",
+        expected_upload_time,
+        empty_sha256,
+    )
+
+    assert result is None
+    fetch_mock.assert_not_called()
+    assert pkg_file_path.stat().st_mtime == pytest.approx(
+        expected_upload_time.timestamp()
+    )
 
 
 @pytest.mark.asyncio

--- a/src/bandersnatch_storage_plugins/filesystem.py
+++ b/src/bandersnatch_storage_plugins/filesystem.py
@@ -70,7 +70,11 @@ class FilesystemStorage(StoragePlugin):
 
     @contextlib.contextmanager
     def rewrite(
-        self, filepath: PATH_TYPES, mode: str = "w", **kw: Any
+        self,
+        filepath: PATH_TYPES,
+        mode: str = "w",
+        file_metadata: dict[str, str] | None = None,
+        **kw: Any,
     ) -> Generator[IO, None, None]:
         """Rewrite an existing file atomically to avoid programs running in
         parallel to have race conditions while reading."""

--- a/src/bandersnatch_storage_plugins/s3.py
+++ b/src/bandersnatch_storage_plugins/s3.py
@@ -377,7 +377,7 @@ class S3Storage(StoragePlugin):
         would_backfill_label: str | None = None,
         refresh_stale_metadata: bool = False,
     ) -> ReleaseFileStatus:
-        if size and head["ContentLength"] != size:
+        if head["ContentLength"] != size:
             return ReleaseFileStatus.MISMATCH
 
         stat_upload_stale = False

--- a/src/bandersnatch_storage_plugins/s3.py
+++ b/src/bandersnatch_storage_plugins/s3.py
@@ -26,7 +26,7 @@ from s3path.accessor import _generate_prefix
 if TYPE_CHECKING:
     from s3path.accessor import _S3DirEntry
 
-from bandersnatch.storage import PATH_TYPES, FileSpec, StoragePlugin
+from bandersnatch.storage import PATH_TYPES, FileSpec, ReleaseFileStatus, StoragePlugin
 
 logger = logging.getLogger("bandersnatch")
 
@@ -59,6 +59,17 @@ def _s3_head_object(client: Any, bucket: str, key: str) -> dict[str, Any] | None
                 code,
             )
         raise
+
+
+def _stream_object_hash(client: Any, bucket: str, key: str, digest_name: str) -> str:
+    h = hashlib.new(digest_name)
+    body = client.get_object(Bucket=bucket, Key=key)["Body"]
+    try:
+        for chunk in iter(lambda: body.read(64 * 1024), b""):
+            h.update(chunk)
+    finally:
+        body.close()
+    return h.hexdigest()
 
 
 class S3Path(_S3Path):
@@ -275,14 +286,207 @@ class S3Storage(StoragePlugin):
 
     @contextlib.contextmanager
     def rewrite(
-        self, filepath: PATH_TYPES, mode: str = "w", **kw: Any
+        self,
+        filepath: PATH_TYPES,
+        mode: str = "w",
+        file_metadata: dict[str, str] | None = None,
+        **kw: Any,
     ) -> Generator[IO]:
         """Rewrite an existing file atomically to avoid programs running in
         parallel to have race conditions while reading."""
         if not isinstance(filepath, self.PATH_BACKEND):
             filepath = self.create_path_backend(filepath)
-        with filepath.open(mode=mode, **kw) as fh:
-            yield fh
+
+        registered_metadata = False
+        if file_metadata:
+            upload_params: dict[str, Any] = {}
+            if self._explicit_config and self.configuration_parameters:
+                upload_params.update(self.configuration_parameters)
+            upload_params["Metadata"] = file_metadata
+            register_configuration_parameter(filepath, parameters=upload_params)
+            registered_metadata = True
+
+        try:
+            with filepath.open(mode=mode, **kw) as fh:
+                yield fh
+        finally:
+            # reset config params for future calls
+            if registered_metadata:
+                restore_params: dict[str, Any] = {}
+                if self._explicit_config and self.configuration_parameters:
+                    restore_params.update(self.configuration_parameters)
+                register_configuration_parameter(filepath, parameters=restore_params)
+
+    def build_release_file_metadata(
+        self,
+        digest: str,
+        upload_time: datetime.datetime,
+        digest_name: str = "sha256",
+    ) -> dict[str, str] | None:
+        return {
+            digest_name: digest,
+            self.UPLOAD_TIME_METADATA_KEY: str(upload_time.timestamp()),
+        }
+
+    def stamps_metadata_on_write(self) -> bool:
+        return True
+
+    def _copy_object_kwargs(self) -> dict[str, Any]:
+        if self._explicit_config and self.configuration_parameters:
+            return dict(self.configuration_parameters)
+        return {}
+
+    def _backfill_release_metadata(
+        self,
+        client: Any,
+        bucket: str,
+        key: str,
+        head: dict[str, Any],
+        *,
+        digest_name: str | None = None,
+        digest: str | None = None,
+        upload_time: datetime.datetime | None = None,
+    ) -> None:
+        merged = dict(head.get("Metadata", {}))
+        if digest_name is not None and digest is not None:
+            merged[digest_name] = digest
+        if upload_time is not None:
+            merged[self.UPLOAD_TIME_METADATA_KEY] = str(upload_time.timestamp())
+        client.copy_object(
+            Bucket=bucket,
+            Key=key,
+            CopySource={"Bucket": bucket, "Key": key},
+            Metadata=merged,
+            MetadataDirective="REPLACE",
+            **self._copy_object_kwargs(),
+        )
+
+    def _certify_from_head(
+        self,
+        client: Any,
+        bucket: str,
+        key: str,
+        head: dict[str, Any],
+        *,
+        size: int,
+        upload_time: datetime.datetime,
+        digest: str,
+        compare_method: str,
+        digest_name: str,
+        backfill: bool,
+        would_backfill_label: str | None = None,
+        refresh_stale_metadata: bool = False,
+    ) -> ReleaseFileStatus:
+        if size and head["ContentLength"] != size:
+            return ReleaseFileStatus.MISMATCH
+
+        stat_upload_stale = False
+        if compare_method == "stat":
+            head_upload_time = self._upload_time_from_head(head)
+            if head_upload_time is not None and head_upload_time == upload_time:
+                return ReleaseFileStatus.CURRENT
+            if not refresh_stale_metadata:
+                return ReleaseFileStatus.MISMATCH
+            stat_upload_stale = True
+
+        stored_hash = head.get("Metadata", {}).get(digest_name)
+        if stored_hash is not None:
+            if stored_hash != digest:
+                return ReleaseFileStatus.MISMATCH
+            if stat_upload_stale:
+                if backfill:
+                    logger.info(
+                        "Updating upload time metadata for s3://%s/%s.",
+                        bucket,
+                        key,
+                    )
+                    self._backfill_release_metadata(
+                        client,
+                        bucket,
+                        key,
+                        head,
+                        upload_time=upload_time,
+                    )
+                elif would_backfill_label is not None:
+                    logger.debug(
+                        "[DRY RUN] would refresh upload time metadata for %s",
+                        would_backfill_label,
+                    )
+            return ReleaseFileStatus.CURRENT
+
+        actual_hash = _stream_object_hash(client, bucket, key, digest_name)
+        if actual_hash != digest:
+            return ReleaseFileStatus.MISMATCH
+
+        if backfill:
+            self._backfill_release_metadata(
+                client,
+                bucket,
+                key,
+                head,
+                digest_name=digest_name,
+                digest=actual_hash,
+                upload_time=upload_time if stat_upload_stale else None,
+            )
+        elif would_backfill_label is not None:
+            logger.debug(
+                "[DRY RUN] would back-fill %s metadata for %s",
+                digest_name,
+                would_backfill_label,
+            )
+        return ReleaseFileStatus.CURRENT
+
+    def _upload_time_from_head(self, head: dict) -> datetime.datetime | None:
+        """Parse the stored upload time out of a HeadObject response."""
+        raw = head.get("Metadata", {}).get(self.UPLOAD_TIME_METADATA_KEY)
+        if raw is None:
+            return None
+        try:
+            ts = int(float(raw))
+        except (TypeError, ValueError):
+            return None
+        return datetime.datetime.fromtimestamp(ts, datetime.UTC)
+
+    def release_file_is_current(
+        self,
+        path: PATH_TYPES,
+        *,
+        size: int,
+        upload_time: datetime.datetime,
+        digest: str,
+        compare_method: str = "hash",
+        digest_name: str = "sha256",
+    ) -> bool:
+        if not isinstance(path, self.PATH_BACKEND):
+            path = self.create_path_backend(path)
+        resource, _ = configuration_map.get_configuration(path)
+        client = resource.meta.client
+        bucket = path.bucket
+        key = str(path.key)
+
+        head = _s3_head_object(client, bucket, key)
+        if head is None:
+            return False
+
+        status = self._certify_from_head(
+            client,
+            bucket,
+            key,
+            head,
+            size=size,
+            upload_time=upload_time,
+            digest=digest,
+            compare_method=compare_method,
+            digest_name=digest_name,
+            backfill=True,
+            refresh_stale_metadata=True,
+        )
+        if status is ReleaseFileStatus.CURRENT:
+            return True
+        if status is ReleaseFileStatus.MISMATCH:
+            logger.info(f"File mismatch with local file {path}, will re-download.")
+            self.delete_file(path)
+        return False
 
     @contextlib.contextmanager
     def update_safe(self, filename: PATH_TYPES, **kw: Any) -> Generator[IO]:
@@ -490,14 +694,7 @@ class S3Storage(StoragePlugin):
             return str(stored)
 
         client = resource.meta.client
-        h = hashlib.new(function)
-        body = client.get_object(Bucket=path.bucket, Key=str(path.key))["Body"]
-        try:
-            for chunk in iter(lambda: body.read(64 * 1024), b""):
-                h.update(chunk)
-        finally:
-            body.close()
-        return h.hexdigest()
+        return _stream_object_hash(client, path.bucket, str(path.key), function)
 
     def symlink(
         self,
@@ -529,15 +726,11 @@ class S3Storage(StoragePlugin):
         s3object.metadata.update({self.UPLOAD_TIME_METADATA_KEY: str(time.timestamp())})
         # s3 does not support editing metadata after upload, it can be done better.
         # by setting metadata before uploading.
-        kwargs: dict[str, Any] = {}
-        # Apply request kwargs only for explicitly-configured instances
-        if self._explicit_config and self.configuration_parameters:
-            kwargs.update(self.configuration_parameters)
         s3object.copy_from(
             CopySource={"Bucket": path.bucket, "Key": str(path.key)},
             Metadata=s3object.metadata,
             MetadataDirective="REPLACE",
-            **kwargs,
+            **self._copy_object_kwargs(),
         )
 
     def set_hash(self, path: PATH_TYPES, digest: str, function: str = "sha256") -> None:
@@ -553,15 +746,11 @@ class S3Storage(StoragePlugin):
         metadata = dict(s3object.metadata)
         metadata[function] = digest
 
-        kwargs: dict[str, Any] = {}
-        if self._explicit_config and self.configuration_parameters:
-            kwargs.update(self.configuration_parameters)
-
         s3object.copy_from(
             CopySource={"Bucket": path.bucket, "Key": str(path.key)},
             Metadata=metadata,
             MetadataDirective="REPLACE",
-            **kwargs,
+            **self._copy_object_kwargs(),
         )
 
     def stamp_file_metadata(
@@ -584,27 +773,12 @@ class S3Storage(StoragePlugin):
             self.UPLOAD_TIME_METADATA_KEY: str(upload_time.timestamp()),
         }
 
-        kwargs: dict[str, Any] = {}
-        if self._explicit_config and self.configuration_parameters:
-            kwargs.update(self.configuration_parameters)
-
         s3object.copy_from(
             CopySource={"Bucket": path.bucket, "Key": str(path.key)},
             Metadata=metadata,
             MetadataDirective="REPLACE",
-            **kwargs,
+            **self._copy_object_kwargs(),
         )
-
-    def _upload_time_from_head(self, head: dict) -> datetime.datetime | None:
-        """Parse the stored upload time out of a HeadObject response."""
-        raw = head.get("Metadata", {}).get(self.UPLOAD_TIME_METADATA_KEY)
-        if raw is None:
-            return None
-        try:
-            ts = int(float(raw))
-        except (TypeError, ValueError):
-            return None
-        return datetime.datetime.fromtimestamp(ts, datetime.UTC)
 
     async def verify_files(
         self, expected: Iterable[FileSpec], dry_run: bool = False
@@ -655,67 +829,28 @@ class S3Storage(StoragePlugin):
                 if head is None:
                     return spec
 
-                if spec.size and head["ContentLength"] != spec.size:
-                    return spec
+                expected_hash = spec.digests.get(digest_name, "")
 
-                if compare == "stat":
-                    # size already verified, now verify the upload time
-                    head_upload_time = self._upload_time_from_head(head)
-                    if (
-                        head_upload_time is not None
-                        and head_upload_time == spec.upload_time
-                    ):
-                        return None
-                    else:
-                        return spec
-
-                expected_hash = spec.digests.get(digest_name)
-                stored_hash = head.get("Metadata", {}).get(digest_name)
-
-                if stored_hash is not None:
-                    return spec if stored_hash != expected_hash else None
-
-                # if hash is not yet been stored in metadata, calculate it and store it
-                def _hash_content() -> str:
-                    h = hashlib.new(digest_name)
-                    body = client.get_object(Bucket=bucket, Key=key)["Body"]
-                    try:
-                        for chunk in iter(lambda: body.read(64 * 1024), b""):
-                            h.update(chunk)
-                    finally:
-                        body.close()
-                    return h.hexdigest()
-
-                actual_hash = await loop.run_in_executor(executor, _hash_content)
-                if actual_hash != expected_hash:
-                    return spec
-
-                # set hash metadata for future get_hash() calls (legacy objects)
-                if not dry_run:
-
-                    def _add_hash_to_metadata() -> None:
-                        merged = dict(head.get("Metadata", {}))
-                        merged[digest_name] = actual_hash
-                        bf_kwargs: dict[str, Any] = {}
-                        if self._explicit_config and self.configuration_parameters:
-                            bf_kwargs.update(self.configuration_parameters)
-                        client.copy_object(
-                            Bucket=bucket,
-                            Key=key,
-                            CopySource={"Bucket": bucket, "Key": key},
-                            Metadata=merged,
-                            MetadataDirective="REPLACE",
-                            **bf_kwargs,
-                        )
-
-                    await loop.run_in_executor(executor, _add_hash_to_metadata)
-                else:
-                    logger.debug(
-                        "[DRY RUN] would back-fill %s metadata for %s",
-                        digest_name,
-                        spec.filename,
+                def _certify() -> ReleaseFileStatus:
+                    return self._certify_from_head(
+                        client,
+                        bucket,
+                        key,
+                        head,
+                        size=spec.size,
+                        upload_time=spec.upload_time,
+                        digest=expected_hash,
+                        compare_method=compare,
+                        digest_name=digest_name,
+                        backfill=not dry_run,
+                        would_backfill_label=spec.filename if dry_run else None,
+                        refresh_stale_metadata=False,
                     )
-                return None
+
+                status = await loop.run_in_executor(executor, _certify)
+                if status is ReleaseFileStatus.CURRENT:
+                    return None
+                return spec
 
         results = await asyncio.gather(*[_check(s) for s in specs])
         for result in results:


### PR DESCRIPTION
Similar to the refactor philosphy of verify action, moved ownership of the validity check of a release file to the storage backend providing a default in storage.py. Reduced write calls to stamp metadata by including it as part of the file write itself for s3. Now mirror and s3 both use the same validation function as they share most of the steps.