### PR TITLE
Release 8.0.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,6 @@
-# 8.0.0.dev0
+# Unreleased
+
+# 8.0.0
 
 ## New Features
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,12 +54,20 @@ Both `filter.py` and `storage.py` carry an `API_REVISION` constant — bump it w
 A release is a PR followed by a GitHub Release. Steps:
 
 1. **In a new branch/PR**, finalize `CHANGES.md`: rename the top `# Unreleased` heading to the new version number (e.g. `# 7.2.0`), keeping its `## New Features` / `## CI / test` / `## Documentation` / `## Bug Fixes` subsections. Add a fresh empty `# Unreleased` section above it for future work.
-1. Bump `version =` in `setup.cfg` to the version the user asks for. It **must be valid semver and strictly greater** than the current value — verify against `git tag` (tags are the released versions) and refuse/flag if the requested version is not higher.
+
+1. Bump the version in **both** places — they must match, and it's easy to update one and forget the other:
+
+   - `version =` in `setup.cfg`
+   - `__version_info__` in `src/bandersnatch/__init__.py` (set `major`/`minor`/`micro` accordingly and clear `releaselevel` to `""` for a final release)
+
+   The version **must be valid semver and strictly greater** than the current value — verify against `git tag` (tags are the released versions) and refuse/flag if the requested version is not higher.
+
 1. Push the PR and wait for it to land on `main` (CI must pass; `main` is normally PR-gated).
+
 1. Once merged, cut a new GitHub Release tagged with that version (`gh release create <version>`), and paste the just-released version's `CHANGES.md` markdown (the section you renamed in step 1) as the release body.
 
 ## Conventions
 
-- Version lives in `setup.cfg` (`version =`). User-facing changes get a `CHANGES.md` entry.
+- Version lives in **two** places that must be kept in sync: `setup.cfg` (`version =`) and `src/bandersnatch/__init__.py` (`__version_info__`). User-facing changes get a `CHANGES.md` entry.
 - Min supported Python is 3.12; CI matrix runs 3.12–3.15. New syntax for >=3.12 is acceptable.
 - Optional features are extras: `s3` (s3path), `uvloop`, `safety_db`. uvloop is auto-installed/used when present (`main.py` tries to import it).

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,7 +17,7 @@ project_urls =
     Source Code = https://github.com/pypa/bandersnatch
     Change Log = https://github.com/pypa/bandersnatch/blob/master/CHANGES.md
 url = https://github.com/pypa/bandersnatch/
-version = 8.0.0.dev0
+version = 8.0.0
 
 [options]
 install_requires =

--- a/src/bandersnatch/__init__.py
+++ b/src/bandersnatch/__init__.py
@@ -22,7 +22,7 @@ __version_info__ = _VersionInfo(
     major=8,
     minor=0,
     micro=0,
-    releaselevel="dev0",
+    releaselevel="",
     serial=0,  # Not currently in use with Bandersnatch versioning
 )
 __version__ = __version_info__.version_str


### PR DESCRIPTION
## Summary
- Finalize `CHANGES.md`: rename the `8.0.0.dev0` heading to `8.0.0` and add a fresh empty `Unreleased` section above it.
- Bump the version in both `setup.cfg` and `src/bandersnatch/__init__.py` (`__version_info__`) from `8.0.0.dev0` to `8.0.0`.
- Update `CLAUDE.md`'s release steps/conventions to call out that the version lives in *two* files (`setup.cfg` and `src/bandersnatch/__init__.py`) so future releases don't miss the second one.

Once merged, this will be tagged as a GitHub Release with the `8.0.0` section of `CHANGES.md` as the release notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)