### PR TITLE
Remove setuptools from runtime requirements

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -32,7 +32,7 @@
 
 ## Bug Fixes
 
-- Drop `setuptools` from runtime requirements: nothing in bandersnatch imports `setuptools`/`pkg_resources` anymore (plugin loading uses `importlib.metadata`), so it is no longer declared in `install_requires` or the pinned requirements files. It remains only as the PEP 517 build backend in `pyproject.toml`
+- Drop `setuptools` from runtime requirements: nothing in bandersnatch imports `setuptools`/`pkg_resources` anymore (plugin loading uses `importlib.metadata`), so it is no longer declared in `install_requires` or the pinned requirements files. It remains only as the PEP 517 build backend in `pyproject.toml` `PR #2306`
 - Fix broken `bandersnatch_docker_compose` symlinks (`Dockerfile`, `nginx.conf`) whose targets included a trailing newline, leaving them unresolvable on disk `PR #2280`
 - Fix `mirror --force-check` to reset the mirror serial via the configured storage backend so it works with non-local backends such as S3 (previously used a local `shutil.move()` to `/tmp`) `Issue #2278`, `PR #2279`
 - Demote per-package filter matching logs from INFO to DEBUG to reduce noise during mirror and verify runs `PR #2193`

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -32,6 +32,7 @@
 
 ## Bug Fixes
 
+- Drop `setuptools` from runtime requirements: nothing in bandersnatch imports `setuptools`/`pkg_resources` anymore (plugin loading uses `importlib.metadata`), so it is no longer declared in `install_requires` or the pinned requirements files. It remains only as the PEP 517 build backend in `pyproject.toml`
 - Fix broken `bandersnatch_docker_compose` symlinks (`Dockerfile`, `nginx.conf`) whose targets included a trailing newline, leaving them unresolvable on disk `PR #2280`
 - Fix `mirror --force-check` to reset the mirror serial via the configured storage backend so it works with non-local backends such as S3 (previously used a local `shutil.move()` to `/tmp`) `Issue #2278`, `PR #2279`
 - Demote per-package filter matching logs from INFO to DEBUG to reduce noise during mirror and verify runs `PR #2193`

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,5 +6,4 @@ humanfriendly==10.0
 idna==3.18
 multidict==6.7.1
 packaging==26.2
-setuptools==83.0.0
 yarl==1.24.2

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -11,7 +11,6 @@ pytest==9.1.1
 pytest-asyncio==1.4.0
 pytest-mock==3.15.1
 pytest-timeout==2.4.0
-setuptools==83.0.0
 tox==4.56.1
 types-filelock==3.2.7
 types-freezegun==1.1.10

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,7 +26,6 @@ install_requires =
     filelock
     humanfriendly
     packaging
-    setuptools
 package_dir =
     =src
 packages = find:

--- a/setup.cfg
+++ b/setup.cfg
@@ -86,5 +86,5 @@ s3 =
 [isort]
 atomic = true
 profile = black
-known_third_party = _pytest,aiohttp,aiohttp_socks,filelock,freezegun,mock_config,packaging,pkg_resources,pytest,setuptools
+known_third_party = _pytest,aiohttp,aiohttp_socks,filelock,freezegun,mock_config,packaging,pytest
 known_first_party = bandersnatch,bandersnatch_filter_plugins,bandersnatch_storage_plugins


### PR DESCRIPTION
## What

Nothing in bandersnatch imports `setuptools` or `pkg_resources` at runtime anymore — plugin entry-point loading moved to `importlib.metadata.entry_points()` (`filter.py`, `storage.py`). The only remaining references are code comments (e.g. `utils.py` noting `bandersnatch_safe_name` was *copied from* `pkg_resources`).

This drops `setuptools` from:
- `setup.cfg` `install_requires`
- `requirements.txt`
- `requirements_test.txt`

## Kept

`setuptools` remains as the PEP 517 build backend in `pyproject.toml` (`build-system.requires` / `build-backend`), which is still required to build the package.

## Testing

Full unit suite passes with the pinned dependencies (`filelock==3.29.4`): `366 passed`. Package builds and imports cleanly (including the S3 plugin) with setuptools no longer pinned — pip's build isolation pulls it from `pyproject.toml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)